### PR TITLE
Disable autosaving of an event's associated groups

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -96,7 +96,8 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
 
   ### ASSOCIATIONS
 
-  has_and_belongs_to_many :groups
+  # Autosave would change updated_at and updater on the group when creating an event.
+  has_and_belongs_to_many :groups, autosave: false
 
   belongs_to :contact, class_name: 'Person'
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -677,6 +677,28 @@ describe Event do
 
   end
 
+  context 'group timestamps' do
+    let(:group) { groups(:top_layer) }
+
+    it 'does not modify the group timestamps when creating an event' do
+      expect do
+        Event.new(name: 'dummy',
+                  groups: [group],
+                  dates: [Event::Date.new(start_at: Time.now)])
+            .save!
+      end.not_to change { group.updated_at }
+    end
+
+    it 'does not modify the updater id when creating an event' do
+      expect do
+        Event.new(name: 'dummy',
+                  groups: [group],
+                  dates: [Event::Date.new(start_at: Time.now)])
+            .save!
+      end.not_to change { group.updater_id }
+    end
+
+  end
 
   def set_start_finish(event, start_at)
     start_at = Time.zone.parse(start_at)


### PR DESCRIPTION
Say we have a group G, its sibling group S and a person P with a role on S but no role on G.
A is allowed to create a shared event that includes both G and S. However, with `autosave: nil` (as it was so far) or `autosave: true`, Rails automatically saves both G and S during the creation of the event. This in turn changes the `updated_at` timestamp and sets `updater` on both groups to P. This can be confusing because now, on G it says that P has last updated G, even though he shouldn't really be allowed to do so. For this reason, we deactivate autosaving groups via the events_groups association.

Based on a real-world [report](https://help.puzzle.ch/#ticket/zoom/1505) with PBS, where a user from one Kantonalverband was listed as `updater` of another Kantonalverband on which he had no permissions.

Tests are green, but can we do anything else to check that this change doesn't break anything?