### PR TITLE
Display tel: Link with phone numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 branches:
   only:
     - master

--- a/app/decorators/contactable_decorator.rb
+++ b/app/decorators/contactable_decorator.rb
@@ -52,7 +52,9 @@ module ContactableDecorator
   end
 
   def all_phone_numbers(only_public = true)
-    nested_values(phone_numbers, only_public)
+    nested_values(phone_numbers, only_public) do |number|
+        h.link_to(number,"tel:#{number}")
+    end
   end
 
   def all_social_accounts(only_public = true)

--- a/app/decorators/contactable_decorator.rb
+++ b/app/decorators/contactable_decorator.rb
@@ -55,6 +55,7 @@ module ContactableDecorator
     nested_values(phone_numbers, only_public) do |number|
         h.link_to(number,"tel:#{number}")
     end
+    
   end
 
   def all_social_accounts(only_public = true)

--- a/spec/decorators/contactable_decorator_spec.rb
+++ b/spec/decorators/contactable_decorator_spec.rb
@@ -59,17 +59,17 @@ describe ContactableDecorator do
     context 'only public' do
       subject { @group.all_phone_numbers }
 
-      it { is_expected.to match(/031.*Home/) }
-      it { is_expected.to match(/041.*Work/) }
-      it { is_expected.not_to match(/079.*Mobile/) }
+      it { is_expected.to match(/tel:031.*Home/) }
+      it { is_expected.to match(/tel:041.*Work/) }
+      it { is_expected.not_to match(/tel:079.*Mobile/) }
     end
 
     context 'all' do
       subject { @group.all_phone_numbers(false) }
 
-      it { is_expected.to match(/031.*Home/) }
-      it { is_expected.to match(/041.*Work/) }
-      it { is_expected.to match(/079.*Mobile/) }
+      it { is_expected.to match(/tel:031.*Home/) }
+      it { is_expected.to match(/tel:041.*Work/) }
+      it { is_expected.to match(/tel:079.*Mobile/) }
     end
   end
 


### PR DESCRIPTION
enable direct call from phone numbers
hyperlink "tel:012345678" is added to every phone number when displaying a person

this is especially helpfull on mobile devices. 
see also iPhoneURLScheme from apple
https://developer.apple.com/library/content/featuredarticles/iPhoneURLScheme_Reference/PhoneLinks/PhoneLinks.html