### PR TITLE
Fix quicksearch field appearance on iOS Safari.

### DIFF
--- a/app/assets/stylesheets/hitobito/_layout.scss
+++ b/app/assets/stylesheets/hitobito/_layout.scss
@@ -218,6 +218,7 @@ body {
   flex-wrap: nowrap;
   .quicksearch-input {
     flex: 1 0 auto;
+    -webkit-appearance: none;
   }
 }
 


### PR DESCRIPTION
By default, iOS Safari renders `<input type="search">` specially (with big rounded corners). This breaks the design:
![IMG_C1525DC47655-1](https://user-images.githubusercontent.com/1735317/65385065-49eacb80-dd2a-11e9-92d7-7c9339cebd86.jpeg)

This sets the default appearance to none:
![IMG_9C0230A12404-1](https://user-images.githubusercontent.com/1735317/65385092-84ecff00-dd2a-11e9-9754-362497dc541e.jpeg)
