### PR TITLE
Do not assume multiple parallel requests in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2019, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -56,5 +56,8 @@ Hitobito::Application.configure do
   config.assets.debug = true
 
   config.middleware.use "Rack::RequestProfiler", printer: RubyProf::CallStackPrinter
+
+  # do not assume interleaved requests in development
+  config.log_tags = []
 
 end


### PR DESCRIPTION
For production and almost anywhere else, it might make sense to tag each
request so that they can be grouped. For development, where I manually
analyse one manual request at a time, I prefer to have less noise.

Also, the log now reads better on a small terminal-window.

Since I might overlook something important here, I put this in a pull-request
with the humble request for comments.