### PR TITLE
Efficient screenspace-use on mobile

### DIFF
--- a/app/assets/stylesheets/hitobito/_layout.scss
+++ b/app/assets/stylesheets/hitobito/_layout.scss
@@ -55,9 +55,9 @@ body {
 
 /* Content */
 #page {
-  padding: 20px 1rem 90px;
+  padding: 3px 0 60px;
   @include responsive(mediaTablet){
-    padding: 3px 0 60px;
+    padding: 20px 1rem 90px;
   }
   margin: 0;
   width: 100%;

--- a/app/assets/stylesheets/hitobito/_layout.scss
+++ b/app/assets/stylesheets/hitobito/_layout.scss
@@ -155,9 +155,9 @@ body {
   background: lighten($contentBackground, 3%);
   @include single-box-shadow($shadowColor, 0, 2px, 8px);
   .sheet {
-    margin: 0 -10px -30px 10px;
-    @include responsive(mediaTablet){
     margin: 0 3px 3px;
+    @include responsive(mediaTablet){
+      margin: 0 -10px -30px 10px;
     }
     &.parent {
       background: lighten($contentBackground, 6%);

--- a/app/assets/stylesheets/hitobito/_layout.scss
+++ b/app/assets/stylesheets/hitobito/_layout.scss
@@ -108,9 +108,9 @@ body {
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: 5px;
   @include responsive(mediaTablet){
-    margin-bottom: 5px;
+    margin-bottom: 1rem;
   }
 
   .toggle-nav {

--- a/app/assets/stylesheets/hitobito/_layout.scss
+++ b/app/assets/stylesheets/hitobito/_layout.scss
@@ -56,6 +56,9 @@ body {
 /* Content */
 #page {
   padding: 20px 1rem 90px;
+  @include responsive(mediaTablet){
+    padding: 3px 0 60px;
+  }
   margin: 0;
   width: 100%;
   background: $pageBackground;
@@ -86,8 +89,14 @@ body {
     max-width: 100%;
     overflow-x: visible;
     overflow-y: visible;
-    padding-bottom: 60px; // needs these paddings to accomodate further sheets
-    padding-right: 20px;  // needs these paddings to accomodate further sheets
+    padding-bottom: 0px;
+    padding-right: 5px;
+    padding-left: 5px;
+    @include responsive(mediaTablet){
+      padding-bottom: 60px; // needs these paddings to accomodate further sheets
+      padding-right: 20px;  // needs these paddings to accomodate further sheets
+      padding-left: 15px;
+    }
   }
 
   .is-logged-out & {
@@ -100,6 +109,9 @@ body {
   flex-direction: row;
   align-items: center;
   margin-bottom: 1rem;
+  @include responsive(mediaTablet){
+    margin-bottom: 5px;
+  }
 
   .toggle-nav {
     margin: -0.5rem 1rem -0.5rem 0rem;
@@ -144,6 +156,9 @@ body {
   @include single-box-shadow($shadowColor, 0, 2px, 8px);
   .sheet {
     margin: 0 -10px -30px 10px;
+    @include responsive(mediaTablet){
+    margin: 0 3px 3px;
+    }
     &.parent {
       background: lighten($contentBackground, 6%);
     }
@@ -154,7 +169,10 @@ body {
 #content {
   @include single-box-shadow($shadowColor, 0, 2px, 8px);
   background: white;
-  padding: 16px 20px 20px;
+  padding: 10px 10px 20px;
+  @include responsive(mediaTablet){
+    padding: 16px 20px 20px;
+  }
 
   aside {
     @include responsive(phone, $mediaDesktop) {

--- a/app/assets/stylesheets/hitobito/_navigation.scss
+++ b/app/assets/stylesheets/hitobito/_navigation.scss
@@ -63,8 +63,12 @@
 // Breadcrumb
 .breadcrumb {
   float: right;
-  margin: 15px 0 0;
-  padding: 5px 15px;
+  margin: 5px 0 0;
+  padding: 5px 10px;
+  @include responsive(mediaTablet) {
+    margin: 15px 0 0;
+    padding: 5px 15px;
+  }
   list-style: none;
   background: none;
   border: none;

--- a/app/assets/stylesheets/hitobito/_typography.scss
+++ b/app/assets/stylesheets/hitobito/_typography.scss
@@ -35,7 +35,10 @@ h5, .h5 {
 }
 
 .content-header {
+  margin-bottom: 0px;
+  @include responsive(mediaTablet){
   margin-bottom: $vSpace;
+  }
   h1 { margin-bottom: 0px; }
 }
 


### PR DESCRIPTION
<table><tr><td>Before<br><img width="300" alt="before" src="https://user-images.githubusercontent.com/3001985/64474076-75d55100-d16f-11e9-932b-ca21dadbb272.png"></td><td>After<br><img width="300" alt="after" src="https://user-images.githubusercontent.com/3001985/64474075-75d55100-d16f-11e9-8f7a-e5ec4691f2e4.png"></tr></table>

It only changes the mobile styles
