### PR TITLE
changed minute select to only use 5 minute steps

### DIFF
--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -124,10 +124,10 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
     time_select(attr, { include_blank: true, ignore_date: true }, html_options)
   end
 
-  # Render a select with minutes
+  # Render a select with every 5 minutes
   def minutes_select(attr, html_options = {})
     html_options[:class] ||= 'time'
-    ma = (0..59).collect { |n| [format('%02d', n), n] }
+    ma = (0..11).collect { |n| [format('%02d', n*5), n] }
     select(attr, ma, {}, html_options)
   end
 


### PR DESCRIPTION
Time selects allow to select every minute. However, such precision is not necessary, to have 5, 10, 15 ... available is enough. Even 15min might be enough, as currently we only use times for event dates.

Should I write a test for that?

If yes, where should I put it?