### PR TITLE
toggle-condense-labels checkbox should also affect the last used label format

### DIFF
--- a/app/helpers/dropdown/label_items.rb
+++ b/app/helpers/dropdown/label_items.rb
@@ -37,7 +37,7 @@ module Dropdown
         last_format = user.last_label_format
         parent.sub_items << Item.new(last_format.to_s,
                                      export_label_format_path(last_format.id),
-                                     target: :new)
+                                     target: :new, class: 'export-label-format')
         parent.sub_items << Divider.new
       end
     end


### PR DESCRIPTION
When clicking on the toggle-condense-labels checkbox in the people_export dropdown, some JavaScript is executed that toggles the option on all label formats in the dropdown with the 'export-label-format' class. This class was missing from the last used label format, so when using that option to export, the uncondensed version of the labels was always exported.
This PR adds the class to the last used label format, so it is affected by the checkbox too.