### PR TITLE
fix the default role when assigning a new group

### DIFF
--- a/app/helpers/roles_helper.rb
+++ b/app/helpers/roles_helper.rb
@@ -58,7 +58,7 @@ module RolesHelper
 
   def roles_type_select_options(group)
     options = { include_blank: true }
-    options[:selected] = '@group.default_role' if group.default_role
+    options[:selected] = group.default_role if group.default_role
     options
   end
 


### PR DESCRIPTION
Fix a typo to enable the automatic selection of the default role of a group when assigning a new role to a user.