### PR TITLE
Fix erroneous upload error

### DIFF
--- a/app/assets/javascripts/modules/ajax_upload.js.coffee
+++ b/app/assets/javascripts/modules/ajax_upload.js.coffee
@@ -1,4 +1,4 @@
-#  Copyright (c) 2015 Pro Natura Schweiz. This file is part of
+#  Copyright (c) 2015-2017 Pro Natura Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -13,6 +13,7 @@ class app.AjaxUpload
     form = $(input).closest('form')
     new app.Spinner().show(form)
     form.submit()
+    $(input).closest('form').reset()
 
   bind: ->
     self = this

--- a/app/controllers/event/attachments_controller.rb
+++ b/app/controllers/event/attachments_controller.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2015, Pro Natura Schweiz. This file is part of
+#  Copyright (c) 2015-2017, Pro Natura Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -22,7 +22,7 @@ class Event::AttachmentsController < CrudController
 
   private
 
-  alias_method :event, :parent
+  alias event parent
 
   def index_path
     group_event_path(*parents)


### PR DESCRIPTION
fixes #305 

Es scheint so zu sein, dass das Formular bei der zweiten Datei zwar abschickbar, aber ohne Datei ist. Daher wird es normal abgeschickt, was dann Rails dazu bringt, zurecht die fehlende Datei zu bemängeln. 

Ein Form-Reset nach dem Submit säubert das Formular und verhindert damit anscheinend diesen Fehler.

Interessanterweise kann man nach dem Submit das Formular nicht weiter verwenden, sondern muss es neu via jQuery suchen.

Ich hätte gerne ein zweites Paar Augen auf dem Code, da ich unsicher bin, ob meine Theorie auch stimmt.