### PR TITLE
Implement convenience method `GroupDecorator#modifiable?`

### DIFF
--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -64,6 +64,10 @@ class GroupDecorator < ApplicationDecorator
     attributes
   end
 
+  def modifiable?(attribute)
+    modifiable_attributes(attribute).each { |_| yield }
+  end
+
   def type_name
     klass.label
   end

--- a/spec/decorators/group_decorator_spec.rb
+++ b/spec/decorators/group_decorator_spec.rb
@@ -52,6 +52,17 @@ describe GroupDecorator, :draper_with_helpers do
       expect(context).to receive(:can?).with(:modify_superior, subject).and_return(false)
       expect(subject.modifiable_attributes(:foo, :bar)).to eq %w(bar)
     end
+
+    it '#modifiable? we can :modify_superior' do
+      expect(context).to receive(:can?).with(:modify_superior, subject).and_return(true)
+      expect(subject.modifiable?(:foo) { |val| val }).to eq %w(foo)
+    end
+
+    it '#modifiable? filters attributes if we cannot :modify_superior' do
+      allow(model.class).to receive_messages(superior_attributes: [:foo])
+      expect(context).to receive(:can?).with(:modify_superior, subject).and_return(false)
+      expect(subject.modifiable_attributes(:foo) { |val| val }).to eq %w()
+    end
   end
 
 end


### PR DESCRIPTION
Similar to `ApplicationDecorator#used?`, this is a convenience method that can be used on single attributes:
```ruby
# The following code...
entry.used_attributes(:name).each do |_|
  # do something now we know :name is a used attribute in entry
end

# ... can be shortened to this:
entry.used?(:name) do
  # do something now we know :name is a used attribute in entry
end


# Similarly, we have a method GroupDecorator#modifiable_attributes...
group.modifiable_attributes(:name).each do |_|
  # do something now we know :name is modifiable in group
end

# ...that can, if this PR is merged, be shortened to
group.modifiable?(:name) do
  # do something now we know :name is modifiable in group
end
```

This is motivated by a work in progress solving #585 