### PR TITLE
Use delegated event handling with turbolinks

### DIFF
--- a/app/assets/javascripts/modules/person_tags.js.coffee
+++ b/app/assets/javascripts/modules/person_tags.js.coffee
@@ -40,9 +40,9 @@ app.PersonTags = {
 }
 
 $(document).on('click', 'a.person-tag-remove', app.PersonTags.removeTag)
+$(document).on('click', '.person-tag-add', app.PersonTags.showForm)
 
 $ ->
-  $('.person-tag-add').on('click', app.PersonTags.showForm)
   $('.person-tags-add-form').on('submit', -> app.PersonTags.loading(true); return true);
   $('.person-tags-add-form input#acts_as_taggable_on_tag_name').on('keypress', (event) ->
     event.keyCode == 27 && app.PersonTags.hideForm(); return true)


### PR DESCRIPTION
After turbolink navigation, event handlers are missing on the `.person-tag-add` `span`. Using delegated event handling does the trick.