### PR TITLE
Allow I18n aware footer links

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -80,7 +80,7 @@
               = link_to image_tag(footer.logo_image), footer.logo_url, target: '_blank'
           .footer_content.span9
             %p
-              -footer.links.to_hash.each do |label, url|
+              - footer.links.to_hash.fetch(I18n.locale, footer.links.to_hash).each do |label, url|
                 = link_to label, url, target: '_blank'
                 %br/
             %p


### PR DESCRIPTION
This PR allows the links in the footer to be set per locale, while preserving the current behavior for unset locales.

settings.yml (before)
```yml
links:
      "Informationen und Hilfe": https://www.scout.ch/de/...
      "Aide et assistance": https://www.scout.ch/fr/...?set_language=fr
      "Aiuto e assistenza": https://www.scout.ch/it/...?set_language=it
```

settings.yml (after)
```yml
links:
    de:
          "Informationen und Hilfe": https://www.scout.ch/de/...
    fr:
          "Aide et assistance": https://www.scout.ch/fr/...?set_language=fr
    it:
          "Aiuto e assistenza": https://www.scout.ch/it/...?set_language=it
```