### PR TITLE
Feature/wildcard mail relay

### DIFF
--- a/app/domain/mail_relay/lists.rb
+++ b/app/domain/mail_relay/lists.rb
@@ -124,10 +124,18 @@ module MailRelay
       message.smtp_envelope_from = env_sender
     end
 
+    def domain_is_valid?(domain)
+        domain !~ /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/
+    end
+
     def sender_is_additional_sender?
       additional_senders = mailing_list.additional_sender.to_s
       list = additional_senders.split(/[,;]/).collect(&:strip).select(&:present?)
-      list.include?(sender_email)
+      sender_domain = sender_email.sub(/^[^@]*@/, "*@")
+      # check if the domain is valid, if the sender is in the senders
+      # list or if the domain is whitelisted
+      list.include?(sender_email) ||
+          (domain_is_valid?(sender_domain) && list.include?(sender_domain))
     end
 
     def sender_is_group_email?

--- a/app/domain/mail_relay/lists.rb
+++ b/app/domain/mail_relay/lists.rb
@@ -124,18 +124,18 @@ module MailRelay
       message.smtp_envelope_from = env_sender
     end
 
-    def domain_is_valid?(domain)
-        domain !~ /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/
+    def valid_domain?(domain)
+      domain !~ /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/
     end
 
     def sender_is_additional_sender?
       additional_senders = mailing_list.additional_sender.to_s
       list = additional_senders.split(/[,;]/).collect(&:strip).select(&:present?)
-      sender_domain = sender_email.sub(/^[^@]*@/, "*@")
+      sender_domain = sender_email.sub(/^[^@]*@/, '*@')
       # check if the domain is valid, if the sender is in the senders
       # list or if the domain is whitelisted
       list.include?(sender_email) ||
-          (domain_is_valid?(sender_domain) && list.include?(sender_domain))
+          (valid_domain?(sender_domain) && list.include?(sender_domain))
     end
 
     def sender_is_group_email?

--- a/app/models/mailing_list.rb
+++ b/app/models/mailing_list.rb
@@ -45,6 +45,9 @@ class MailingList < ActiveRecord::Base
                         allow_blank: true
   validates :description, length: { allow_nil: true, maximum: 2**16 - 1 }
   validate :assert_mail_name_is_not_protected
+  validates :additional_sender,
+      allow_blank: true,
+      format: /\A *(([a-z][a-z0-9\-\_\.]*|\*)@([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,} *(,|;|\Z) *)+\Z/
 
   DEFAULT_LABEL = '_main'.freeze
 

--- a/app/views/mailing_lists/_form.html.haml
+++ b/app/views/mailing_lists/_form.html.haml
@@ -12,7 +12,7 @@
         = f.input_field(:mail_name, class: 'span3')
         %span.add-on= "@#{entry.mail_domain}"
 
-    = f.labeled_input_field(:additional_sender, help: t('.help_additional_sender'))
+    = f.labeled_input_field(:additional_sender, help: t('.help_additional_sender'), placeholder: "hans.muster@pfadi-beispiel.ch; *@pfadi-muster.ch")
 
   %fieldset
     = f.labeled(:preferred_labels) do

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -124,6 +124,10 @@ de:
               invalid_check_digit: 'ist nicht gültig; Inkorrekte Prüfziffer'
             payee:
               to_long: 'darf höchstens 2 Zeilen enthalten'
+        mailing_list:
+            attributes:
+                additional_sender:
+                    invalid: "muss Mailadressen vom Format abcd@ee.ch oder *@ee.ch enthalten. Mehrere Adressen müssen mit ',' oder ';' abgetrennt werden."
 
     models:
       acts_as_taggable_on/tag:

--- a/spec/models/mailing_list_spec.rb
+++ b/spec/models/mailing_list_spec.rb
@@ -86,6 +86,23 @@ describe MailingList do
       list.mail_name = 'foo'
       expect(list).to have(1).error_on(:mail_name)
     end
+
+    it 'succeed with additional_sender' do
+      list.additional_sender = ''
+      expect(list).to be_valid
+    end
+    it 'succeed with additional_sender' do
+      list.additional_sender = 'abc@de.ft; *@df.dfd.ee,test@test.test'
+      expect(list).to be_valid
+    end
+    it 'succeed with additional_sender' do
+      list.additional_sender = 'abc*dv@test.ch'
+      expect(list).to have(1).error_on(:additional_sender)
+    end
+    it 'succeed with additional_sender' do
+      list.additional_sender = 'abc@de.ft;as*d@df.dfd.ee,test@test.test'
+      expect(list).to have(1).error_on(:additional_sender)
+    end
   end
 
   describe '#subscribed?' do


### PR DESCRIPTION
- Allow wildcards in mailing lists.
- Give feedback for malformed additional email senders in generation of new mailing lists.