### PR TITLE
[WIP] Add contact details to ics export

### DIFF
--- a/app/domain/export/ics/events.rb
+++ b/app/domain/export/ics/events.rb
@@ -21,13 +21,31 @@ module Export::Ics
       end
     end
 
+    def generate_additional_description_from_event(event)
+      con = event.contact
+      if con
+        con_phone_mail = "\n#{con.person_name}"
+        con.phone_numbers.each do |item|
+            con_phone_mail += "\n#{item.label}: #{item.number}" if item.public
+        end
+        con_phone_mail += "\n#{con.email}" if con.email?
+        # I did not get the following to work. By importing
+        # Rails.application.routes.url_helpers
+        # It would run the tests but failed in the development environment.
+        # It complained about missing default_url_options[:host] but I have
+        # not found a way to set it in a way the application would recognise it.
+        #con_phone_mail += event_url(id: event)
+        con_phone_mail
+      end
+    end
+
     def generate_ical_from_event_date(event_date, event)
       Icalendar::Event.new.tap do |ical_event|
         ical_event.dtstart = datetime_to_ical(event_date.start_at)
         ical_event.dtend = datetime_to_ical(event_date.finish_at)
         ical_event.summary = "#{event.name}: #{event_date.label}"
         ical_event.location = event_date.location || event.location
-        ical_event.description = event.description
+        ical_event.description = "#{event.description} \n#{generate_additional_description_from_event(event)}"
         ical_event.contact = event.contact && event.contact.to_s
       end
     end

--- a/spec/domain/export/ics/events_spec.rb
+++ b/spec/domain/export/ics/events_spec.rb
@@ -24,8 +24,16 @@ describe Export::Ics::Events do
 
     it 'does not fail if contact is set' do
       event.update(contact: people(:top_leader))
+
+      people(:top_leader).phone_numbers.create!(label: 'showme', number: 'Bar', public: true)
+      people(:top_leader).phone_numbers.create!(label: 'notme', number: 'Bar', public: false)
+
       is_expected.to all(be_a(Icalendar::Event))
       expect(subject.first.contact.first.value).to eq 'Top Leader'
+      expect(subject.first.description.value).to include "Top Leader"
+      expect(subject.first.description.value).to include "top_leader@example.com"
+      expect(subject.first.description.value).to include "showme"
+      expect(subject.first.description.value).not_to include "notme"
     end
   end
 


### PR DESCRIPTION
**This needs work**

First part of a better description for ics events.
Added information about the creator of the event and added his (public) phone numbers and his standard mail address.
The missing piece is an URL that points directly to the event. The problem here is that the routing component only works for relative url because the _default_url_options[:host]_ is not set. However, I was not able to set this setting. In the end, tests were succeeding but the development environment was not working.
Maybe someone more familiar with the application does know an easy fix, otherwise I will remove the URL and recreate the PR with the contact data only.