### PR TITLE
Update gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 addons:
-  firefox: 45.0
+  firefox: 60.0
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ gem 'therubyracer', platforms: :ruby
 gem 'turbolinks'
 gem 'uglifier'
 
+# security updates, can be deleted if they get in the way of updates or so
+gem 'sprockets', '~> 3.7.2'
 
 group :development, :test do
   gem 'binding_of_caller'

--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ group :test do
   gem 'pdf-inspector', require: 'pdf/inspector'
   gem 'rspec-collection_matchers'
   gem 'rspec-its'
-  gem 'selenium-webdriver', '2.51.0' # 3.2.2 fails with "Unable to find Mozilla geckodriver"
+  gem 'selenium-webdriver'
 end
 
 group :console do

--- a/Gemfile
+++ b/Gemfile
@@ -12,13 +12,15 @@ gem 'rails', '4.2.8'
 gem 'activerecord-session_store'
 gem 'acts-as-taggable-on', '~> 3.5.0'
 gem 'airbrake', '< 5.0' # requires newer errbit
-gem 'axlsx', '>= 3.0.0.pre'
 gem 'awesome_nested_set', '< 3.1.0' # requires ruby 2.0
+gem 'axlsx', '>= 3.0.0.pre'
 gem 'bcrypt-ruby'
 gem 'cancancan', '< 1.13.0' # requires ruby 2.0
 gem 'carrierwave', '< 0.11.1' # uses 2.0 for testing (no explicit requirement, yet)
 gem 'cmess'
+gem 'config', '< 1.1.0' # requires ruby 2
 gem 'country_select'
+gem 'customized_piwik_analytics', '~> 1.0.0'
 gem 'daemons'
 gem 'dalli'
 gem 'delayed_job_active_record'
@@ -37,14 +39,12 @@ gem 'nested_form'
 gem 'oat'
 gem 'paper_trail'
 gem 'paranoia', '< 2.1.2' # uses 2.0 for testing (no explicit requirement, yet)
-gem 'customized_piwik_analytics', '~> 1.0.0'
 gem 'prawn', '< 2.0' # 2.0 requires ruby 2.0
 gem 'prawn-table'
 gem 'protective'
 gem 'rack'
-gem 'rails_autolink'
-gem 'config', '< 1.1.0' # requires ruby 2
 gem 'rails-i18n'
+gem 'rails_autolink'
 gem 'rubyzip'
 gem 'seed-fu'
 gem 'simpleidn'
@@ -67,22 +67,22 @@ gem 'compass'
 gem 'compass-rails'
 gem 'jquery-cookie-rails'
 gem 'jquery-rails'
-gem 'jquery-ui-rails'
 gem 'jquery-turbolinks'
+gem 'jquery-ui-rails'
 gem 'remotipart'
 gem 'sass-rails'
 gem 'therubyracer', platforms: :ruby
 gem 'turbolinks'
 gem 'uglifier'
 
-gem 'parallel_tests', group: [:development, :test]
-
 
 group :development, :test do
   gem 'binding_of_caller'
-  gem 'rspec-rails'
   gem 'codez-tarantula', require: 'tarantula-rails3'
+  gem 'parallel_tests'
   gem 'pry-rails'
+  gem 'rspec-rails'
+
   gem 'pry-debugger', platforms: :ruby_19
   gem 'pry-doc'
   # gem 'pry-byebug', platforms: [:ruby_20, :ruby_21]
@@ -102,10 +102,10 @@ group :test do
   gem 'fabrication'
   gem 'headless'
   gem 'launchy'
-  gem 'rspec-its'
-  gem 'rspec-collection_matchers'
-  gem 'selenium-webdriver', '2.51.0' # 3.2.2 fails with "Unable to find Mozilla geckodriver"
   gem 'pdf-inspector', require: 'pdf/inspector'
+  gem 'rspec-collection_matchers'
+  gem 'rspec-its'
+  gem 'selenium-webdriver', '2.51.0' # 3.2.2 fails with "Unable to find Mozilla geckodriver"
 end
 
 group :console do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,8 @@ GEM
       tzinfo (~> 1.1)
     acts-as-taggable-on (3.5.0)
       activerecord (>= 3.2, < 5)
-    addressable (2.4.0)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     afm (0.2.2)
     airbrake (4.3.4)
       builder
@@ -77,13 +78,13 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
     cancancan (1.12.0)
-    capybara (2.12.1)
+    capybara (2.18.0)
       addressable
-      mime-types (>= 1.16)
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      xpath (~> 2.0)
+      xpath (>= 2.0, < 4.0)
     capybara-screenshot (1.0.14)
       capybara (>= 1.0, < 3)
       launchy
@@ -92,7 +93,7 @@ GEM
       activesupport (>= 3.2.0)
       json (>= 1.7)
       mime-types (>= 1.16)
-    childprocess (0.6.2)
+    childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     choice (0.2.0)
     chosen-rails (1.5.2)
@@ -189,7 +190,7 @@ GEM
     fabrication (2.16.1)
     faker (1.6.3)
       i18n (~> 0.5)
-    ffi (1.9.18)
+    ffi (1.9.25)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     globalize (5.0.1)
@@ -249,12 +250,13 @@ GEM
     mime-types (2.6.2)
     mimemagic (0.3.2)
     mini_magick (4.6.1)
+    mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     mysql2 (0.4.9)
     nested_form (0.3.2)
-    nokogiri (1.8.3)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     nuggets (1.5.0)
     oat (0.5.0)
@@ -305,6 +307,7 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    public_suffix (3.0.3)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.10)
@@ -417,11 +420,9 @@ GEM
       activesupport (>= 3.1)
     seed-fu-ndo (0.0.2)
       seed-fu (>= 2.2.0)
-    selenium-webdriver (2.51.0)
+    selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
-      multi_json (~> 1.0)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0)
+      rubyzip (~> 1.2)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -492,10 +493,9 @@ GEM
       seed-fu-ndo (>= 0.0.2)
     warden (1.2.7)
       rack (>= 1.0)
-    websocket (1.2.4)
     wirble (0.1.3)
-    xpath (2.0.0)
-      nokogiri (~> 1.3)
+    xpath (3.1.0)
+      nokogiri (~> 1.8)
     yard (0.9.12)
 
 PLATFORMS
@@ -543,6 +543,7 @@ DEPENDENCIES
   hirb
   http_accept_language
   icalendar
+  jquery-cookie-rails
   jquery-rails
   jquery-turbolinks
   jquery-ui-rails
@@ -586,7 +587,7 @@ DEPENDENCIES
   rubyzip
   sass-rails
   seed-fu
-  selenium-webdriver (= 2.51.0)
+  selenium-webdriver
   simplecov-rcov
   simpleidn
   spring-commands-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,7 +445,7 @@ GEM
       activesupport (>= 4.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)
@@ -591,6 +591,7 @@ DEPENDENCIES
   simplecov-rcov
   simpleidn
   spring-commands-rspec
+  sprockets (~> 3.7.2)
   sqlite3
   therubyracer
   thinking-sphinx


### PR DESCRIPTION
tl;dr There is one security issue and some build-issues. :scream: But this PR fixes them both :smile: 

On our other build-system, we updated the older firefox to a more recent version.
Therefore I took in upon myself to update selenium-webdriver and capybara. 
To reflect and motivate the change for the Community, the `.travis.yml` has been updated as well.

While at the topic of updating Gems, I updated Sprockets to mitigate a security issue and ordered the dependencies in the Gemfile alphabetically to make rubocop more happy.