### PR TITLE
Fix broken rails console in production environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ group :development, :test do
   gem 'codez-tarantula', require: 'tarantula-rails3'
   gem 'pry-rails'
   gem 'pry-debugger', platforms: :ruby_19
+  gem 'pry-doc'
   # gem 'pry-byebug', platforms: [:ruby_20, :ruby_21]
 end
 
@@ -103,7 +104,6 @@ group :console do
   gem 'awesome_print'
   gem 'hirb'
   gem 'mailcatcher'
-  gem 'pry-doc'
   gem 'pry-remote'
   gem 'pry-stack_explorer'
   gem 'rdoc-tags'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,3 @@
-PATH
-  remote: ../hitobito_insieme
-  specs:
-    hitobito_insieme (0.0.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -544,7 +539,6 @@ DEPENDENCIES
   haml
   headless
   hirb
-  hitobito_insieme!
   http_accept_language
   jquery-rails
   jquery-turbolinks


### PR DESCRIPTION
Before:

```
RAILS_HOST_NAME=example.com RAILS_ENV=production bundle exec rails c
/home/sraez/.rvm/gems/ruby-2.0.0-p643@pitc-post-innoweek/gems/pry-doc-0.8.0/lib/pry-doc.rb:33:in `<class:Pry>': undefined method `config' for Pry:Class (NoMethodError)
```

After:

```
RAILS_HOST_NAME=example.com RAILS_ENV=production bundle exec rails c
Loading production environment (Rails 4.2.7.1)
2.0.0-p643 :001 > 
```

as well as

```
RAILS_ENV=development bundle exec rails c
require rails:   0.470000   0.120000   0.590000 (  0.580558)
require gems:   2.530000   0.260000   2.790000 (  2.818350)
Loading development environment (Rails 4.2.7.1)
```