### PR TITLE
Feature/condensed labels

### DIFF
--- a/app/assets/javascripts/modules/toggle_condensed_labels.coffee
+++ b/app/assets/javascripts/modules/toggle_condensed_labels.coffee
@@ -1,0 +1,13 @@
+$ ->
+  button = $('#toggle-condensed-labels')
+  checkbox = button.find('input[type="checkbox"]')
+  param = 'condense='
+
+  button.click (event) ->
+    event.stopPropagation()
+    checkbox.toggle
+
+  checkbox.change ->
+    checked = !!this.checked
+    $(this).parents('.dropdown-menu').find('a.export-label-format').each ->
+      $(this).attr('href', $(this).attr('href').replace(param + !checked, param + checked))

--- a/app/assets/javascripts/modules/toggle_condensed_labels.coffee
+++ b/app/assets/javascripts/modules/toggle_condensed_labels.coffee
@@ -1,7 +1,7 @@
 $ ->
-  button = $('#toggle-condensed-labels')
+  button = $('#toggle-condense-labels')
   checkbox = button.find('input[type="checkbox"]')
-  param = 'condense='
+  param = 'condense_labels='
 
   button.click (event) ->
     event.stopPropagation()

--- a/app/assets/stylesheets/hitobito/_navigation.scss
+++ b/app/assets/stylesheets/hitobito/_navigation.scss
@@ -224,6 +224,8 @@
 }
 
 .dropdown-menu label > .help-text {
+  max-width: 240px;
+  white-space: pre-wrap;
   font-size: 0.8em;
 }
 

--- a/app/assets/stylesheets/hitobito/_navigation.scss
+++ b/app/assets/stylesheets/hitobito/_navigation.scss
@@ -223,6 +223,10 @@
   left: auto;
 }
 
+.dropdown-menu label > .help-text {
+  font-size: 0.8em;
+}
+
 // Left navigation
 .nav-left {
   .inner {

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -147,7 +147,7 @@ class PeopleController < CrudController
   end
 
   def condense_entries
-    return filter_entries unless params[:condense].present?
+    return filter_entries unless params[:condense_labels] == 'true'
     Person::CondensedContact.condense_list(filter_entries)
   end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -40,7 +40,7 @@ class PeopleController < CrudController
   def index
     respond_to do |format|
       format.html  { @people = prepare_entries(filter_entries).page(params[:page]) }
-      format.pdf   { render_pdf(filter_entries) }
+      format.pdf   { render_pdf(condense_entries) }
       format.csv   { render_entries_csv(filter_entries) }
       format.email { render_emails(filter_entries) }
       format.json  { render_entries_json(filter_entries) }
@@ -141,10 +141,14 @@ class PeopleController < CrudController
     filter = list_filter
     entries = filter.filter_entries
     entries = entries.reorder(sort_expression) if sorting?
-    entries = CondensedContact.condense_list(entries) if params[:condense]
     @multiple_groups = filter.multiple_groups
     @all_count = filter.all_count if html_request?
     entries
+  end
+
+  def condense_entries
+    return filter_entries unless params[:condense].present?
+    Person::CondensedContact.condense_list(filter_entries)
   end
 
   def list_filter

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -141,6 +141,7 @@ class PeopleController < CrudController
     filter = list_filter
     entries = filter.filter_entries
     entries = entries.reorder(sort_expression) if sorting?
+    entries = CondensedContact.condense_list(entries) if params[:condense]
     @multiple_groups = filter.multiple_groups
     @all_count = filter.all_count if html_request?
     entries

--- a/app/helpers/dropdown/people_export.rb
+++ b/app/helpers/dropdown/people_export.rb
@@ -51,6 +51,7 @@ module Dropdown
         label_item = add_item(translate(:labels), main_label_link)
         add_last_used_format_item(label_item)
         add_label_format_items(label_item)
+        add_condensed_labels_option_items(label_item)
       end
     end
 
@@ -74,13 +75,48 @@ module Dropdown
 
     def add_label_format_items(parent)
       LabelFormat.all_as_hash.each do |id, label|
-        parent.sub_items << Item.new(label, export_label_format_path(id), target: :new)
+        parent.sub_items << Item.new(label, export_label_format_path(id),
+                                     target: :new, class: 'export-label-format')
       end
     end
 
-    def export_label_format_path(id)
-      params.merge(format: :pdf, label_format_id: id)
+    def add_condensed_labels_option_items(parent)
+      parent.sub_items << Divider.new
+      parent.sub_items << ToggleCondensedLabelsItem.new(@template)
     end
 
+    def export_label_format_path(id)
+      params.merge(format: :pdf, label_format_id: id,
+                   condense: ToggleCondensedLabelsItem::DEFAULT_STATE)
+    end
+
+  end
+
+  class ToggleCondensedLabelsItem < Base
+    DEFAULT_STATE = false
+
+    def initialize(template)
+      super(template, template.t('groups.global.link.add'), :plus)
+    end
+
+    def render(template)
+      template.content_tag(:li) do
+        template.link_to('#', id: 'toggle-condensed-labels') do
+          render_checkbox(template)
+        end
+      end
+    end
+
+    def render_checkbox(template)
+      template.content_tag(:div, class: 'checkbox') do
+        template.content_tag(:label, for: :condense) do
+          template.safe_join([
+            template.check_box_tag(:condense, '1', DEFAULT_STATE),
+            template.t('groups.global.link.add'),
+            template.content_tag(:p, template.t('groups.global.link.add'), class: 'help-text')
+          ].compact)
+        end
+      end
+    end
   end
 end

--- a/app/helpers/dropdown/people_export.rb
+++ b/app/helpers/dropdown/people_export.rb
@@ -87,7 +87,7 @@ module Dropdown
 
     def export_label_format_path(id)
       params.merge(format: :pdf, label_format_id: id,
-                   condense: ToggleCondensedLabelsItem::DEFAULT_STATE)
+                   condense_labels: ToggleCondensedLabelsItem::DEFAULT_STATE)
     end
 
   end
@@ -96,12 +96,12 @@ module Dropdown
     DEFAULT_STATE = false
 
     def initialize(template)
-      super(template, template.t('groups.global.link.add'), :plus)
+      super(template, template.t('dropdown/people_export.condense_labels'), :plus)
     end
 
     def render(template)
       template.content_tag(:li) do
-        template.link_to('#', id: 'toggle-condensed-labels') do
+        template.link_to('#', id: 'toggle-condense-labels') do
           render_checkbox(template)
         end
       end
@@ -112,8 +112,9 @@ module Dropdown
         template.content_tag(:label, for: :condense) do
           template.safe_join([
             template.check_box_tag(:condense, '1', DEFAULT_STATE),
-            template.t('groups.global.link.add'),
-            template.content_tag(:p, template.t('groups.global.link.add'), class: 'help-text')
+            template.t('dropdown/people_export.condense_labels'),
+            template.content_tag(:p, template.t('dropdown/people_export.condense_labels_hint'),
+                                 class: 'help-text')
           ].compact)
         end
       end

--- a/app/models/condensed_contact.rb
+++ b/app/models/condensed_contact.rb
@@ -6,7 +6,7 @@
 #  https://github.com/hitobito/hitobito.
 
 class CondensedContact
-  CONDENSABLE_ATTRIBUTES = [:address, :last_name, :zip_code, :town, :country]
+  CONDENSABLE_ATTRIBUTES = [:address, :last_name, :zip_code, :town, :country, :country_label, :ignored_country?]
 
   attr_accessor :base_contactable, :other_contactables
   delegate(*CONDENSABLE_ATTRIBUTES, to: :@base_contactable)

--- a/app/models/condensed_contact.rb
+++ b/app/models/condensed_contact.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class CondensedContact
+  CONDENSABLE_ATTRIBUTES = [:address, :last_name, :zip_code, :town, :country]
+
+  attr_accessor :base_contactable, :merged_contactables
+  delegate(*CONDENSABLE_ATTRIBUTES, to: :@base_contactable)
+
+  def initialize(base_contactable, *contactables)
+    self.base_contactable = base_contactable
+    self.merged_contactables = contactables
+  end
+
+  def contactables
+    [base_contactable] + merged_contactables
+  end
+
+  def full_name
+    "#{contactables.map(&:first_name).to_sentence} #{base_contactable.last_name}"
+  end
+
+  def condensable?(contactable)
+    CondensedContact.condensable?(self, contactable)
+  end
+
+  def condense(contactable)
+    merged_contactables << contactable if condensable?(contactable)
+  end
+  alias_method :<<, :condense
+
+  def self.condensable?(base_contactable, contactable)
+    CONDENSABLE_ATTRIBUTES.each do |attribute|
+      return false unless base_contactable.try(attribute) == contactable.try(attribute)
+    end
+    true
+  end
+
+end

--- a/app/models/condensed_contact.rb
+++ b/app/models/condensed_contact.rb
@@ -6,12 +6,13 @@
 #  https://github.com/hitobito/hitobito.
 
 class CondensedContact
-  CONDENSABLE_ATTRIBUTES = [:address, :last_name, :zip_code, :town, :country, :country_label, :ignored_country?]
+  CONDENSABLE_ATTRIBUTES = [:address, :last_name, :zip_code, :town, :country, :country_label,
+    :ignored_country?]
 
   attr_accessor :base_contactable, :other_contactables
   delegate(*CONDENSABLE_ATTRIBUTES, to: :@base_contactable)
 
-  def initialize(base_contactable, contactables=[])
+  def initialize(base_contactable, contactables = [])
     self.base_contactable = base_contactable
     self.other_contactables = []
     condense(contactables)
@@ -31,7 +32,9 @@ class CondensedContact
 
   def condense(candidates)
     Array.wrap(candidates).each do |candidate|
-      other_contactables << candidate if(condensable?(candidate) && !condensed_contactables.include?(candidate))
+      if (condensable?(candidate) && !condensed_contactables.include?(candidate))
+        other_contactables << candidate
+      end
     end
   end
 

--- a/app/models/person/condensed_contact.rb
+++ b/app/models/person/condensed_contact.rb
@@ -4,8 +4,7 @@
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
-
-class CondensedContact
+class Person::CondensedContact
   CONDENSABLE_ATTRIBUTES = [:address, :last_name, :zip_code, :town, :country, :country_label,
     :ignored_country?]
 
@@ -27,7 +26,7 @@ class CondensedContact
   end
 
   def condensable?(contactable)
-    CondensedContact.condensable?(self, contactable)
+    self.class.condensable?(self, contactable)
   end
 
   def condense(candidates)
@@ -54,7 +53,7 @@ class CondensedContact
       next if condensed.include?(base_contactable)
       candidates = condense_candidates(base_contactable, list[base_index+1..-1])
       condensed += candidates
-      condensed_contactable = CondensedContact.new(base_contactable, candidates) if candidates.any?
+      condensed_contactable = self.new(base_contactable, candidates) if candidates.any?
       condensed_contactable || base_contactable
     end.compact
   end

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -132,6 +132,8 @@ de:
     emails: 'E-Mail Adressen'
     addresses: 'Adressliste'
     everything: 'Alle Angaben'
+    condense_labels: 'Mehrfachsendungen vermeiden'
+    condense_labels_hint: 'Nur einen Eintrag ausgeben, wenn die gesamte Adresse und der Nachname übereinstimmen.'
 
   devise:
     failure:

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -127,7 +127,7 @@ describe PeopleController do
 
           it 'generates condensed pdf labels' do
             expect(Person::CondensedContact).to receive(:condense_list).once.and_call_original
-            get :index, group_id: group, label_format_id: label_formats(:standard).id, condense: true, format: :pdf
+            get :index, group_id: group, label_format_id: label_formats(:standard).id, condense_labels: 'true', format: :pdf
 
             expect(@response.content_type).to eq('application/pdf')
             expect(people(:top_leader).reload.last_label_format).to eq(label_formats(:standard))

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -118,7 +118,16 @@ describe PeopleController do
 
         context '.pdf' do
           it 'generates pdf labels' do
+            expect(Person::CondensedContact).not_to receive(:condense_list)
             get :index, group_id: group, label_format_id: label_formats(:standard).id, format: :pdf
+
+            expect(@response.content_type).to eq('application/pdf')
+            expect(people(:top_leader).reload.last_label_format).to eq(label_formats(:standard))
+          end
+
+          it 'generates condensed pdf labels' do
+            expect(Person::CondensedContact).to receive(:condense_list).once.and_call_original
+            get :index, group_id: group, label_format_id: label_formats(:standard).id, condense: true, format: :pdf
 
             expect(@response.content_type).to eq('application/pdf')
             expect(people(:top_leader).reload.last_label_format).to eq(label_formats(:standard))

--- a/spec/models/condensed_contact_spec.rb
+++ b/spec/models/condensed_contact_spec.rb
@@ -7,11 +7,11 @@
 
 require 'spec_helper'
 
-describe CondensedContact do
+describe Person::CondensedContact do
   let(:person) { Fabricate(:person_with_address_and_phone) }
   let(:condensable_person) { Person.create(person.attributes.merge({id: nil, first_name: Faker::Name.first_name})) }
   let(:noncondensable_person) { Person.create(person.attributes.merge({id: nil, last_name: Faker::Name.last_name})) }
-  let(:condensed_contact) { CondensedContact.new(person) }
+  let(:condensed_contact) { Person::CondensedContact.new(person) }
 
   def condensed_attributes(contactable)
     contactable.attributes.with_indifferent_access.slice(:address, :last_name, :zip_code, :town, :country)
@@ -71,7 +71,7 @@ describe CondensedContact do
   end
 
   context 'with merged contactable' do
-    let(:merged_condensed_contact) { CondensedContact.new(person, [condensable_person]) }
+    let(:merged_condensed_contact) { Person::CondensedContact.new(person, [condensable_person]) }
 
     describe '#full_name' do
       subject { merged_condensed_contact.full_name }
@@ -82,7 +82,7 @@ describe CondensedContact do
 
   describe '::condense_list' do
     let(:condensable_list) { [person, condensable_person, noncondensable_person] }
-    subject { CondensedContact.condense_list(condensable_list) }
+    subject { Person::CondensedContact.condense_list(condensable_list) }
 
     its(:count) { is_expected.to be 2 }
   end

--- a/spec/models/condensed_contact_spec.rb
+++ b/spec/models/condensed_contact_spec.rb
@@ -1,0 +1,76 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+describe CondensedContact do
+  let(:person) { Fabricate(:person_with_address_and_phone) }
+  let(:condensable_person) { Person.create(person.attributes.merge({first_name: Faker::Name.first_name})) }
+  let(:noncondensable_person) { Person.create(person.attributes.merge({last_name: Faker::Name.last_name})) }
+  let(:condensed_contact) { CondensedContact.new(person) }
+
+  def condensed_attributes(contactable)
+    contactable.attributes.with_indifferent_access.slice(:address, :last_name, :zip_code, :town, :country)
+  end
+
+  context 'without merged contactable' do
+    describe '#initialize' do
+      subject { condensed_contact }
+
+      it { is_expected.to have_attributes(condensed_attributes(person)) }
+      its(:base_contactable) { is_expected.to be person }
+    end
+
+    describe '#contactables' do
+      subject { condensed_contact.contactables }
+
+      it { is_expected.to eq([person]) }
+    end
+
+    describe '#mergeable?' do
+      context 'with mergeable contact' do
+        subject { condensed_contact.condensable?(condensable_person) }
+
+        it { is_expected.to be true }
+      end
+
+      context 'with nonmergeable contact' do
+        subject { condensed_contact.condensable?(noncondensable_person) }
+
+        it { is_expected.to be false }
+      end
+    end
+
+    describe '#merge' do
+      context 'with mergeable contact' do
+        subject { condensed_contact.condense(condensable_person) }
+
+        it 'merges the contact' do
+          expect { subject }.to change { condensed_contact.contactables }
+        end
+      end
+
+      context 'with nonmergeable contact' do
+        subject { condensed_contact.condense(noncondensable_person) }
+
+        it 'does not merge the contact' do
+          expect { subject }.not_to change { condensed_contact.contactables }
+        end
+      end
+    end
+  end
+
+  context 'with merged contactable' do
+    let(:merged_condensed_contact) { CondensedContact.new(person, condensable_person) }
+
+    describe '#full_name' do
+      subject { merged_condensed_contact.full_name }
+
+      it { is_expected.to eq("#{[person.first_name, condensable_person.first_name].to_sentence} #{person.last_name}") }
+    end
+  end
+end


### PR DESCRIPTION
# Abstract
This PR includes the implementation of a feature that has been requested on ideascale here: http://midata.ideascale.com/a/dtd/Nur-eine-Etikette-pro-Haushalt/94704-26593. It states that it should be possible for multiple people living at the same household to only print one, condensed label.

# Usage
To make use of this feature either check the checkbox located in the "Export > Labels"-Menu or add ```condense_labels=true``` to the query parameters when calling the export.

![image](https://cloud.githubusercontent.com/assets/939106/12224496/ace5f8f6-b7f2-11e5-9316-7930eb4fa457.png)

# Implementation
To implement this feature a wrapper class for contactables ```CondensedContact``` was created. The 'merge-strategy' is conservative and only allows contactables with matching country, town, zip-code, address, and last_name to be merged. The CondensedContact class acts to implement the same interface as any other contactable, but will raise an error when an ambivalent field is accessed (e.g. id or first_name) 

# Performance
The condensation of a list runs with **O(n^2)**, as it has to compare every item with another in the list. This is necessary, as it can not be asserted that the list has been sorted correctly.

# Conventions
It has been tried to follow the established conventions of the project, which includes testing with rspec and asserting code style with ```rubocop -c rubocup-must.yml```

# Contact
Diego Steiner / Filou, Pfadi Züri