### PR TITLE
Drop older Ruby-Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,4 @@ script:
   - bundle exec rake db:create ci --trace
 matrix:
   allow_failures:
-  - rvm: 2.1.7
-  - rvm: 2.3.1
   - rvm: 2.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ env:
     - HEADLESS=true
     - RAILS_DB_ADAPTER=mysql2
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1.7
   - 2.2.3
   - 2.3.1
@@ -31,7 +29,6 @@ script:
   - bundle exec rake db:create ci --trace
 matrix:
   allow_failures:
-  - rvm: 2.0.0
   - rvm: 2.1.7
   - rvm: 2.3.1
   - rvm: 2.4.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ hitobito is an open source web application to manage complex group hierarchies w
 
 ## Development
 
-Hitobito is a Ruby on Rails application that runs on Ruby >= 1.9.3 and Rails 4.
+Hitobito is a Ruby on Rails application that runs on Ruby >= 2.1 and Rails 4.
+It might run with minor tweaks on older Rubies, but is not tested against those
+versions.
+
 To get going, after you got a copy of hitobito and at least one wagon with an organization
 structure setup as described below, issue the following commands in the main directory:
 

--- a/spec/domain/person/filter/role_spec.rb
+++ b/spec/domain/person/filter/role_spec.rb
@@ -156,7 +156,7 @@ describe Person::Filter::Role do
       end
 
       it 'sets min to beginning_of_time if missing' do
-        expect(time_range.min).to eq Time.at(0).beginning_of_day
+        expect(time_range.min).to eq Time.zone.at(0).beginning_of_day
       end
 
       it 'sets max to Date.today#end_of_day if missing' do


### PR DESCRIPTION
For some security-updates, we need to drop some older Ruby-Versions. Those are EOL'd by upstream ruby anyway.