### PR TITLE
Allow mailcatcher to be defined through ENV

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,10 @@ Hitobito::Application.configure do
     end
   else
     # mailcatcher
-    config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
+    config.action_mailer.smtp_settings = {
+      address: "#{ENV.fetch('MAILCATCHER_HOST', 'localhost')}",
+      port: Integer(ENV.fetch('MAILCATCHER_PORT', 1025))
+    }
   end
 
   # Print deprecation notices to the Rails logger


### PR DESCRIPTION
I've setup my local dev-environment using Docker, and my mailcatcher runs in a separate container.
That's why I need a way to overwrite the default configuration for mailcatcher.