### PR TITLE
Add Email Claim

### DIFF
--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -58,7 +58,17 @@ Doorkeeper::OpenidConnect.configure do
   #   end
   # end
 
-  # claims do
-    # This should be definable by each wagon
-  # end
+  claims do
+    claim :email, scope: :email do |resource_owner|
+      resource_owner.email
+    end
+    
+    claim :first_name, scope: :name do |resource_owner|
+      resource_owner.first_name
+    end
+
+    claim :last_name, scope: :name do |resource_owner|
+      resource_owner.last_name
+    end
+  end
 end


### PR DESCRIPTION
Wir brauchen noch mindestens den Email-Claim, damit wir das als Login verwenden können. Vor- und Nachname machen IMHO im name scope Sinn. Siehe https://github.com/doorkeeper-gem/doorkeeper-openid_connect#claims