### PR TITLE
Make first column of people view have flexible with.

### DIFF
--- a/app/views/people/_attrs.html.haml
+++ b/app/views/people/_attrs.html.haml
@@ -4,7 +4,7 @@
 -#  https://github.com/hitobito/hitobito.
 
 #main.row
-  %article.col-lg-6
+  %article.col-lg
     = render 'contact_data', person: entry, only_public: cannot?(:show_details, entry)
     - if can?(:show_details, entry)
       %h2= t('.additional_data')


### PR DESCRIPTION
Unfortunately Safari rendering engine rounds differently than others, so the second column of the people view always got wrapped on to a new line. By making the first on grow to use available space, the problem won't occur anymore.

Tested in current versions of Safari, Firefox, Chrome, Opera, IE 11 on macOS, Windows and Linux.