### PR TITLE
Mailchimp export: Fix difference calculation to avoid persistence of deleted members

### DIFF
--- a/app/domain/synchronize/mailchimp/synchronizator.rb
+++ b/app/domain/synchronize/mailchimp/synchronizator.rb
@@ -15,8 +15,10 @@ module Synchronize
         @mailing_list = mailing_list
         @gibbon = Gibbon::Request.new(api_key: mailing_list.mailchimp_api_key)
         @people_on_the_list = mailing_list.people
-        @people_on_the_mailchimp_list =
-          gibbon.lists(mailing_list.mailchimp_list_id).members.retrieve.body['members']
+        @people_on_the_mailchimp_list = gibbon.lists(mailing_list.mailchimp_list_id)
+                                              .members
+                                              .retrieve(params: { 'count' => '1000000' })
+                                              .body['members']
       end
 
       def call


### PR DESCRIPTION
The Mailchimp API is [paginated](https://developer.mailchimp.com/documentation/mailchimp/guides/get-started-with-mailchimp-api-3/#pagination). By default, it returns only the first 10 entries and there's no way to disable pagination altogether.

Previous versions of the Mailchimp integration didn't take this into account, causing the synchronization to fail deleting members on mailchimp, as only the first 10 members from mailchimp were compared to the hitobito members of a mailing list.

This PR is a «quick fix» that raises the pagination count (entries per page) to one million entries, which should suffice for most use cases, but the export will still fail if a mailing list exceeds this number. If this is not good / sustainable enough, I can reach out to our client in an effort to secure more time for an alternative approach (researching the upper limits of Mailchimp API calls and fetching the members in multiple batches).