### PR TITLE
Issue #127: Enable moving sub-subgroups up into the top group

### DIFF
--- a/app/controllers/group/move_controller.rb
+++ b/app/controllers/group/move_controller.rb
@@ -37,7 +37,7 @@ class Group::MoveController < ApplicationController
   end
 
   def candidates
-    @candidates = mover.candidates.select { |candidate| can?(:create, candidate) }.
+    @candidates = mover.candidates.select { |candidate| can?(:update, candidate) }.
                                    group_by { |candidate| candidate.class.label }
     @candidates.values.each { |groups| groups.sort_by(&:name) }
 

--- a/spec/controllers/group/move_controller_spec.rb
+++ b/spec/controllers/group/move_controller_spec.rb
@@ -21,6 +21,16 @@ describe Group::MoveController do
       get :select, id: group.id
       expect(assigns(:candidates)['Bottom Layer']).to include target
     end
+    it 'leader of a group can move sub-subgroup up into his group' do
+      group = groups(:bottom_layer_one)
+      subsubgroup = groups(:bottom_group_one_one_one)
+      user = Fabricate(Group::BottomLayer::Leader.name.to_s, label: 'foo', group: group).person
+      sign_in(user)
+ 
+      get :select, id: subsubgroup
+      expect(assigns(:candidates)['Bottom Layer']).to include group
+      expect(assigns(:candidates)['Bottom Group']).to include groups(:bottom_group_one_two)
+    end
   end
 
   context 'POST :perform' do


### PR DESCRIPTION
The current users' group is now available as a target when moving sub-subgroups