### PR TITLE
Add regression test and fix 500 error

### DIFF
--- a/app/controllers/full_text_controller.rb
+++ b/app/controllers/full_text_controller.rb
@@ -32,6 +32,7 @@ class FullTextController < ApplicationController
   private
 
   def list_people
+    return [] unless params[:q].present?
     entries = Person.search(Riddle::Query.escape(params[:q]),
                             page: params[:page],
                             order: 'last_name asc, ' \
@@ -45,6 +46,7 @@ class FullTextController < ApplicationController
   end
 
   def query_people
+    return [] unless params[:q].present?
     Person.search(Riddle::Query.escape(params[:q]),
                   per_page: 10,
                   star: true,
@@ -52,6 +54,7 @@ class FullTextController < ApplicationController
   end
 
   def query_groups
+    return [] unless params[:q].present?
     Group.search(Riddle::Query.escape(params[:q]),
                  per_page: 10,
                  star: true,

--- a/spec/regressions/full_text_controller_spec.rb
+++ b/spec/regressions/full_text_controller_spec.rb
@@ -63,12 +63,19 @@ describe FullTextController, :mysql, type: :controller do
         end
       end
 
+      context 'without any params' do
+        before { sign_in(people(:top_leader)) }
+        it 'returns nothing' do
+          get :index
+
+          expect(@response).to be_ok
+        end
+      end
     end
 
     describe 'GET query' do
 
       before { sign_in(people(:top_leader)) }
-
 
       it 'finds accessible person' do
         get :query, q: @bg_leader.last_name[1..5]
@@ -86,6 +93,15 @@ describe FullTextController, :mysql, type: :controller do
         get :query, q: groups(:bottom_layer_one).to_s[1..5]
 
         expect(@response.body).to include(groups(:bottom_layer_one).to_s)
+      end
+
+      context 'without any params' do
+        it 'returns nothing' do
+          get :query
+
+          expect(@response).to be_ok
+          expect(JSON.parse(@response.body)).to eq([])
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #68 

## Steps taken
* Added tests for actions that throw an exception
* Added preconditions to the controller methods that caused the exception

## Result
* When calling without the q param, no error will be thrown. Instead, an empty array will be returned

Note: This PR was made during [renuo open source day 2016](https://www.renuo.ch).