### PR TITLE
Fix bulk tag delete modal and add tests

### DIFF
--- a/app/controllers/tag_lists_controller.rb
+++ b/app/controllers/tag_lists_controller.rb
@@ -10,12 +10,12 @@ class TagListsController < ListController
   respond_to :js, only: [:new, :deletable]
 
   def create
-    count = Tag::List.new(manageable_people, tags).add
+    count = tag_list.add
     redirect_to(group_people_path(group), notice: flash_message(:success, count: count))
   end
 
   def destroy
-    count = Tag::List.new(manageable_people, tags).remove
+    count = tag_list.remove
     redirect_to(group_people_path(group), notice: flash_message(:success, count: count))
   end
 
@@ -64,5 +64,9 @@ class TagListsController < ListController
     return [] if params[:tags].nil?
     return params[:tags].keys if params[:tags].is_a?(Hash)
     params[:tags].split(',').each(&:strip)
+  end
+
+  def tag_list
+    @tag_list ||= Tag::List.new(manageable_people, tags)
   end
 end

--- a/app/controllers/tag_lists_controller.rb
+++ b/app/controllers/tag_lists_controller.rb
@@ -24,7 +24,9 @@ class TagListsController < ListController
   end
 
   def deletable
-    @existing_tags = manageable_people.tags_on(:tags).collect { |tag| [tag, tag.taggings_count] }
+    @existing_tags = manageable_people.flat_map(&:tags)
+                                      .group_by { |tag| tag }
+                                      .map { |tag, occurrences| [tag, occurrences.count] }
   end
 
   private

--- a/app/controllers/tag_lists_controller.rb
+++ b/app/controllers/tag_lists_controller.rb
@@ -4,6 +4,7 @@ class TagListsController < ListController
   skip_authorization_check
   skip_authorize_resource
 
+  before_action :manageable_people_ids, only: [:new, :deletable]
   helper_method :group
 
   respond_to :js, only: [:new, :deletable]
@@ -19,13 +20,11 @@ class TagListsController < ListController
   end
 
   def new
-    @people_ids = manageable_people_ids
-    @people_count = @people_ids.count
+    @people_count = manageable_people.count
   end
 
   def deletable
-    @people_ids = manageable_people_ids
-    @existing_tags = people.tags_on(:tags).collect { |tag| [tag, tag.taggings_count] }
+    @existing_tags = manageable_people.tags_on(:tags).collect { |tag| [tag, tag.taggings_count] }
   end
 
   private
@@ -39,7 +38,7 @@ class TagListsController < ListController
   end
 
   def manageable_people_ids
-    manageable_people.map(&:id)
+    @people_ids ||= manageable_people.map(&:id)
   end
 
   def manageable_people

--- a/app/controllers/tag_lists_controller.rb
+++ b/app/controllers/tag_lists_controller.rb
@@ -48,7 +48,6 @@ class TagListsController < ListController
   end
 
   def people_ids
-    return [] if params[:ids].nil?
     params[:ids].to_s.split(',')
   end
 
@@ -57,9 +56,8 @@ class TagListsController < ListController
   end
 
   def tag_names
-    return [] if params[:tags].nil?
-    return params[:tags].keys if params[:tags].is_a?(Hash)
-    params[:tags].split(',').each(&:strip)
+    return params[:tags].each(&:strip) if params[:tags].is_a?(Array)
+    params[:tags].to_s.split(',').each(&:strip)
   end
 
   def tag_list

--- a/app/domain/tag/list.rb
+++ b/app/domain/tag/list.rb
@@ -13,13 +13,14 @@ module Tag
 
     def add
       new_tags = build_new_tags
+      count = 0
       ActiveRecord::Base.transaction do
-        new_tags[:hash].each do |person, tags|
+        new_tags.each do |person, tags|
           person.tag_list.add(tags)
-          new_tags[:count] -= tags.count unless person.save
+          count += tags.count if person.save
         end
       end
-      new_tags[:count]
+      count
     end
 
     def remove
@@ -32,10 +33,7 @@ module Tag
     private
 
     def build_new_tags
-      new_tags = @people.map do |person|
-        [person, @tags - person.tags]
-      end
-      { hash: new_tags.to_h, count: new_tags.sum { |e| e[1].count } }
+      @people.map { |person| [person, @tags - person.tags] }.to_h
     end
   end
 end

--- a/app/domain/tag/list.rb
+++ b/app/domain/tag/list.rb
@@ -13,9 +13,9 @@ module Tag
 
     def add
       ActiveRecord::Base.transaction do
-        @people.map do |person|
+        @people.sum do |person|
           add_to_person(person)
-        end.sum
+        end
       end
     end
 

--- a/app/domain/tag/list.rb
+++ b/app/domain/tag/list.rb
@@ -12,15 +12,11 @@ module Tag
     end
 
     def add
-      new_tags = build_new_tags
-      count = 0
       ActiveRecord::Base.transaction do
-        new_tags.each do |person, tags|
-          person.tag_list.add(tags)
-          count += tags.count if person.save
-        end
+        @people.map do |person|
+          add_to_person(person)
+        end.sum
       end
-      count
     end
 
     def remove
@@ -32,8 +28,10 @@ module Tag
 
     private
 
-    def build_new_tags
-      @people.map { |person| [person, @tags - person.tags] }.to_h
+    def add_to_person(person)
+      tags = @tags - person.tags
+      person.tag_list.add(tags)
+      person.save ? tags.count : 0
     end
   end
 end

--- a/app/domain/tag/list.rb
+++ b/app/domain/tag/list.rb
@@ -3,60 +3,39 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
-class Tag
+module Tag
   class List
 
-    attr_reader :ability, :params
-    delegate :can?, to: :ability
-
-    def initialize(ability, params)
-      @ability = ability
-      @params = params
+    def initialize(people, tags)
+      @people = people
+      @tags = tags
     end
 
-    def existing_tags_with_count
-      manageable_people.tags_on(:tags).collect do |tag|
-        [tag, tag.taggings_count]
+    def add
+      new_tags = build_new_tags
+      ActiveRecord::Base.transaction do
+        new_tags[:hash].each do |person, tags|
+          person.tag_list.add(tags)
+          new_tags[:count] -= tags.count unless person.save
+        end
       end
+      new_tags[:count]
     end
 
-    def build_new_tags
-      new_tags = manageable_people.map do |person|
-        [person, tags - person.tags]
-      end
-      { hash: new_tags.to_h, count: new_tags.sum { |e| e[1].count } }
-    end
-
-    def tag_ids
-      tags.map(&:id)
-    end
-
-    def manageable_people_ids
-      manageable_people.map(&:id)
+    def remove
+      tags = ActsAsTaggableOn::Tagging.where(taggable_type: Person.name,
+                                             taggable_id: @people.map(&:id),
+                                             tag_id: @tags.map(&:id))
+      tags.destroy_all.count
     end
 
     private
 
-    def tags
-      @tags ||= ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name(model_params)
-    end
-
-    def manageable_people
-      @manageable_people ||= people.select { |person| can?(:manage_tags, person) }
-    end
-
-    def people
-      @people ||= Person.includes(:tags).where(id: people_ids).uniq
-    end
-
-    def people_ids
-      params[:ids].to_s.split(',')
-    end
-
-    def model_params
-      return [] if params[:tags].nil?
-      return params[:tags].keys if params[:tags].is_a?(Hash)
-      params[:tags].split(',').each(&:strip)
+    def build_new_tags
+      new_tags = @people.map do |person|
+        [person, @tags - person.tags]
+      end
+      { hash: new_tags.to_h, count: new_tags.sum { |e| e[1].count } }
     end
   end
 end

--- a/app/helpers/tag_lists_helper.rb
+++ b/app/helpers/tag_lists_helper.rb
@@ -19,7 +19,7 @@ module TagListsHelper
 
   def tag_checkbox(tag, count)
     label_tag(nil, class: 'checkbox ') do
-      out = check_box_tag("tags[#{tag.name}]", nil, false)
+      out = check_box_tag("tags[]", tag.name, false)
       out << tag
       out << content_tag(:div, class: 'role-count') do
         count.to_s

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,9 +1,0 @@
-# encoding: utf-8
-
-#  Copyright (c) 2019, hitobito AG. This file is part of
-#  hitobito and licensed under the Affero General Public License version 3
-#  or later. See the COPYING file at the top-level directory or at
-#  https://github.com/hitobito/hitobito.
-
-class Tag < ActsAsTaggableOn::Tag
-end

--- a/app/views/tag_lists/_deletable.html.haml
+++ b/app/views/tag_lists/_deletable.html.haml
@@ -11,7 +11,7 @@
           .row-fluid
             = hidden_field_tag('ids', @people_ids.join(','))
             .checkboxes
-              - if not @existing_tags.empty?
+              - unless @existing_tags.empty?
                 = available_tags_checkboxes(@existing_tags)
               - else
                 = t('.no_entries')

--- a/app/views/tag_lists/_deletable.html.haml
+++ b/app/views/tag_lists/_deletable.html.haml
@@ -9,7 +9,7 @@
         url: group_tag_list_path(group), method: :delete) do |f|
         .modal-body
           .row-fluid
-            = hidden_field_tag('ids', @people_ids.join(','))
+            = hidden_field_tag('ids', @manageable_people.map(&:id).join(','))
             .checkboxes
               - unless @existing_tags.empty?
                 = available_tags_checkboxes(@existing_tags)

--- a/app/views/tag_lists/_new.html.haml
+++ b/app/views/tag_lists/_new.html.haml
@@ -10,19 +10,19 @@
         .modal-body
           .row-fluid
 
-            - unless @people_ids.empty?
-              = hidden_field_tag('ids', @people_ids.join(','))
+            - unless @people_count.zero?
+              = hidden_field_tag('ids', @manageable_people.map(&:id).join(','))
               = f.text_field(:tags,
                              name: :tags,
                              class: 'tag-list-add',
                              data: { provide: 'entity',
-                                     url: group_person_tags_query_path(group_id: group.id, person_id: @people_ids.first) })
+                                     url: group_person_tags_query_path(group_id: group.id, person_id: @manageable_people.first.id) })
               = f.help_inline t('.separate_multiple_tags_with_comma')
             - else
               = t('.no_entries')
 
         .modal-footer
-          = submit_button(f, t('.submit', count: @people_count)) unless @people_ids.empty?
+          = submit_button(f, t('.submit', count: @people_count)) unless @people_count.zero?
           = link_to(ti('button.cancel'), '#',
             class: 'link cancel',
             onclick: "event.preventDefault(); $('#tag-lists-new').modal('hide')")

--- a/app/views/tag_lists/_new.html.haml
+++ b/app/views/tag_lists/_new.html.haml
@@ -10,7 +10,7 @@
         .modal-body
           .row-fluid
 
-            - if not @people_ids.empty?
+            - unless @people_ids.empty?
               = hidden_field_tag('ids', @people_ids.join(','))
               = f.text_field(:tags,
                              name: :tags,
@@ -22,7 +22,7 @@
               = t('.no_entries')
 
         .modal-footer
-          = submit_button(f, t('.submit', count: @people_count)) if @people_ids.present?
+          = submit_button(f, t('.submit', count: @people_count)) unless @people_ids.empty?
           = link_to(ti('button.cancel'), '#',
             class: 'link cancel',
             onclick: "event.preventDefault(); $('#tag-lists-new').modal('hide')")

--- a/spec/controllers/tag_lists_controller_spec.rb
+++ b/spec/controllers/tag_lists_controller_spec.rb
@@ -8,8 +8,10 @@ require 'spec_helper'
 describe TagListsController do
 
   before { sign_in(people(:top_leader)) }
+  before { allow(controller).to receive(:tag_list).and_return(tag_list_double) }
 
-  let(:group)   { groups(:top_group) }
+  let(:tag_list_double) { double('tag_list') }
+  let(:group) { groups(:top_group) }
   let(:person1) { people(:top_leader) }
   let(:person2) { people(:bottom_member) }
 
@@ -20,20 +22,21 @@ describe TagListsController do
     end
 
     it 'refuses to add a tag to a person we cannot manage' do
+      expect(tag_list_double).to receive(:add).and_return(0)
       person = people(:top_leader)
-      post :create, group_id: group.id, ids: person.id, tags: 'Tagname'
-      expect(flash[:notice]).to include 'Es wurden keine Tags erstellt'
-      expect(person.reload.tags.count).to be 0
+      expect do
+        post :create, group_id: group.id, ids: person.id, tags: 'Tagname'
+      end.not_to(change { person.reload.tags })
     end
 
     it 'refuses to remove a tag from a person we cannot manage' do
+      expect(tag_list_double).to receive(:remove).and_return(0)
       person = people(:top_leader)
       person.tag_list.add('remove?')
       expect(person.save).to be_truthy
-      tags_before = person.tags
-      post :destroy, group_id: group.id, ids: people(:top_leader).id, tags: 'remove?'
-      expect(flash[:notice]).to include 'Es wurden keine Tags entfernt'
-      expect(person.reload.tags).to eq tags_before
+      expect do
+        post :destroy, group_id: group.id, ids: people(:top_leader).id, tags: 'remove?'
+      end.not_to(change { person.reload.tags })
     end
   end
 
@@ -47,50 +50,22 @@ describe TagListsController do
   end
 
   context 'POST create' do
-    it 'creates only one tag for one person' do
-      expect do
-        post :create, group_id: group, ids: person1.id, tags: 'new tag'
-      end.to change { Person.tags.count }.by(1)
-
+    it 'creates a tag and displays flash message' do
+      expect(tag_list_double).to receive(:add).and_return(1)
+      post :create, group_id: group, ids: person1.id, tags: 'new tag'
       expect(flash[:notice]).to include 'Ein Tag wurde erstellt'
     end
 
-    it 'does nothing if the tag already exists' do
-      person = people(:top_leader)
-      person.tag_list.add('existing')
-      person.save!
-      expect do
-        post :create, group_id: group, ids: person.id, tags: 'existing'
-      end.not_to(change { Person.tags.count })
-
+    it 'creates zero tags and displays flash message' do
+      expect(tag_list_double).to receive(:add).and_return(0)
+      post :create, group_id: group, ids: person1.id, tags: 'existing'
       expect(flash[:notice]).to include 'Es wurden keine Tags erstellt'
     end
 
-    it 'may create the same tag on multiple people' do
-      expect do
-        post :create, group_id: group, ids: [person1.id, person2.id].join(','), tags: 'same tag multiple people'
-      end.to change { Person.tags.count }.by(1)
-
-      expect(flash[:notice]).to include '2 Tags wurden erstellt'
-
-      expect(person1.tags.collect(&:name)).to include 'same tag multiple people'
-      expect(person2.tags.collect(&:name)).to include 'same tag multiple people'
-    end
-
-    it 'may create multiple tags for one person' do
-      expect do
-        post :create, group_id: group, ids: person1.id, tags: 'new tag 2, another, one more'
-      end.to change { Person.tags.count }.by(3)
-
-      expect(flash[:notice]).to include '3 Tags wurden erstellt'
-    end
-
-    it 'may create multiple tags on multiple people' do
-      expect do
-        post :create, group_id: group, ids: [person1.id, person2.id].join(','), tags: 't3, t4'
-      end.to change { Person.tags.count }.by(2)
-
-      expect(flash[:notice]).to include '4 Tags wurden erstellt'
+    it 'creates many tags and displays flash message' do
+      expect(tag_list_double).to receive(:add).and_return(17)
+      post :create, group_id: group, ids: person1.id, tags: 'new tag'
+      expect(flash[:notice]).to include '17 Tags wurden erstellt'
     end
   end
 
@@ -114,9 +89,9 @@ describe TagListsController do
       unrelated_person = people(:bottom_member)
       unrelated_person.tag_list.add('once', 'another')
       unrelated_person.save!
-      tag_test  = ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name('test')[0]
-      tag_once  = ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name('once')[0]
-      tag_twice = ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name('twice')[0]
+      tag_test  = ActsAsTaggableOn::Tag.find_or_create_with_like_by_name('test')
+      tag_once  = ActsAsTaggableOn::Tag.find_or_create_with_like_by_name('once')
+      tag_twice = ActsAsTaggableOn::Tag.find_or_create_with_like_by_name('twice')
       xhr :get, :deletable, group_id: group.id, ids: [person.id, another_person.id].join(','),
                             format: :js
       expect(response).to have_http_status(:ok)
@@ -129,57 +104,22 @@ describe TagListsController do
   end
 
   context 'DELETE destroy' do
-    it 'deletes only one tag from one person' do
-      person1.tag_list.add('remove me')
-      person1.save!
-      expect do
-        delete :destroy, group_id: group, ids: person1.id, tags: {'remove me' => 'on'}
-      end.to change { Person.tags.count }.by(-1)
-
+    it 'removes a tag and displays flash message' do
+      expect(tag_list_double).to receive(:remove).and_return(1)
+      post :destroy, group_id: group, ids: person1.id, tags: 'new tag'
       expect(flash[:notice]).to include 'Ein Tag wurde entfernt'
     end
 
-    it 'does nothing if the tag does not exist' do
-      expect do
-        delete :destroy, group_id: group, ids: person1.id, tags: 'existing'
-      end.to change { Person.tags.count }.by(0)
-
+    it 'removes zero tags and displays flash message' do
+      expect(tag_list_double).to receive(:remove).and_return(0)
+      post :destroy, group_id: group, ids: person1.id, tags: 'existing'
       expect(flash[:notice]).to include 'Es wurden keine Tags entfernt'
     end
 
-    it 'may delete the same tag from multiple people' do
-      tag_name = 'remove me too'
-      person1.tag_list.add(tag_name)
-      person1.save!
-      person2.tag_list.add(tag_name)
-      person2.save!
-      expect do
-        delete :destroy, group_id: group, ids: [person1.id, person2.id].join(','), tags: {tag_name => 'on'}
-      end.to change { Person.tags.count }.by(-1)
-
-      expect(flash[:notice]).to include '2 Tags wurden entfernt'
-    end
-
-    it 'may delete multiple tags from one person' do
-      person1.tag_list.add(['tag 1', 'tag 2', 'tag 3'])
-      person1.save!
-      expect do
-        delete :destroy, group_id: group, ids: person1.id, tags: {'tag 2' => 'on', 'tag 1' => 'on', 'tag 3' => 'on'}
-      end.to change { Person.tags.count }.by(-3)
-
-      expect(flash[:notice]).to include '3 Tags wurden entfernt'
-    end
-
-    it 'may delete multiple tags from multiple people' do
-      person1.tag_list.add(['t3', 't4'])
-      person1.save!
-      person2.tag_list.add(['t3', 't4'])
-      person2.save!
-      expect do
-        delete :destroy, group_id: group, ids: [person1.id, person2.id].join(','), tags: {t3: 'on', t4: 'on'}
-      end.to change { Person.tags.count }.by(-2)
-
-      expect(flash[:notice]).to include '4 Tags wurden entfernt'
+    it 'removes many tags and displays flash message' do
+      expect(tag_list_double).to receive(:remove).and_return(17)
+      post :destroy, group_id: group, ids: person1.id, tags: 'new tag'
+      expect(flash[:notice]).to include '17 Tags wurden entfernt'
     end
   end
 

--- a/spec/domain/tag/list_spec.rb
+++ b/spec/domain/tag/list_spec.rb
@@ -7,115 +7,114 @@ require 'spec_helper'
 
 describe Tag::List do
 
-  let(:person1) { people(:top_leader) }
-  let(:person2) { people(:bottom_member) }
+  let(:leader) { people(:top_leader) }
+  let(:bottom_member) { people(:bottom_member) }
   let(:tag1) { ActsAsTaggableOn::Tag.find_or_create_with_like_by_name('No mail') }
   let(:tag2) { ActsAsTaggableOn::Tag.find_or_create_with_like_by_name('Category: Value') }
 
   context 'add tags' do
     it 'creates only one tag for one person' do
-      tag_list = Tag::List.new([person1], [tag1])
+      tag_list = Tag::List.new([leader], [tag1])
       expect do
         expect(tag_list.add).to be 1
-      end.to change { person1.tags.count }.by(1)
+      end.to change { leader.tags.count }.by(1)
     end
 
     it 'does nothing if the tag already exists' do
-      person = people(:top_leader)
-      person.tag_list.add(tag1)
-      person.save!
-      tag_list = Tag::List.new([person], [tag1])
+      leader.tag_list.add(tag1)
+      leader.save!
+      tag_list = Tag::List.new([leader], [tag1])
       expect do
         expect(tag_list.add).to be 0
-      end.not_to(change { person1.reload.tags })
+      end.not_to(change { leader.reload.tags })
     end
 
     it 'may create the same tag on multiple people' do
-      tag_list = Tag::List.new([person1, person2], [tag1])
+      tag_list = Tag::List.new([leader, bottom_member], [tag1])
       expect do
         expect(tag_list.add).to be 2
-      end.to change { person1.tags.count }.by(1).and change { person2.tags.count }.by(1)
+      end.to change { leader.tags.count }.by(1).and change { bottom_member.tags.count }.by(1)
 
-      expect(person1.reload.tags.collect(&:name)).to include tag1.name
-      expect(person2.reload.tags.collect(&:name)).to include tag1.name
+      expect(leader.reload.tags.collect(&:name)).to include tag1.name
+      expect(bottom_member.reload.tags.collect(&:name)).to include tag1.name
     end
 
     it 'may create multiple tags for one person' do
-      tag_list = Tag::List.new([person1], [tag1, tag2])
+      tag_list = Tag::List.new([leader], [tag1, tag2])
       expect do
         expect(tag_list.add).to be 2
-      end.to change { person1.tags.count }.by(2)
+      end.to change { leader.tags.count }.by(2)
 
-      expect(person1.reload.tags.collect(&:name)).to include tag1.name, tag2.name
+      expect(leader.reload.tags.collect(&:name)).to include tag1.name, tag2.name
     end
 
     it 'may create multiple tags on multiple people' do
-      person2.tag_list.add(tag2)
-      person2.save!
-      tag_list = Tag::List.new([person1, person2], [tag1, tag2])
+      bottom_member.tag_list.add(tag2)
+      bottom_member.save!
+      tag_list = Tag::List.new([leader, bottom_member], [tag1, tag2])
       expect do
         expect(tag_list.add).to be 3
-      end.to change { person1.tags.count }.by(2).and change { person2.tags.count }.by(1)
+      end.to change { leader.tags.count }.by(2).and change { bottom_member.tags.count }.by(1)
 
-      expect(person1.reload.tags.collect(&:name)).to include tag1.name, tag2.name
-      expect(person2.reload.tags.collect(&:name)).to include tag1.name, tag2.name
+      expect(leader.reload.tags.collect(&:name)).to include tag1.name, tag2.name
+      expect(bottom_member.reload.tags.collect(&:name)).to include tag1.name, tag2.name
     end
   end
 
   context 'remove tags' do
     it 'deletes only one tag from one person' do
-      person1.tag_list.add(tag1)
-      person1.save!
-      tag_list = Tag::List.new([person1], [tag1])
+      leader.tag_list.add(tag1)
+      leader.save!
+      tag_list = Tag::List.new([leader], [tag1])
       expect do
         expect(tag_list.remove).to be 1
-      end.to change { person1.tags.count }.by(-1)
+      end.to change { leader.tags.count }.by(-1)
     end
 
     it 'does nothing if the tag does not exist on the person' do
-      tag_list = Tag::List.new([person1], [tag1])
+      tag_list = Tag::List.new([leader], [tag1])
       expect do
         expect(tag_list.remove).to be 0
-      end.not_to(change { person1.reload.tags })
+      end.not_to(change { leader.reload.tags })
     end
 
     it 'may delete the same tag from multiple people' do
-      person1.tag_list.add(tag1)
-      person1.save!
-      person2.tag_list.add(tag1)
-      person2.save!
-      tag_list = Tag::List.new([person1, person2], [tag1])
+      leader.tag_list.add(tag1)
+      leader.save!
+      bottom_member.tag_list.add(tag1)
+      bottom_member.save!
+      tag_list = Tag::List.new([leader, bottom_member], [tag1])
       expect do
         expect(tag_list.remove).to be 2
-      end.to change { person1.tags.count }.by(-1).and change { person2.tags.count }.by(-1)
+      end.to change { leader.tags.count }.by(-1).and change { bottom_member.tags.count }.by(-1)
 
-      expect(person1.reload.tags.collect(&:name)).not_to include tag1.name
-      expect(person2.reload.tags.collect(&:name)).not_to include tag1.name
+      expect(leader.reload.tags.collect(&:name)).not_to include tag1.name
+      expect(bottom_member.reload.tags.collect(&:name)).not_to include tag1.name
     end
 
     it 'may delete multiple tags from one person' do
-      person1.tag_list.add(tag1, tag2)
-      person1.save!
-      tag_list = Tag::List.new([person1], [tag1, tag2])
+      leader.tag_list.add(tag1, tag2)
+      leader.save!
+      tag_list = Tag::List.new([leader], [tag1, tag2])
       expect do
         expect(tag_list.remove).to be 2
-      end.to change { person1.tags.count }.by(-2)
+      end.to change { leader.tags.count }.by(-2)
 
-      expect(person1.reload.tags.collect(&:name)).not_to include tag1.name, tag2.name
+      expect(leader.reload.tags.collect(&:name)).not_to include tag1.name, tag2.name
     end
 
     it 'may delete multiple tags from multiple people' do
-      person1.tag_list.add(tag1, tag2)
-      person1.save!
-      person2.tag_list.add(tag1)
-      person2.save!
-      tag_list = Tag::List.new([person1, person2], [tag1, tag2])
+      leader.tag_list.add(tag1, tag2)
+      leader.save!
+      bottom_member.tag_list.add(tag1)
+      bottom_member.save!
+      tag_list = Tag::List.new([leader, bottom_member], [tag1, tag2])
       expect do
         expect(tag_list.remove).to be 3
-      end.to change { person1.tags.count }.by(-2).and change { person2.tags.count }.by(-1)
+      end.to change { leader.tags.count }.by(-2).and change { bottom_member.tags.count }.by(-1)
 
-      expect(person1.reload.tags.collect(&:name)).not_to include tag1.name, tag2.name
-      expect(person2.reload.tags.collect(&:name)).not_to include tag1.name, tag2.name
+      expect(leader.reload.tags.collect(&:name)).not_to include tag1.name, tag2.name
+      expect(bottom_member.reload.tags.collect(&:name)).not_to include tag1.name, tag2.name
     end
   end
 

--- a/spec/domain/tag/list_spec.rb
+++ b/spec/domain/tag/list_spec.rb
@@ -1,0 +1,122 @@
+#  Copyright (c) 2012-2018, Schweizer Blasmusikverband. This file is part of
+#  hitobito_sbv and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+describe Tag::List do
+
+  let(:person1) { people(:top_leader) }
+  let(:person2) { people(:bottom_member) }
+  let(:tag1) { ActsAsTaggableOn::Tag.find_or_create_with_like_by_name('No mail') }
+  let(:tag2) { ActsAsTaggableOn::Tag.find_or_create_with_like_by_name('Category: Value') }
+
+  context 'add tags' do
+    it 'creates only one tag for one person' do
+      tag_list = Tag::List.new([person1], [tag1])
+      expect do
+        expect(tag_list.add).to be 1
+      end.to change { person1.tags.count }.by(1)
+    end
+
+    it 'does nothing if the tag already exists' do
+      person = people(:top_leader)
+      person.tag_list.add(tag1)
+      person.save!
+      tag_list = Tag::List.new([person], [tag1])
+      expect do
+        expect(tag_list.add).to be 0
+      end.not_to(change { person1.reload.tags })
+    end
+
+    it 'may create the same tag on multiple people' do
+      tag_list = Tag::List.new([person1, person2], [tag1])
+      expect do
+        expect(tag_list.add).to be 2
+      end.to change { person1.tags.count }.by(1).and change { person2.tags.count }.by(1)
+
+      expect(person1.reload.tags.collect(&:name)).to include tag1.name
+      expect(person2.reload.tags.collect(&:name)).to include tag1.name
+    end
+
+    it 'may create multiple tags for one person' do
+      tag_list = Tag::List.new([person1], [tag1, tag2])
+      expect do
+        expect(tag_list.add).to be 2
+      end.to change { person1.tags.count }.by(2)
+
+      expect(person1.reload.tags.collect(&:name)).to include tag1.name, tag2.name
+    end
+
+    it 'may create multiple tags on multiple people' do
+      person2.tag_list.add(tag2)
+      person2.save!
+      tag_list = Tag::List.new([person1, person2], [tag1, tag2])
+      expect do
+        expect(tag_list.add).to be 3
+      end.to change { person1.tags.count }.by(2).and change { person2.tags.count }.by(1)
+
+      expect(person1.reload.tags.collect(&:name)).to include tag1.name, tag2.name
+      expect(person2.reload.tags.collect(&:name)).to include tag1.name, tag2.name
+    end
+  end
+
+  context 'remove tags' do
+    it 'deletes only one tag from one person' do
+      person1.tag_list.add(tag1)
+      person1.save!
+      tag_list = Tag::List.new([person1], [tag1])
+      expect do
+        expect(tag_list.remove).to be 1
+      end.to change { person1.tags.count }.by(-1)
+    end
+
+    it 'does nothing if the tag does not exist on the person' do
+      tag_list = Tag::List.new([person1], [tag1])
+      expect do
+        expect(tag_list.remove).to be 0
+      end.not_to(change { person1.reload.tags })
+    end
+
+    it 'may delete the same tag from multiple people' do
+      person1.tag_list.add(tag1)
+      person1.save!
+      person2.tag_list.add(tag1)
+      person2.save!
+      tag_list = Tag::List.new([person1, person2], [tag1])
+      expect do
+        expect(tag_list.remove).to be 2
+      end.to change { person1.tags.count }.by(-1).and change { person2.tags.count }.by(-1)
+
+      expect(person1.reload.tags.collect(&:name)).not_to include tag1.name
+      expect(person2.reload.tags.collect(&:name)).not_to include tag1.name
+    end
+
+    it 'may delete multiple tags from one person' do
+      person1.tag_list.add(tag1, tag2)
+      person1.save!
+      tag_list = Tag::List.new([person1], [tag1, tag2])
+      expect do
+        expect(tag_list.remove).to be 2
+      end.to change { person1.tags.count }.by(-2)
+
+      expect(person1.reload.tags.collect(&:name)).not_to include tag1.name, tag2.name
+    end
+
+    it 'may delete multiple tags from multiple people' do
+      person1.tag_list.add(tag1, tag2)
+      person1.save!
+      person2.tag_list.add(tag1)
+      person2.save!
+      tag_list = Tag::List.new([person1, person2], [tag1, tag2])
+      expect do
+        expect(tag_list.remove).to be 3
+      end.to change { person1.tags.count }.by(-2).and change { person2.tags.count }.by(-1)
+
+      expect(person1.reload.tags.collect(&:name)).not_to include tag1.name, tag2.name
+      expect(person2.reload.tags.collect(&:name)).not_to include tag1.name, tag2.name
+    end
+  end
+
+end


### PR DESCRIPTION
Refs #342
Reverts 2ee8ad3cddfbebbb461571e9af2ffb996313a855 because the business logic was wrong and it broke bulk tag deletion.
Also adds tests for the modals so that doesn't happen again