### PR TITLE
Fix people layout in Safari

### DIFF
--- a/app/views/people/_attrs.html.haml
+++ b/app/views/people/_attrs.html.haml
@@ -1,10 +1,10 @@
--#  Copyright (c) 2012-2019, Jungwacht Blauring Schweiz. This file is part of
+-#  Copyright (c) 2012-2020, Jungwacht Blauring Schweiz. This file is part of
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-#main.row
-  %article.col-lg-6
+#main.row-fluid
+  %article.span6
     = render 'contact_data', person: entry, only_public: cannot?(:show_details, entry)
     - if can?(:show_details, entry)
       %h2= t('.additional_data')
@@ -27,7 +27,7 @@
       = render 'notes/section', create_path: group_person_notes_path(@group, entry)
 
   - if can?(:show_full, entry)
-    %aside.col-lg-5.offset-lg-1
+    %aside.span5.offset1
       = render 'tags'
       = render 'roles'
       = render 'add_requests'


### PR DESCRIPTION
By adapting the layout classes of groups for people pages the fluid layout doesn't break anymore in Safari on macOS and iPadOS.

Before:
![People_before](https://user-images.githubusercontent.com/111190/76398319-f7a37280-637c-11ea-9be6-e552849095c2.jpg)

After:
![People_after](https://user-images.githubusercontent.com/111190/76398387-13a71400-637d-11ea-9ba3-f2ba40857b59.jpg)
