### PR TITLE
Do not disrupt the user-workflow

### DIFF
--- a/app/controllers/crud_controller.rb
+++ b/app/controllers/crud_controller.rb
@@ -127,6 +127,7 @@ class CrudController < ListController
   def save_entry
     entry.save
   rescue Mysql2::Error => e
+    Airbrake.notify(e, parameters: params)
     logger.error e.message
     false
   end

--- a/app/controllers/crud_controller.rb
+++ b/app/controllers/crud_controller.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2018, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -126,6 +126,9 @@ class CrudController < ListController
   # perform the save operation
   def save_entry
     entry.save
+  rescue Mysql2::Error => e
+    logger.error e.message
+    false
   end
 
   # A label for the current entry, including the model name.


### PR DESCRIPTION
Fixes #414

Since most DB-Errors are either setup-issues or race-conditions, I
silence them here. The setup-issues will be visible on other places and
also be logged for debugging. The race-conditions are nothing the App
can sensibly handle everytime.

So I just return "false" indicating the failed save and let the user
handle the situation according to the displayed data.