### PR TITLE
Improved Person history

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ Code:
   Pascal Simon, Puzzle ITC
   Mathis Hofer, Puzzle ITC
   Diego Steiner
+  Lukas Blunschi
 
 Design & Style:
   Roland Studer, Puzzle ITC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Hitobito Changelog
 
+*   Der Verlauf einer Person zeigt neu die Rollen so an, dass die Gruppen auch die übergeordneten Ebenen anzeigt.
+*   Der Verlauf einer Person wird neu nach der Gruppe inkl. übergeordneter Ebenen sortiert.
+
 ## Version 1.14
 
 *   Automatisches Ausfüllen der Kurs Beschreibung wenn ein Kurstyp gewählt wird.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Hitobito Changelog
 
+## Version 1.15
+
 *   Der Verlauf einer Person zeigt neu die Rollen so an, dass die Gruppen auch die übergeordneten Ebenen anzeigt.
 *   Der Verlauf einer Person wird neu nach der Gruppe inkl. übergeordneter Ebenen sortiert.
 

--- a/app/controllers/person/history_controller.rb
+++ b/app/controllers/person/history_controller.rb
@@ -19,10 +19,10 @@ class Person::HistoryController < ApplicationController
   private
 
   def fetch_roles
-    Role.with_deleted.
-         where(person_id: entry.id).
-         includes(:group).
-         order('groups.name', 'roles.deleted_at')
+    Person::PreloadGroups.for([entry]).first.roles.
+      with_deleted.
+      includes(:group).
+      sort_by {|r| GroupDecorator.new(r.group).name_with_layer }
   end
 
   def fetch_participations

--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -44,6 +44,12 @@ class GroupDecorator < ApplicationDecorator
     h.safe_join(links, ' / ')
   end
 
+  # compute layers and concat group names using a '/'
+  def name_with_layer
+    group_names = with_layer.map { |g| g.to_s }
+    group_names.join(' / ')
+  end
+
   def possible_events
     klass.event_types
   end

--- a/app/views/person/history/index.html.haml
+++ b/app/views/person/history/index.html.haml
@@ -6,7 +6,8 @@
 %h2= Role.model_name.human(count: 2)
 
 = table(@roles, class: 'table table-striped') do |t|
-  - t.attr(:group_id, Group.model_name.human)
+  - t.col(Group.model_name.human) do |r|
+    = GroupDecorator.new(r.group).link_with_layer
   - t.col(Role.model_name.human) do |r|
     = r.to_s
   - t.attr(:created_at, t('global.from'))

--- a/spec/controllers/person/history_controller_spec.rb
+++ b/spec/controllers/person/history_controller_spec.rb
@@ -17,15 +17,16 @@ describe Person::HistoryController do
 
     context 'all roles' do
 
-      it 'all group roles ordered by group, to date' do
+      it 'all group roles ordered by group and layer' do
         person = Fabricate(:person)
         r1 = Fabricate(Group::BottomGroup::Member.name.to_sym, group: groups(:bottom_group_one_one), person: person)
         r2 = Fabricate(Group::BottomGroup::Member.name.to_sym, group: groups(:bottom_group_two_one), person: person, created_at: Date.today - 3.years, deleted_at: Date.today - 2.years)
         r3 = Fabricate(Group::BottomGroup::Leader.name.to_sym, group: groups(:bottom_group_two_one), person: person)
+        r4 = Fabricate(Group::BottomGroup::Member.name.to_sym, group: groups(:bottom_layer_one), person: person)
 
         get :index, group_id: groups(:bottom_group_one_one).id, id: person.id
 
-        expect(assigns(:roles)).to eq([r1, r3, r2])
+        expect(assigns(:roles)).to eq([r4, r1, r2, r3])
       end
     end
 

--- a/spec/controllers/person/history_controller_spec.rb
+++ b/spec/controllers/person/history_controller_spec.rb
@@ -22,11 +22,11 @@ describe Person::HistoryController do
         r1 = Fabricate(Group::BottomGroup::Member.name.to_sym, group: groups(:bottom_group_one_one), person: person)
         r2 = Fabricate(Group::BottomGroup::Member.name.to_sym, group: groups(:bottom_group_two_one), person: person, created_at: Date.today - 3.years, deleted_at: Date.today - 2.years)
         r3 = Fabricate(Group::BottomGroup::Leader.name.to_sym, group: groups(:bottom_group_two_one), person: person)
-        r4 = Fabricate(Group::BottomGroup::Member.name.to_sym, group: groups(:bottom_layer_one), person: person)
+        r4 = Fabricate(Group::BottomGroup::Member.name.to_sym, group: groups(:bottom_group_one_one_one), person: person)
 
         get :index, group_id: groups(:bottom_group_one_one).id, id: person.id
 
-        expect(assigns(:roles)).to eq([r4, r1, r2, r3])
+        expect(assigns(:roles)).to eq([r1, r4, r2, r3])
       end
     end
 

--- a/spec/regressions/person/history_controller_spec.rb
+++ b/spec/regressions/person/history_controller_spec.rb
@@ -27,7 +27,7 @@ describe Person::HistoryController, type: :controller do
       get :index, params
       expect(dom.all('table tbody tr').size).to eq 1
       role_row = dom.find('table tbody tr:eq(1)')
-      expect(role_row.find('td:eq(1) a').text).to eq 'TopGroup'
+      expect(role_row.find('td:eq(1) a:eq(2)').text).to eq 'TopGroup'
       expect(role_row.find('td:eq(2)').text.strip).to eq 'Member'
       expect(role_row.find('td:eq(3)').text).to be_present
       expect(role_row.find('td:eq(4)').text).not_to be_present
@@ -40,7 +40,7 @@ describe Person::HistoryController, type: :controller do
       get :index, params
       expect(dom.all('table tbody tr').size).to eq 2
       role_row = dom.find('table tbody tr:eq(1)')
-      expect(role_row.find('td:eq(1) a').text).to eq 'Group 11'
+      expect(role_row.find('td:eq(1) a:eq(2)').text).to eq 'Group 11'
       expect(role_row.find('td:eq(2)').text.strip).to eq 'Member'
       expect(role_row.find('td:eq(3)').text).to be_present
       expect(role_row.find('td:eq(4)').text).to be_present
@@ -51,7 +51,7 @@ describe Person::HistoryController, type: :controller do
       get :index, params
       expect(dom.all('table tbody tr').size).to eq 2
       role_row = dom.find('table tbody tr:eq(2)')
-      expect(role_row.find('td:eq(1) a').text).to eq 'TopGroup'
+      expect(role_row.find('td:eq(1) a:eq(2)').text).to eq 'TopGroup'
       expect(role_row.find('td:eq(4)').text).not_to be_present
     end
 
@@ -62,7 +62,7 @@ describe Person::HistoryController, type: :controller do
       get :index, params
       expect(dom.all('table tbody tr').size).to eq 2
       role_row = dom.find('table tbody tr:eq(2)')
-      expect(role_row.find('td:eq(1) a').text).to eq 'TopGroup'
+      expect(role_row.find('td:eq(1) a:eq(2)').text).to eq 'TopGroup'
       expect(role_row.find('td:eq(4)').text).to be_present
     end
 


### PR DESCRIPTION
- Person history now displays the roles with layers in the group colmmn. This allows to identify to which parent group a group belongs.
- Person history now orders the roles by group with layers instead of only the group name.