### PR TITLE
Make it possible to use better_errors in dockerized setups

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,7 @@ Hitobito::Application.configure do
   # do not assume interleaved requests in development
   config.log_tags = []
 
+  # Allow using better_errors in Docker
+  BetterErrors::Middleware.allow_ip! ENV['DOCKER_HOST_IP'] if ENV['DOCKER_HOST_IP'].present?
+
 end


### PR DESCRIPTION
better_errors only engages in requests from whitelisted IPs. By default only localhost is whitelisted. However, in dockerized setups, the requests come from a different host. This change enables docker setups to set an environment variable to specify the IP of the docker host.