### PR TITLE
"Add Another" Button

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -206,7 +206,7 @@ class RolesController < CrudController
     return return_path if return_path.present?
     return new_group_role_path(entry.group_id) if params.key?(:add_another)
     return edit_group_person_path(entry.group_id, entry.person_id) if new_person &&
-      entry.person&.persisted?
+      entry.person.try(:persisted?)
 
     group_people_path(entry.group_id)
   end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -203,12 +203,12 @@ class RolesController < CrudController
   end
 
   def after_create_location(new_person)
-    return_path ||
-      if new_person && entry.person && entry.person.persisted?
-        group_person_path(entry.group_id, entry.person_id)
-      else
-        group_people_path(entry.group_id)
-      end
+    return return_path if return_path.present?
+    return new_group_role_path(entry.group_id) if params.key?(:add_another)
+    return edit_group_person_path(entry.group_id, entry.person_id) if new_person &&
+      entry.person&.persisted?
+
+    group_people_path(entry.group_id)
   end
 
   def after_update_location

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -54,7 +54,9 @@ module FormHelper
                    form.labeled_input_fields(*attrs)
                  end
 
-      content << form_buttons(form, form_button_options.merge(toolbar_class: 'bottom')) if buttons_bottom
+      if buttons_bottom
+        content << form_buttons(form, form_button_options.merge(toolbar_class: 'bottom'))
+      end
 
       content.html_safe
     end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -81,12 +81,8 @@ module FormHelper
 
   def add_another_button(form, label, options = {})
     content_tag(:div, class: 'btn-group') do
-      form.button(:add_another, options.merge(name: :add_another,
-                                              class: 'btn btn-primary',
-                                              data: { disable_with: label })
-                                             ) do
-        label
-      end
+      form.button(label, options.merge(name: :add_another, class: 'btn btn-primary',
+                                       data: { disable: true }))
     end
   end
 

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -63,7 +63,7 @@ module FormHelper
   end
 
   def button_toolbar(form, toolbar_class:, &block)
-    content_tag(:div, toolbar_class: "btn-toolbar #{toolbar_class}") do
+    content_tag(:div, class: "btn-toolbar #{toolbar_class}") do
       capture(form, &block)
     end
   end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -75,7 +75,7 @@ module FormHelper
       content << add_another_button(form, add_another_label) if add_another.present?
       content << cancel_link(cancel_url) if cancel_url.present?
 
-      content.html_safe
+      content
     end
   end
 

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -40,13 +40,13 @@ module FormHelper
 
     buttons_bottom = options.delete(:buttons_bottom)
     buttons_top = options.delete(:buttons_top) { true }
-    submit_label = options.delete(:submit_label)
-    cancel_url = get_cancel_url(object, options)
+    form_button_options = options.slice(:add_another_label, :add_another, :submit_label)
+                                 .merge(cancel_url: get_cancel_url(object, options))
 
     standard_form(object, options) do |form|
       content = form.error_messages
 
-      content << save_form_buttons(form, submit_label, cancel_url, 'top') if buttons_top
+      content << form_buttons(form, form_button_options.merge(toolbar_class: 'top')) if buttons_top
 
       content << if block_given?
                    capture(form, &block)
@@ -54,17 +54,37 @@ module FormHelper
                    form.labeled_input_fields(*attrs)
                  end
 
-      content << save_form_buttons(form, submit_label, cancel_url, 'bottom') if buttons_bottom
+      content << form_buttons(form, form_button_options.merge(toolbar_class: 'bottom')) if buttons_bottom
 
       content.html_safe
     end
   end
 
-  def save_form_buttons(form, submit_label, cancel_url, toolbar_class = nil)
-    submit_label ||= ti(:"button.save")
-    content_tag(:div, class: "btn-toolbar #{toolbar_class}") do
-      submit_button(form, submit_label) +
-      cancel_link(cancel_url)
+  def button_toolbar(form, toolbar_class:, &block)
+    content_tag(:div, toolbar_class: "btn-toolbar #{toolbar_class}") do
+      capture(form, &block)
+    end
+  end
+
+  def form_buttons(form, submit_label: ti(:"button.save"), cancel_url: nil, toolbar_class: nil,
+                          add_another: false, add_another_label: ti(:"button.add_another"))
+    button_toolbar(form, toolbar_class: toolbar_class) do
+      content = submit_button(form, submit_label)
+      content << add_another_button(form, add_another_label) if add_another.present?
+      content << cancel_link(cancel_url)
+
+      content.html_safe
+    end
+  end
+
+  def add_another_button(form, label, options = {})
+    content_tag(:div, class: 'btn-group') do
+      form.button(:add_another, options.merge(name: :add_another,
+                                              class: 'btn btn-primary',
+                                              data: { disable_with: label })
+                                             ) do
+        label
+      end
     end
   end
 

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -73,7 +73,7 @@ module FormHelper
     button_toolbar(form, toolbar_class: toolbar_class) do
       content = submit_button(form, submit_label)
       content << add_another_button(form, add_another_label) if add_another.present?
-      content << cancel_link(cancel_url)
+      content << cancel_link(cancel_url) if cancel_url.present?
 
       content.html_safe
     end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -11,4 +11,4 @@
     = f.labeled(:current_password, t('.old_password')) { f.input_field(:current_password) }
   = f.labeled(:password, t('.new_password')) { f.input_field(:password) }
   = f.labeled(:password_confirmation, t('.new_password_confirmation')) { f.input_field(:password_confirmation) }
-  = save_form_buttons(f, title, person_path(resource))
+  = form_buttons(f, submit_label: title, cancel_url: person_path(resource))

--- a/app/views/event/application_market/_popover_waiting_list.html.haml
+++ b/app/views/event/application_market/_popover_waiting_list.html.haml
@@ -12,4 +12,4 @@
                 remote: true,
                 stacked: true) do |f|
   = f.labeled_input_field(:waiting_list_comment, class: 'span12')
-  = save_form_buttons(f, nil, '#')
+  = form_buttons(f, submit_label: nil, cancel_url: '#')

--- a/app/views/group/merge/select.html.haml
+++ b/app/views/group/merge/select.html.haml
@@ -21,4 +21,4 @@
     - @candidates.each do |group|
       = f.inline_radio_button(:merge_group_id, group.id, group.to_s, false)
 
-  = save_form_buttons(f, t('.merge_button'), group_path(@group))
+  = form_buttons(f, submit_label: t('.merge_button'), cancel_url: group_path(@group))

--- a/app/views/group/move/select.html.haml
+++ b/app/views/group/move/select.html.haml
@@ -13,4 +13,4 @@
       - values.each do |candidate|
         = f.inline_radio_button(:target_group_id, candidate.id, candidate.to_s, false)
 
-  = save_form_buttons(f, t('.title'), group_path(@group))
+  = form_buttons(f, submit_label: t('.title'), cancel_url: group_path(@group))

--- a/app/views/invoice_configs/_form.html.haml
+++ b/app/views/invoice_configs/_form.html.haml
@@ -14,4 +14,4 @@
     #reminders.tab-pane
       = f.fields_for(:payment_reminder_configs) do |ff|
         = render 'reminder_fields', f: ff
-  = save_form_buttons(f, nil, group_invoice_config_path(parent))
+  = form_buttons(f, submit_label: nil, cancel_url: group_invoice_config_path(parent))

--- a/app/views/invoices/_payment_form.html.haml
+++ b/app/views/invoices/_payment_form.html.haml
@@ -3,5 +3,5 @@
   = standard_form(@payment, url: group_invoice_payments_path(parent, entry)) do |f|
     = f.error_messages
     = f.labeled_input_fields :amount, :received_at
-    = save_form_buttons(f, nil, cancel_url: group_invoice_path(parent, entry))
+    = form_buttons(f, submit_label: nil, cancel_url: group_invoice_path(parent, cancel_url: entry))
 

--- a/app/views/invoices/_payment_reminder_form.html.haml
+++ b/app/views/invoices/_payment_reminder_form.html.haml
@@ -6,4 +6,4 @@
     = f.error_messages
     = f.labeled_input_field :due_at unless entry.new_record?
     = f.labeled_input_field :message
-    = save_form_buttons(f, nil, cancel_url: entry.persisted? ? group_invoice_path(parent, entry) : group_invoices_path(parent))
+    = form_buttons(f, submit_label: nil, cancel_url: entry.persisted? ? group_invoice_path(parent, cancel_url: entry) : group_invoices_path(parent))

--- a/app/views/notes/_section.html.haml
+++ b/app/views/notes/_section.html.haml
@@ -21,7 +21,7 @@
 
     = form_for(Note.new, url: create_path, remote: true) do |f|
       = f.text_area(:text, rows: 5, class: 'input-block-level')
-      = save_form_buttons(f, nil, '')
+      = form_buttons(f)
 
   = render 'notes/list',
            notes: entry.notes.includes(:author, :subject).list.page(params[:notes_page]).per(10),

--- a/app/views/payment_processes/new.html.haml
+++ b/app/views/payment_processes/new.html.haml
@@ -6,7 +6,7 @@
 #main.row-fluid
   .span5
     = standard_form(:payment_process, url: group_payment_process_path(group), builder: PlainObjectFormBuilder) do |f|
-      = save_form_buttons(f, t('.upload_button'), group_invoices_path(group))
+      = form_buttons(f, submit_label: t('.upload_button'), cancel_url: group_invoices_path(group))
       = f.labeled(:file, t('.xml_file')) do
         = f.file_field(:file)
   .span7

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -7,9 +7,9 @@
   - if entry.new_record?
     = hidden_field_tag('role[group_id]', params[:role][:group_id])
     = hidden_field_tag('role[type]', params[:role][:type])
-  
+
   = render 'fields', f: f
-  
+
   = render 'picture_fields', f: f
 
   = hidden_field_tag('return_url', params[:return_url])

--- a/app/views/person/csv_imports/define_mapping.html.haml
+++ b/app/views/person/csv_imports/define_mapping.html.haml
@@ -45,4 +45,4 @@
                               { include_blank: true, selected: guess(column_name) },
                               { class: 'span4' })
 
-  = save_form_buttons(f, t('.preview'), group_people_path(group))
+  = form_buttons(f, submit_label: t('.preview'), cancel_url: group_people_path(group))

--- a/app/views/person/csv_imports/new.html.haml
+++ b/app/views/person/csv_imports/new.html.haml
@@ -6,7 +6,7 @@
 #main.row-fluid
   .span5
     = standard_form(:csv_import, url: define_mapping_group_csv_imports_path, builder: PlainObjectFormBuilder) do |f|
-      = save_form_buttons(f, t('.upload_button'), group_people_path(group))
+      = form_buttons(f, submit_label: t('.upload_button'), cancel_url: group_people_path(group))
       = f.labeled(:file, t('.csv_file')) do
         = f.file_field(:file)
 

--- a/app/views/roles/_form.html.haml
+++ b/app/views/roles/_form.html.haml
@@ -5,7 +5,8 @@
 
 #main.row-fluid
   .span7
-    = entry_form(cancel_url: role_cancel_url, add_another: true, add_another_url: new_group_role_path(entry.group)) do |f|
+    = entry_form(cancel_url: role_cancel_url, add_another: entry.new_record?,
+                                              add_another_url: new_group_role_path(entry.group)) do |f|
       = hidden_field_tag('return_url', params[:return_url])
 
       - if entry.person.persisted?

--- a/app/views/roles/_form.html.haml
+++ b/app/views/roles/_form.html.haml
@@ -5,7 +5,7 @@
 
 #main.row-fluid
   .span7
-    = entry_form(cancel_url: role_cancel_url, add_another_url: new_group_role_path(entry.group)) do |f|
+    = entry_form(cancel_url: role_cancel_url, add_another: true, add_another_url: new_group_role_path(entry.group)) do |f|
       = hidden_field_tag('return_url', params[:return_url])
 
       - if entry.person.persisted?

--- a/app/views/roles/_form.html.haml
+++ b/app/views/roles/_form.html.haml
@@ -5,7 +5,7 @@
 
 #main.row-fluid
   .span7
-    = entry_form(cancel_url: role_cancel_url) do |f|
+    = entry_form(cancel_url: role_cancel_url, add_another_url: new_group_role_path(entry.group)) do |f|
       = hidden_field_tag('return_url', params[:return_url])
 
       - if entry.person.persisted?

--- a/app/views/roles/_popover.html.haml
+++ b/app/views/roles/_popover.html.haml
@@ -33,8 +33,8 @@
                     class: 'span4',
                     help: t('roles.fields.help_optional_label'),
                     data: { provide: :typeahead, source: entry.klass.available_labels })
-  
+
   - if @person_id
     = f.hidden_field :person_id, value: @person_id
 
-  = save_form_buttons(f, ti(:"button.save"), '#')
+  = form_buttons(f, submit_label: ti(:"button.save"), cancel_url: '#')

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -41,6 +41,7 @@ de:
 
     button:
       save: Speichern
+      add_another: Speichern und weitere erfassen
       cancel: Abbrechen
       close: Schliessen
       search: Suchen

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -26,6 +26,7 @@ en:
       remove: Remove
     button:
       save: Save
+      add_another: Save and add another
       cancel: Cancel
       close: close
       search: Search

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -37,7 +37,7 @@ describe RolesController do
       expect(role).to be_kind_of(Group::TopGroup::Member)
     end
 
-    it 'new role for new person redirects to person show' do
+    it 'new role for new person redirects to person edit' do
       post :create, group_id: group.id,
                     role: { group_id: group.id,
                             person_id: nil,
@@ -46,7 +46,7 @@ describe RolesController do
                                           last_name: 'Beispiel' } }
 
       role = assigns(:role)
-      is_expected.to redirect_to(group_person_path(group, role.person), :edit)
+      is_expected.to redirect_to(edit_group_person_path(group, role.person))
 
       expect(role.group_id).to eq(group.id)
       expect(flash[:notice]).to eq('Rolle <i>Member</i> für <i>Hans Beispiel</i> in <i>TopGroup</i> wurde erfolgreich erstellt.')

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -46,7 +46,7 @@ describe RolesController do
                                           last_name: 'Beispiel' } }
 
       role = assigns(:role)
-      is_expected.to redirect_to(group_person_path(group, role.person))
+      is_expected.to redirect_to(group_person_path(group, role.person), :edit)
 
       expect(role.group_id).to eq(group.id)
       expect(flash[:notice]).to eq('Rolle <i>Member</i> für <i>Hans Beispiel</i> in <i>TopGroup</i> wurde erfolgreich erstellt.')


### PR DESCRIPTION
Die Änderungen in diesem PR hatten zum Ziel, das Verhalten beim erstellen von neuen Rollen zu verbessern:

- Wird der Knopf "Speichern und weitere erfassen" gedrückt, kommt man automatisch wieder auf die erfassen Maske
- Wird eine völlig neue Person erfasst und normal gespeichert, soll man im :edit der Person landen, um weitere Felder erfassen zu können

![image](https://user-images.githubusercontent.com/939106/68602938-94c1cd80-04a7-11ea-98d1-6ff2b8f4faa8.png)

Achtung:
Ich dabei den form_helper angepasst und die Methoden (aus meiner Sicht klarer gemacht). Konkret: save_form_buttons => form_buttons (mit keyword Argumenten). Im Core habe ich alle Aufrufe angepasst, aber es könnte in den Wagons noch weitere aufrufe haben.

Im Zusammenhang mit diesem PR ist mir auch der Bug der in PR hitobito/hitobito_pbs#123 aufgefallen
