### PR TITLE
Add better_errors to improve debugging/development experience

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ gem 'sprockets', '~> 3.7.2'
 
 
 group :development, :test do
+  gem 'better_errors'
   gem 'binding_of_caller'
   gem 'codez-tarantula', require: 'tarantula-rails3'
   gem 'parallel_tests'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,10 @@ GEM
     bcrypt (3.1.12)
     bcrypt-ruby (3.1.5)
       bcrypt (>= 3.1.3)
+    better_errors (2.5.1)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (2.3.2.2)
@@ -195,6 +199,7 @@ GEM
       activemodel (>= 3.0)
       activesupport (>= 3.0)
       request_store (~> 1.0)
+    erubi (1.8.0)
     erubis (2.7.0)
     eventmachine (1.0.9.1)
     execjs (2.7.0)
@@ -535,6 +540,7 @@ DEPENDENCIES
   awesome_print
   axlsx (>= 3.0.0.pre)
   bcrypt-ruby
+  better_errors
   binding_of_caller
   bootstrap-sass (~> 2.3)
   bootstrap-wysihtml5-rails (~> 0.3.1.24)


### PR DESCRIPTION
I am wondering if anything stands against using better_errors. Personally, I can see no downside, since I very much enjoy the increased visibility into the state in case of an error.