### PR TITLE
Enrich participation serializer

### DIFF
--- a/app/serializers/event_participation_serializer.rb
+++ b/app/serializers/event_participation_serializer.rb
@@ -27,7 +27,7 @@ class EventParticipationSerializer < ApplicationSerializer
     end
 
     property :birthday, item.person.birthday.try(:iso8601)
-    property :roles, Hash[item.roles.collect { |role| { type: role.class.name, name: role.to_s } }]
+    property :roles, item.roles.collect { |role| { type: role.class.name, name: role.to_s } }
 
     entity :person, item.person_id, PersonIdSerializer
 

--- a/app/serializers/event_participation_serializer.rb
+++ b/app/serializers/event_participation_serializer.rb
@@ -26,7 +26,7 @@ class EventParticipationSerializer < ApplicationSerializer
       property name, item.person.try(name)
     end
 
-    property :birthday, item.person.birthday&.iso8601
+    property :birthday, item.person.birthday.try(:iso8601)
     property :roles, Hash[item.roles.collect { |role| [role.class.name, role.to_s] }]
 
     entity :person, item.person_id, PersonIdSerializer

--- a/app/serializers/event_participation_serializer.rb
+++ b/app/serializers/event_participation_serializer.rb
@@ -27,7 +27,7 @@ class EventParticipationSerializer < ApplicationSerializer
     end
 
     property :birthday, item.person.birthday.try(:iso8601)
-    property :roles, Hash[item.roles.collect { |role| [role.class.name, role.to_s] }]
+    property :roles, Hash[item.roles.collect { |role| { type: role.class.name, name: role.to_s } }]
 
     entity :person, item.person_id, PersonIdSerializer
 

--- a/app/serializers/event_participation_serializer.rb
+++ b/app/serializers/event_participation_serializer.rb
@@ -37,6 +37,6 @@ class EventParticipationSerializer < ApplicationSerializer
 
     person_template_link "#{type_name}.person"
 
-    apply_extensions(:wagon)
+    apply_extensions(:attrs)
   end
 end

--- a/app/serializers/event_participation_serializer.rb
+++ b/app/serializers/event_participation_serializer.rb
@@ -22,15 +22,14 @@ class EventParticipationSerializer < ApplicationSerializer
   schema do
     json_api_properties
 
-    property :first_name, item.person.first_name
-    property :last_name, item.person.last_name
-    property :nickname, item.person.nickname
-    property :email, item.person.email
-    property :birthday, item.person.birthday&.iso8601
-    property :gender, item.person.gender
+    (Person::PUBLIC_ATTRS - [:id]).each do |name|
+      property name, item.person.try(name)
+    end
 
+    property :birthday, item.person.birthday&.iso8601
     property :roles, Hash[item.roles.collect { |role| [role.class.name, role.to_s] }]
-    entity :person, item.person, PersonSerializer
+
+    entity :person, item.person_id, PersonIdSerializer
 
     map_properties :additional_information, :active, :qualified
 
@@ -38,6 +37,6 @@ class EventParticipationSerializer < ApplicationSerializer
 
     person_template_link "#{type_name}.person"
 
-    apply_extensions(:attrs)
+    apply_extensions(:wagon)
   end
 end

--- a/app/serializers/event_participation_serializer.rb
+++ b/app/serializers/event_participation_serializer.rb
@@ -24,10 +24,13 @@ class EventParticipationSerializer < ApplicationSerializer
 
     property :first_name, item.person.first_name
     property :last_name, item.person.last_name
+    property :nickname, item.person.nickname
     property :email, item.person.email
+    property :birthday, item.person.birthday&.iso8601
+    property :gender, item.person.gender
 
-    property :roles, item.roles.collect(&:to_s)
-    entity :person, item.person_id, PersonIdSerializer
+    property :roles, Hash[item.roles.collect { |role| [role.class.name, role.to_s] }]
+    entity :person, item.person, PersonSerializer
 
     map_properties :additional_information, :active, :qualified
 

--- a/doc/development/05_rest_api.md
+++ b/doc/development/05_rest_api.md
@@ -332,9 +332,12 @@ curl "https://demo.hitobito.ch/groups/1/events/1/participations.json?user_email=
         }
       },
       "primary_group_id": 18,
-      "roles": {
-        "Event::Role::Leader": "Leitung"
-      },
+      "roles": [
+        {
+          "type": "Event::Role::Leader", 
+          "name": "Leitung"
+        }
+      ],
       "links": {
         "person": "3086"
       },
@@ -367,9 +370,12 @@ curl "https://demo.hitobito.ch/groups/1/events/1/participations.json?user_email=
         }
       },
       "primary_group_id": 1,
-      "roles": {
-        "Event::Role::Leader": "Leitung"
-      },
+      "roles": [
+        {
+          "type": "Event::Role::Leader", 
+          "name": "Leitung"
+        }
+      ],
       "links": {
         "person": "3103"
       },
@@ -383,9 +389,30 @@ curl "https://demo.hitobito.ch/groups/1/events/1/participations.json?user_email=
       "type": "event_participations",
       "first_name": "Thomas",
       "last_name": "Test III",
+      "nickname": "Toast",
+      "company_name": null,
+      "company": false,
       "email": "thomas3@mail.ch",
+      "address": "Gluckstr. 4",
+      "zip_code": "7185",
+      "town": "Nord Judy",
+      "country": null,
+      "gender": "m",
+      "birthday": "2000-12-31",
+      "picture": {
+        "picture": {
+          "url": "/assets/profil-3a8452c9ac8e8b1b70b9d4f4250417bea5be8a4518dbfae44db944f8fda07ca5.png",
+          "thumb": {
+            "url": "/assets/profil_thumb-0296a3526d1e1cb1a5a9c63fbe5c913977bc1d1361f8bccb23259dda216aa9e8.png"
+          }
+        }
+      },
+      "primary_group_id": 33,
       "roles": [
-        "Teilnehmer/-in"
+        {
+          "type": "Event::Role::Participant", 
+          "name": "Teilnehmer"
+        }
       ],
       "links": {
         "person": "3105"

--- a/doc/development/05_rest_api.md
+++ b/doc/development/05_rest_api.md
@@ -313,10 +313,28 @@ curl "https://demo.hitobito.ch/groups/1/events/1/participations.json?user_email=
       "type": "event_participations",
       "first_name": "Thomas",
       "last_name": "Schüpbach",
+      "nickname": "Ipsam",
+      "company_name": null,
+      "company": false,
       "email": "schuepbach.thomas@hotmail.com",
-      "roles": [
-        "Hauptleitung"
-      ],
+      "address": "Gluckstr. 2",
+      "zip_code": "7185",
+      "town": "Nord Judy",
+      "country": null,
+      "gender": "m",
+      "birthday": "1974-05-17",
+      "picture": {
+        "picture": {
+          "url": "/assets/profil-3a8452c9ac8e8b1b70b9d4f4250417bea5be8a4518dbfae44db944f8fda07ca5.png",
+          "thumb": {
+            "url": "/assets/profil_thumb-0296a3526d1e1cb1a5a9c63fbe5c913977bc1d1361f8bccb23259dda216aa9e8.png"
+          }
+        }
+      },
+      "primary_group_id": 18,
+      "roles": {
+        "Event::Role::Leader": "Leitung"
+      },
       "links": {
         "person": "3086"
       },
@@ -330,10 +348,28 @@ curl "https://demo.hitobito.ch/groups/1/events/1/participations.json?user_email=
       "type": "event_participations",
       "first_name": "Thomas",
       "last_name": "Test II",
+      "nickname": "Toast",
+      "company_name": null,
+      "company": false,
       "email": "thomas2@mail.com",
-      "roles": [
-        "Leitung"
-      ],
+      "address": "Gluckstr. 4",
+      "zip_code": "7185",
+      "town": "Nord Judy",
+      "country": null,
+      "gender": "m",
+      "birthday": "2000-12-31",
+      "picture": {
+        "picture": {
+          "url": "/assets/profil-3a8452c9ac8e8b1b70b9d4f4250417bea5be8a4518dbfae44db944f8fda07ca5.png",
+          "thumb": {
+            "url": "/assets/profil_thumb-0296a3526d1e1cb1a5a9c63fbe5c913977bc1d1361f8bccb23259dda216aa9e8.png"
+          }
+        }
+      },
+      "primary_group_id": 1,
+      "roles": {
+        "Event::Role::Leader": "Leitung"
+      },
       "links": {
         "person": "3103"
       },

--- a/spec/serializers/event_participation_serializer_spec.rb
+++ b/spec/serializers/event_participation_serializer_spec.rb
@@ -41,13 +41,18 @@ describe EventParticipationSerializer do
   end
 
   it 'includes main person attributes ' do
+    participation.person.update(nickname: 'Nick', birthday: Date.new(2000, 1, 1), gender: 'm')
+
     expect(subject[:first_name]).to eq('Bottom')
     expect(subject[:last_name]).to eq('Member')
     expect(subject[:email]).to eq('bottom_member@example.com')
+    expect(subject[:nickname]).to eq('Nick')
+    expect(subject[:birthday]).to eq('2000-01-01')
+    expect(subject[:gender]).to eq('m')
   end
 
   it 'includes event roles' do
-    expect(subject[:roles]).to eq ['Hauptleitung']
+    expect(subject[:roles]).to eq({ 'Event::Role::Leader' => 'Hauptleitung' })
   end
 
   it 'includes person template link' do

--- a/spec/serializers/event_participation_serializer_spec.rb
+++ b/spec/serializers/event_participation_serializer_spec.rb
@@ -49,6 +49,7 @@ describe EventParticipationSerializer do
     expect(subject[:nickname]).to eq('Nick')
     expect(subject[:birthday]).to eq('2000-01-01')
     expect(subject[:gender]).to eq('m')
+    expect(subject.keys).to include(*Person::PUBLIC_ATTRS.map(&:to_s))
   end
 
   it 'includes event roles' do

--- a/spec/serializers/event_participation_serializer_spec.rb
+++ b/spec/serializers/event_participation_serializer_spec.rb
@@ -53,7 +53,7 @@ describe EventParticipationSerializer do
   end
 
   it 'includes event roles' do
-    expect(subject[:roles]).to eq({ 'Event::Role::Leader' => 'Hauptleitung' })
+    expect(subject[:roles]).to eq([{ 'type' => 'Event::Role::Leader', 'name' => 'Hauptleitung' })
   end
 
   it 'includes person template link' do

--- a/spec/serializers/event_participation_serializer_spec.rb
+++ b/spec/serializers/event_participation_serializer_spec.rb
@@ -41,13 +41,13 @@ describe EventParticipationSerializer do
   end
 
   it 'includes main person attributes ' do
-    participation.person.update(nickname: 'Nick', birthday: Date.new(2000, 1, 1), gender: 'm')
+    participation.person.update(nickname: 'Nick', birthday: Date.new(2000, 12, 31), gender: 'm')
 
     expect(subject[:first_name]).to eq('Bottom')
     expect(subject[:last_name]).to eq('Member')
     expect(subject[:email]).to eq('bottom_member@example.com')
     expect(subject[:nickname]).to eq('Nick')
-    expect(subject[:birthday]).to eq('2000-01-01')
+    expect(subject[:birthday]).to eq('2000-12-31')
     expect(subject[:gender]).to eq('m')
     expect(subject.keys).to include(*Person::PUBLIC_ATTRS.map(&:to_s))
   end

--- a/spec/serializers/event_participation_serializer_spec.rb
+++ b/spec/serializers/event_participation_serializer_spec.rb
@@ -53,7 +53,7 @@ describe EventParticipationSerializer do
   end
 
   it 'includes event roles' do
-    expect(subject[:roles]).to eq([{ 'type' => 'Event::Role::Leader', 'name' => 'Hauptleitung' })
+    expect(subject[:roles]).to eq([{ 'type' => 'Event::Role::Leader', 'name' => 'Hauptleitung' }])
   end
 
   it 'includes person template link' do


### PR DESCRIPTION
Wie kurz mit @carlobeltrame besprochen benötigen wir zusätzliche Attribute zu den Teilnehmenden. Im Moment werde nur Vor- und Nachname sowie Email-Adresse mitgegeben. Mit diesem PR werden alle PUBLIC_ATTRS auf Person inkludiert. Konkret sollte das auch Erweiterungen aus den wagons zulassen.