### PR TITLE
Feature: Display required fields with an asterisk

### DIFF
--- a/app/assets/stylesheets/hitobito/_form.scss
+++ b/app/assets/stylesheets/hitobito/_form.scss
@@ -311,8 +311,10 @@ textarea {
     content: '*';
     color: $orange;
     font-size: 9pt;
-    vertical-align: super;
-    float: right;
+  }
+
+  @media all and (max-width: $mediaPhone) {
+    transform: none;
   }
 }
 

--- a/app/assets/stylesheets/hitobito/_form.scss
+++ b/app/assets/stylesheets/hitobito/_form.scss
@@ -116,7 +116,7 @@ fieldset {
   $content-padding: 20px;
   margin-bottom: 9px;
   padding-top: $content-padding / 2;
-  padding-bottom: $content-padding / 2; 
+  padding-bottom: $content-padding / 2;
   margin-left: - $content-padding;
   margin-right: - $content-padding;
   padding-left: $content-padding;
@@ -176,7 +176,7 @@ input[type="color"],
   line-height: 20px;
   color: $black;
 
-  &::placeholder, 
+  &::placeholder,
   &::-webkit-input-placeholder
   {
     color: $gray;
@@ -303,6 +303,17 @@ textarea {
 .fields-separation hr {
   margin: 7px 0 15px;
   border-top-color: $grayLight;
+}
+
+.control-group.required > label {
+  transform: translate(5pt);
+  &::after {
+    content: '*';
+    color: $orange;
+    font-size: 9pt;
+    vertical-align: super;
+    float: right;
+  }
 }
 
 .control-group .fields {

--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -264,11 +264,6 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
     template.render('shared/error_messages', errors: @object.errors, object: @object)
   end
 
-  # Renders a marker if the given attr has to be present.
-  def required_mark(attr)
-    required?(attr) ? REQUIRED_MARK : ''
-  end
-
   # Render a label for the given attribute with the passed field html section.
   # The following parameters may be specified:
   #   labeled(:attr) { #content }
@@ -284,8 +279,9 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
     end
     caption_or_content ||= captionize(attr, klass)
     add_css_class(html_options, 'controls')
+    css_classes = { 'control-group' => true, error: errors_on?(attr), required: required?(attr) }
 
-    content_tag(:div, class: "control-group#{' error' if errors_on?(attr)}") do
+    content_tag(:div, class: css_classes.select { |css, show| show }.keys.join(" ")) do
       label(attr, caption_or_content, class: 'control-label') +
       content_tag(:div, content, html_options)
     end
@@ -437,7 +433,7 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
     labeled_args = [args.first]
     labeled_args << label if label.present?
 
-    text = send(field_method, *(args << options)) + required_mark(args.first)
+    text = send(field_method, *(args << options))
     text = with_addon(addon, text) if addon.present?
     text << help_inline(help_inline) if help_inline.present?
     text << help_block(help) if help.present?

--- a/spec/helpers/standard_form_builder_spec.rb
+++ b/spec/helpers/standard_form_builder_spec.rb
@@ -57,12 +57,12 @@ describe 'StandardFormBuilder' do
   describe '#labeled_input_field' do
     context 'when required' do
       subject { form.labeled_input_field(:name) }
-      it { is_expected.to include(StandardFormBuilder::REQUIRED_MARK) }
+      it { is_expected.to include('class="control-group required"') }
     end
 
     context 'when not required' do
       subject { form.labeled_input_field(:remarks) }
-      it { is_expected.not_to include(StandardFormBuilder::REQUIRED_MARK) }
+      it { is_expected.not_to include('class="control-group required"') }
     end
 
     context 'with help text' do
@@ -219,20 +219,6 @@ describe 'StandardFormBuilder' do
 
       it { is_expected.to be_html_safe }
       it { is_expected.to match /label [^>]*for.+>Caption<\/label>.*<input/m }
-    end
-  end
-
-  describe '#required_mark' do
-    it 'is shown for required attrs' do
-      expect(form.required_mark(:name)).to eq(StandardFormBuilder::REQUIRED_MARK)
-    end
-
-    it 'is not shown for optional attrs' do
-      expect(form.required_mark(:rating)).to be_empty
-    end
-
-    it 'is not shown for non existing attrs' do
-      expect(form.required_mark(:not_existing)).to be_empty
     end
   end
 


### PR DESCRIPTION
# Problem

As of right now, required fields are indicated with an asterisk _after_ the input-field. This is quiet unconventional and users might oversee it easily.

# Solution

Move the asterisk in front of the input-field, next to the label. Instead of hardcoding it into the label, a "required"-class is added to the control-group. The label is then extended via css.

Credits to @rapkosi