### PR TITLE
Feature/542 sort groups correctly

### DIFF
--- a/app/helpers/sheet/group/nav_left.rb
+++ b/app/helpers/sheet/group/nav_left.rb
@@ -93,7 +93,7 @@ module Sheet
       def group_link(group)
         cls = " class=\"active\"" if group == entry
         "<li#{cls}>".html_safe +
-        link_to(group.short_name.present? ? group.short_name : group.to_s,
+        link_to(group.display_name,
                 active_path(group), title: group.to_s)
       end
 
@@ -112,7 +112,7 @@ module Sheet
           content_tag(:li, content_tag(:span, type, class: 'divider')) +
           safe_join(layers) do |l|
             l.use_hierarchy_from_parent(layer)
-            content_tag(:li, link_to(l.short_name.present? ? l.short_name : l.to_s,
+            content_tag(:li, link_to(l.display_name,
                                      active_path(l), title: l.to_s))
           end
         end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -155,7 +155,6 @@ class Group < ActiveRecord::Base
     display_name.downcase
   end
 
-
   def with_layer
     layer? ? [self] : [layer_group, self]
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -147,6 +147,15 @@ class Group < ActiveRecord::Base
     name
   end
 
+  def display_name
+    short_name.present? ? short_name : name
+  end
+
+  def display_name_downcase
+    display_name.downcase
+  end
+
+
   def with_layer
     layer? ? [self] : [layer_group, self]
   end

--- a/app/models/group/nested_set.rb
+++ b/app/models/group/nested_set.rb
@@ -111,7 +111,7 @@ module Group::NestedSet
   end
 
   def move_to_right_of_if_change(node)
-    if node.display_name.downcase != name.downcase && node.rgt != lft - 1
+    if node.display_name.downcase != display_name.downcase && node.rgt != lft - 1
       move_to_right_of(node)
     end
   end  

--- a/app/models/group/nested_set.rb
+++ b/app/models/group/nested_set.rb
@@ -11,7 +11,7 @@ module Group::NestedSet
   included do
     acts_as_nested_set dependent: :destroy
 
-    before_save :store_new_name
+    before_save :store_new_display_name
     after_save :move_to_alphabetic_position
   end
 
@@ -88,15 +88,15 @@ module Group::NestedSet
 
   private
 
-  def store_new_name
-    @move_to_new_name = name_changed? ? name : false
+  def store_new_display_name
+    @move_to_new_name = name_changed? || short_name_changed? ? display_name : false
     true # force callback to return true
   end
 
   def move_to_alphabetic_position
     return unless move_required?
 
-    left_neighbor = find_left_neighbor(parent, :name, true)
+    left_neighbor = find_left_neighbor(parent, :display_name_downcase, true)
     if left_neighbor
       move_to_right_of_if_change(left_neighbor)
     else
@@ -111,13 +111,14 @@ module Group::NestedSet
   end
 
   def move_to_right_of_if_change(node)
-    if node.name != name && node.rgt != lft - 1
+    if node.display_name.downcase != name.downcase && node.rgt != lft - 1
       move_to_right_of(node)
     end
-  end
+  end  
 
   def move_to_most_left_if_change
     first = parent.children[0]
     move_to_left_of(first) unless first == self
   end
+
 end

--- a/app/models/group/nested_set.rb
+++ b/app/models/group/nested_set.rb
@@ -114,7 +114,7 @@ module Group::NestedSet
     if node.display_name.downcase != display_name.downcase && node.rgt != lft - 1
       move_to_right_of(node)
     end
-  end  
+  end
 
   def move_to_most_left_if_change
     first = parent.children[0]

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -55,7 +55,6 @@ toppers:
 
 bottom_layer_one:
   name: Bottom One
-  short_name: One
   type: Group::BottomLayer
   parent: top_layer
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bottom_layer_one) %>

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -98,6 +98,26 @@ describe Group do
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
          'Bottom One', 'Bottom Two', 'TopGroup', 'Toppers', 'Toppers']
       end
+
+      context 'with short_name' do
+        it 'in the middle' do
+          parent = groups(:top_layer)
+          group = Group::TopGroup.new(name: 'Bottom A', short_name: 'Bottom X', parent_id: parent.id)
+          group.save!
+          expect = expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
+           'Bottom One', 'Bottom Two','Bottom A', 'TopGroup', 'Toppers']
+        end
+      end
+
+      context 'with lowercase' do
+        it 'in the middle' do
+          parent = groups(:top_layer)
+          group = Group::TopGroup.new(name: 'bottom x', parent_id: parent.id)
+          group.save!
+          expect = expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
+           'Bottom One', 'Bottom Two', 'bottom x', 'TopGroup', 'Toppers']
+        end
+      end
     end
 
     context 'on update' do
@@ -154,6 +174,23 @@ describe Group do
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
          'Bottom One', 'TopGroup', 'Toppers', 'Toppers']
       end
+
+      context 'with short_name' do
+        it 'at the end' do
+          groups(:bottom_layer_two).update_attributes!(short_name: 'XXX')
+          expect(groups(:top_layer).children.order(:lft).collect(&:display_name)).to eq [
+           'Bottom One', 'TopGroup', 'Toppers', "XXX"]
+        end
+      end
+
+      context 'with lowercase' do
+        it 'in the middle' do
+          groups(:bottom_layer_two).update_attributes!(name: 'topGroupX')
+          expect(groups(:top_layer).children.order(:lft).collect(&:display_name)).to eq [
+           'Bottom One', 'TopGroup', 'topGroupX', 'Toppers']
+        end
+      end
+
     end
   end
 


### PR DESCRIPTION
nested set now sorts after :display_name_downcase , as this is the expected way to display it usually. fixes #542 

But I don't know how to rebuild the nested set, so it actually updates the current situation. So help with this would be appreciated.

Or should all this have been done only in the view where it is displayed. Is there some other impact I have not thought of?