### PR TITLE
Change icon for accepting request

### DIFF
--- a/app/views/people/_add_requests.html.haml
+++ b/app/views/people/_add_requests.html.haml
@@ -7,7 +7,7 @@
   = section_table(Person::AddRequest.model_name.human(count: 2), @add_requests) do |request|
     %td
       - if can?(:approve, request)
-        = link_to(icon(:ok),
+        = link_to(icon(:check),
                   person_add_request_path(request),
                   method: :post,
                   title: t('people.add_requests.approve_title'))


### PR DESCRIPTION
Change the icon for accepting an request because the current icon does not exist. Makes the function working again.

Current state:
![image](https://user-images.githubusercontent.com/37982272/65379542-052f4800-dcca-11e9-89ad-8147d2dbeb81.png)

After PR:
![image](https://user-images.githubusercontent.com/37982272/65379533-e16c0200-dcc9-11e9-84a4-e4a49ce149f6.png)
