### PR TITLE
Consider group when updating role inline

### DIFF
--- a/app/views/roles/update.js.haml
+++ b/app/views/roles/update.js.haml
@@ -1,3 +1,4 @@
+- group ||= defined(@group) ? group : nil
 $('##{dom_id(@old_role || @role)}').parent().hide()
-$('##{dom_id(@old_role || @role)}').popover('destroy').replaceWith('#{j(PersonDecorator.new(entry.person).roles_short(@group))}')
+$('##{dom_id(@old_role || @role)}').popover('destroy').replaceWith('#{j(PersonDecorator.new(entry.person).roles_short(group))}')
 $('##{dom_id(entry)}').parent().toggle('highlight', {duration: 1000})

--- a/app/views/roles/update.js.haml
+++ b/app/views/roles/update.js.haml
@@ -1,3 +1,3 @@
 $('##{dom_id(@old_role || @role)}').parent().hide()
-$('##{dom_id(@old_role || @role)}').popover('destroy').replaceWith('#{j(PersonDecorator.new(entry.person).roles_short)}')
+$('##{dom_id(@old_role || @role)}').popover('destroy').replaceWith('#{j(PersonDecorator.new(entry.person).roles_short(@group))}')
 $('##{dom_id(entry)}').parent().toggle('highlight', {duration: 1000})

--- a/app/views/roles/update.js.haml
+++ b/app/views/roles/update.js.haml
@@ -1,4 +1,4 @@
-- group ||= defined(@group) ? group : nil
+- group ||= defined?(@group) ? group : nil
 $('##{dom_id(@old_role || @role)}').parent().hide()
 $('##{dom_id(@old_role || @role)}').popover('destroy').replaceWith('#{j(PersonDecorator.new(entry.person).roles_short(group))}')
 $('##{dom_id(entry)}').parent().toggle('highlight', {duration: 1000})


### PR DESCRIPTION
# Problem

Wie nachfolgend illustriert werden nach dem Inline-Update einer Rolle die Rollen aller Gruppen einer Person angezeigt:

![sep-18-2017 19-56-19](https://user-images.githubusercontent.com/939106/30556616-b5dd4ece-9cab-11e7-8506-e1f8854a2a1a.gif)

# Lösung

Die Gruppe wird beim rendern berücksichtigt
