### PR TITLE
Fix failing tests between 0:00 and 1:00 UTC

### DIFF
--- a/spec/models/duration_spec.rb
+++ b/spec/models/duration_spec.rb
@@ -74,27 +74,27 @@ describe Duration do
 
     context 'by date' do
       it 'today is active' do
-        @duration = Duration.new(Date.today, Date.today)
+        @duration = Duration.new(Time.zone.today, Time.zone.today)
         is_expected.to be_active
       end
 
       it 'until today is active' do
-        @duration = Duration.new(Date.today - 10.days, Date.today)
+        @duration = Duration.new(Time.zone.today - 10.days, Time.zone.today)
         is_expected.to be_active
       end
 
       it 'from today is active' do
-        @duration = Duration.new(Date.today, Date.today + 10.days)
+        @duration = Duration.new(Time.zone.today, Time.zone.today + 10.days)
         is_expected.to be_active
       end
 
       it 'from tomorrow is not active' do
-        @duration = Duration.new(Date.today + 1.day, Date.today + 10.days)
+        @duration = Duration.new(Time.zone.today + 1.day, Time.zone.today + 10.days)
         is_expected.not_to be_active
       end
 
       it 'until yesterday is not active' do
-        @duration = Duration.new(Date.today - 10.days, Date.today - 1.day)
+        @duration = Duration.new(Time.zone.today - 10.days, Time.zone.today - 1.day)
         is_expected.not_to be_active
       end
     end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -82,7 +82,7 @@ describe Event do
     end
 
     context 'with closing date in the future' do
-      before { subject.application_closing_at = Date.today + 1 }
+      before { subject.application_closing_at = Time.zone.today + 1 }
 
        it 'is open without maximum participant' do
         is_expected.to be_application_possible
@@ -97,7 +97,7 @@ describe Event do
     end
 
     context 'with closing date today' do
-      before { subject.application_closing_at = Date.today }
+      before { subject.application_closing_at = Time.zone.today }
 
       it 'is open without maximum participant' do
         is_expected.to be_application_possible
@@ -111,7 +111,7 @@ describe Event do
     end
 
     context 'with closing date in the past' do
-      before { subject.application_closing_at = Date.today - 1 }
+      before { subject.application_closing_at = Time.zone.today - 1 }
 
       it 'is closed without maximum participant' do
         is_expected.not_to be_application_possible
@@ -126,7 +126,7 @@ describe Event do
 
 
     context 'with opening date in the past' do
-      before { subject.application_opening_at = Date.today - 1 }
+      before { subject.application_opening_at = Time.zone.today - 1 }
 
       it 'is open without maximum participant' do
         is_expected.to be_application_possible
@@ -140,7 +140,7 @@ describe Event do
     end
 
     context 'with opening date today' do
-      before { subject.application_opening_at = Date.today }
+      before { subject.application_opening_at = Time.zone.today }
 
       it 'is open without maximum participant' do
         is_expected.to be_application_possible
@@ -154,7 +154,7 @@ describe Event do
     end
 
     context 'with opening date in the future' do
-      before { subject.application_opening_at = Date.today + 1 }
+      before { subject.application_opening_at = Time.zone.today + 1 }
 
       it 'is closed without maximum participant' do
         is_expected.not_to be_application_possible
@@ -163,8 +163,8 @@ describe Event do
 
     context 'with opening and closing dates' do
       before do
-        subject.application_opening_at = Date.today - 2
-        subject.application_closing_at = Date.today + 2
+        subject.application_opening_at = Time.zone.today - 2
+        subject.application_closing_at = Time.zone.today + 2
       end
 
       it 'is open' do
@@ -186,8 +186,8 @@ describe Event do
 
     context 'with opening and closing dates in the future' do
       before do
-        subject.application_opening_at = Date.today + 1
-        subject.application_closing_at = Date.today + 2
+        subject.application_opening_at = Time.zone.today + 1
+        subject.application_closing_at = Time.zone.today + 2
       end
 
       it 'is closed' do
@@ -197,8 +197,8 @@ describe Event do
 
     context 'with opening and closing dates in the past' do
       before do
-        subject.application_opening_at = Date.today - 2
-        subject.application_closing_at = Date.today - 1
+        subject.application_opening_at = Time.zone.today - 2
+        subject.application_closing_at = Time.zone.today - 1
       end
 
       it 'is closed' do
@@ -289,28 +289,28 @@ describe Event do
     end
 
     it 'is valid with application closing after opening' do
-      subject.application_opening_at = Date.today - 5
-      subject.application_closing_at = Date.today + 5
+      subject.application_opening_at = Time.zone.today - 5
+      subject.application_closing_at = Time.zone.today + 5
       subject.valid?
 
       is_expected.to be_valid
     end
 
     it 'is not valid with application closing before opening' do
-      subject.application_opening_at = Date.today - 5
-      subject.application_closing_at = Date.today - 6
+      subject.application_opening_at = Time.zone.today - 5
+      subject.application_closing_at = Time.zone.today - 6
 
       is_expected.not_to be_valid
     end
 
     it 'is valid with application closing and without opening' do
-      subject.application_closing_at = Date.today - 6
+      subject.application_closing_at = Time.zone.today - 6
 
       is_expected.to be_valid
     end
 
     it 'is valid with application opening and without closing' do
-      subject.application_opening_at = Date.today - 6
+      subject.application_opening_at = Time.zone.today - 6
 
       is_expected.to be_valid
     end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -83,7 +83,7 @@ describe Qualification do
 
 
   context '#set_finish_at' do
-    let(:date) { Date.today }
+    let(:date) { Time.zone.today }
 
     it 'set current end of year if validity is 0' do
       quali = build_qualification(0, date)
@@ -128,25 +128,25 @@ describe Qualification do
     subject { person.reload.qualifications.active }
 
     it 'contains from today' do
-      q = Fabricate(:qualification, person: person, start_at: Date.today)
+      q = Fabricate(:qualification, person: person, start_at: Time.zone.today)
       expect(q).to be_active
       is_expected.to include(q)
     end
 
     it 'does contain until this year' do
-      q = Fabricate(:qualification, person: person, start_at: Date.today - 2.years)
+      q = Fabricate(:qualification, person: person, start_at: Time.zone.today - 2.years)
       expect(q).to be_active
       is_expected.to include(q)
     end
 
     it 'does not contain past' do
-      q = Fabricate(:qualification, person: person, start_at: Date.today - 5.years)
+      q = Fabricate(:qualification, person: person, start_at: Time.zone.today - 5.years)
       expect(q).not_to be_active
       is_expected.not_to include(q)
     end
 
     it 'does not contain future' do
-      q = Fabricate(:qualification, person: person, start_at: Date.today + 1.day)
+      q = Fabricate(:qualification, person: person, start_at: Time.zone.today + 1.day)
       expect(q).not_to be_active
       is_expected.not_to include(q)
     end
@@ -155,7 +155,7 @@ describe Qualification do
   context 'reactivateable qualification kind' do
     subject { person.reload.qualifications }
 
-    let(:today) { Date.today }
+    let(:today) { Time.zone.today }
     let(:kind) { qualification_kinds(:sl) }
     let(:start_date) { today - 1.years }
     let(:q) { Fabricate(:qualification, qualification_kind: kind, person: person, start_at: start_date) }
@@ -219,7 +219,7 @@ describe Qualification do
       expect do
         person.qualifications.create!(qualification_kind: qualification_kinds(:sl),
                                       origin: 'Bar',
-                                      start_at: Date.today)
+                                      start_at: Time.zone.today)
       end.to change { PaperTrail::Version.count }.by(1)
 
       version = PaperTrail::Version.order(:created_at, :id).last
@@ -230,7 +230,7 @@ describe Qualification do
     it 'sets main on update' do
       quali = person.qualifications.create!(qualification_kind: qualification_kinds(:sl),
                                             origin: 'Bar',
-                                            start_at: Date.today)
+                                            start_at: Time.zone.today)
       expect do
         quali.update_attributes!(origin: 'Bur')
       end.to change { PaperTrail::Version.count }.by(1)
@@ -243,7 +243,7 @@ describe Qualification do
     it 'sets main on destroy' do
       quali = person.qualifications.create!(qualification_kind: qualification_kinds(:sl),
                                             origin: 'Bar',
-                                            start_at: Date.today)
+                                            start_at: Time.zone.today)
       expect do
         quali.destroy!
       end.to change { PaperTrail::Version.count }.by(1)


### PR DESCRIPTION
Because the timezone of the app is set to 'Berne' and the CI server is in a UTC timezone. Use Time.zone.today instead Date.today.
See [this](https://travis-ci.org/hitobito/hitobito/jobs/212571141) failed build.