### PR TITLE
Icons in den Suchresultaten (Z-33)

### DIFF
--- a/app/assets/javascripts/modules/remote_typeahead.js.coffee
+++ b/app/assets/javascripts/modules/remote_typeahead.js.coffee
@@ -83,7 +83,13 @@ delayedQueryForTypeahead = (query, process, delay = 450) ->
 typeaheadHighlighter = (item) ->
   query = this.query.trim().replace(/[\-\[\]{}()*+?.,\\\^$|#]/g, '\\$&')
   query = query.replace(/\s+/g, '|')
-  JSON.parse(item).label.replace(new RegExp('(' + query + ')', 'ig'), ($1, match) -> '<strong>' + match + '</strong>')
+  labelWithIcon(JSON.parse(item)).replace(new RegExp('(' + query + ')', 'ig'), ($1, match) -> '<strong>' + match + '</strong>')
+
+labelWithIcon = (item) ->
+  if item.icon
+    '<i class="fa fa-' + item.icon + '"></i> ' + item.label
+  else
+    item.label
 
 isModifyingKey = (k) ->
   ! (k == 20 || # Caps lock */

--- a/app/controllers/full_text_controller.rb
+++ b/app/controllers/full_text_controller.rb
@@ -16,7 +16,7 @@ class FullTextController < ApplicationController
   def index
     @people = with_query { search_strategy.list_people }
     @groups = with_query { search_strategy.query_groups }
-    @events = with_query { search_strategy.query_events }
+    @events = with_query { decorate_events(search_strategy.query_events) }
     @active_tab = active_tab
   end
 
@@ -69,5 +69,11 @@ class FullTextController < ApplicationController
 
   def tab_class(tab)
     'active' if @active_tab == tab
+  end
+
+  def decorate_events(events)
+    events.map do |event|
+      EventDecorator.new(event)
+    end
   end
 end

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -111,7 +111,7 @@ class EventDecorator < ApplicationDecorator
   end
 
   def as_quicksearch
-    { id: id, label: label_with_group, type: :event }
+    { id: id, label: label_with_group, type: :event, icon: :'calendar-alt' }
   end
 
   def label_with_group

--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -32,7 +32,7 @@ class GroupDecorator < ApplicationDecorator
   end
 
   def as_quicksearch
-    { id: id, label: label_with_parent, type: :group }
+    { id: id, label: label_with_parent, type: :group, icon: :users }
   end
 
   def label_with_parent

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -16,7 +16,7 @@ class PersonDecorator < ApplicationDecorator
   end
 
   def as_quicksearch
-    { id: id, label: h.h(full_label), type: :person }
+    { id: id, label: h.h(full_label), type: :person, icon: :user }
   end
 
   def as_typeahead_with_address

--- a/app/views/full_text/_events.html.haml
+++ b/app/views/full_text/_events.html.haml
@@ -1,5 +1,7 @@
 = table(@events, class: 'table table-striped table-hover') do |t|
   - t.col(Event.human_attribute_name(:name)) do |e|
-    - content_tag(:strong, link_to(e, e))
+    - content_tag(:strong) do
+      %i.fa{class: "fa-#{e.as_quicksearch[:icon]}", style: "width: 20px"}
+      = link_to(e, e)
   - t.col(Event.human_attribute_name(:dates)) { |e| format_attr(e, :dates) }
   - t.col(Group.model_name.human) { |e| format_attr(e, :groups) }


### PR DESCRIPTION
### Absicht

Die verschiedenen Typen von Suchresultaten, speziell die verschiedenen Anlasstypen im Youth-Wagon, sollen einfacher unterscheidbar sein.  

### Lösungsvorschlag

Dieser PR serialisiert mit den Suchresultaten eine Icon-Klasse mit, die in der Schnellsuche und der Resultatseite im Tab Anlass angezeigt wird:

![grafik](https://user-images.githubusercontent.com/656013/83764346-1ebac900-a67a-11ea-8847-f6816884ec91.png)

![grafik](https://user-images.githubusercontent.com/656013/83764246-021e9100-a67a-11ea-8bbc-7720bde46dd5.png)

Die Änderungen hier sind im Kontext einer [dazugehörigen Anpassung im Youth-Wagon](https://github.com/hitobito/hitobito_youth/pull/9) zu verstehen, welche individuelle Icons für die verschiedenen Anlasstypen definiert.

### Verknüpfungen

* [Issue im Trello «MiData Development»](https://trello.com/c/nPOn6Kmv/33-midata-z-33-suchresultate-typ-der-resultate)
* [Diskussion im Trello «Team MiData Features»](https://trello.com/c/uawnFN18/240-priorisierung-suchresultate)