### PR TITLE
Fix label-export: Render only company's company_name

### DIFF
--- a/app/domain/export/pdf/labels.rb
+++ b/app/domain/export/pdf/labels.rb
@@ -95,7 +95,7 @@ module Export::Pdf
     end
 
     def print_company?(contactable)
-      contactable.respond_to?(:company) && contactable.company_name?
+      contactable.try(:company) && contactable.company_name?
     end
 
     def print_nickname?(contactable)

--- a/spec/domain/export/pdf/labels_spec.rb
+++ b/spec/domain/export/pdf/labels_spec.rb
@@ -30,4 +30,25 @@ describe Export::Pdf::Labels do
       expect(subject.strings.join(' ')).not_to include("Post CH AG")
     end
   end
+
+  context 'when company_name is given' do
+    let(:company_name) { 'Sample Inc.' }
+    let(:contactables) { [people(:top_leader).tap{ |u| u.update(company_name: company_name, company: company) }] }
+
+    context 'when marked as a company' do
+      let(:company) { true }
+
+      it 'renders company_name' do
+        expect(subject.strings).to include(company_name)
+      end
+    end
+
+    context 'when not marked as a company' do
+      let(:company) { false }
+
+      it 'does not render company_name' do
+        expect(subject.strings).not_to include(company_name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Label export showed company names even if address was not marked as a company. This is annoying because users often think, they have to fill the `company_name` with the company they currently work. 

If filled like that:

![2019-03-31 at 13 17](https://user-images.githubusercontent.com/1132797/55288672-1b171c80-53bb-11e9-8608-468b5bd21200.png)

**Idea:** A further improvement could be, to only display the `company_name` field, if `company` is marked.

**Before:**
![2019-03-31 at 13 19](https://user-images.githubusercontent.com/1132797/55288671-1a7e8600-53bb-11e9-8446-3fe883afd7d6.png)

**Now:**
![image](https://user-images.githubusercontent.com/1132797/55288686-67faf300-53bb-11e9-83f3-61321b427769.png)