### PR TITLE
Increase the MySQL sort_buffer_size on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ rvm:
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install sphinxsearch
+  - echo -e '[mysqld]\nsort_buffer_size = 2M\n' > /etc/mysql/conf.d/sort_buffer_size.cnf
 install:
   - sed -i "s/^\(gem .mysql2.\),.*$/\1/" Gemfile
   - bundle install --path vendor/bundle


### PR DESCRIPTION
A test fails on Travis CI with this error

```
Mysql2::Error: Out of sort memory, consider increasing server sort buffer size
```

Therefore I am considering.