### PR TITLE
Allows validity of 0 year for qualification kind, fixes #458

### DIFF
--- a/app/models/qualification_kind.rb
+++ b/app/models/qualification_kind.rb
@@ -34,7 +34,7 @@ class QualificationKind < ActiveRecord::Base
   validates_by_schema
   validates :label, presence: true, length: { maximum: 255, allow_nil: true }
   validates :description, length: { maximum: 1023, allow_nil: true }
-  validates :reactivateable, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
+  validates :reactivateable, numericality: { greater_than_or_equal_to: 1, allow_nil: true }
 
   validate :assert_validity_when_reactivateable
 

--- a/app/models/qualification_kind.rb
+++ b/app/models/qualification_kind.rb
@@ -58,7 +58,7 @@ class QualificationKind < ActiveRecord::Base
 
   def assert_validity_when_reactivateable
     if reactivateable.present? && (validity.nil? || validity.to_i < 0)
-      errors.add(:validity, :not_a_number)
+      errors.add(:validity, :not_a_valid_number)
     end
   end
 

--- a/app/models/qualification_kind.rb
+++ b/app/models/qualification_kind.rb
@@ -34,7 +34,7 @@ class QualificationKind < ActiveRecord::Base
   validates_by_schema
   validates :label, presence: true, length: { maximum: 255, allow_nil: true }
   validates :description, length: { maximum: 1023, allow_nil: true }
-  validates :reactivateable, numericality: { greater_than_or_equal_to: 1, allow_nil: true }
+  validates :reactivateable, numericality: { greater_than_or_equal_to: 0, allow_nil: true }
 
   validate :assert_validity_when_reactivateable
 
@@ -57,8 +57,8 @@ class QualificationKind < ActiveRecord::Base
   private
 
   def assert_validity_when_reactivateable
-    if reactivateable.present? && (validity.to_i <= 0)
-      errors.add(:validity, :not_a_positive_number)
+    if reactivateable.present? && (validity.nil? || validity.to_i < 0)
+      errors.add(:validity, :not_a_number)
     end
   end
 

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -99,7 +99,7 @@ de:
         qualification_kind:
           attributes:
             validity:
-              not_a_positive_number: 'muss einen positive Zahl sein um die %{model} reaktivierbar zu machen'
+              not_a_valid_number: 'muss grösser oder gleich Null sein um %{model} reaktivierbar zu machen'
         subscription:
           attributes:
             subscriber_id:

--- a/spec/models/qualification_kind_spec.rb
+++ b/spec/models/qualification_kind_spec.rb
@@ -40,6 +40,12 @@ describe QualificationKind do
       it { is_expected.to have(1).error_on(:validity) }
     end
 
+    context '0 year validity' do
+      let(:validity) { 0 }
+      it{ is_expected.to be_valid }
+    end
+
+
     context 'nil validity' do
       let(:validity) { nil }
       it { is_expected.to have(1).error_on(:validity) }


### PR DESCRIPTION
Validation on validity required validity to be bigger than zero. Probably because 0 Year validitity does not seem to make sense, but it actually exists see #458 

Probably this was done this way, because nil.to_i returns 0, so you have to explicitely check for nil.
