### PR TITLE
API-Zugriff auf Abos und Abonnent*innen (Z-30)

### DIFF
--- a/app/abilities/token_ability.rb
+++ b/app/abilities/token_ability.rb
@@ -89,7 +89,7 @@ class TokenAbility
 
   def define_mailing_list_abilities
     can :show, MailingList do |mailing_list|
-      token.layer == mailing_list.group
+      token.layer.layer_group == mailing_list.group.layer_group
     end
   end
 

--- a/app/abilities/token_ability.rb
+++ b/app/abilities/token_ability.rb
@@ -74,6 +74,11 @@ class TokenAbility
     can :show, Group do |g|
       token_layer_and_below.include?(g)
     end
+
+    can :show, MailingList do |mailing_list|
+      token_layer_and_below.include?(mailing_list.group)
+    end
+
   end
 
   def define_invoice_abilities

--- a/app/abilities/token_ability.rb
+++ b/app/abilities/token_ability.rb
@@ -27,6 +27,7 @@ class TokenAbility
     define_group_abilities if token.groups?
     define_invoice_abilities if token.invoices?
     define_event_participation_abilities if token.event_participations?
+    define_mailing_list_abilities if token.mailing_lists?
   end
 
   def define_base_abilities
@@ -74,11 +75,6 @@ class TokenAbility
     can :show, Group do |g|
       token_layer_and_below.include?(g)
     end
-
-    can :show, MailingList do |mailing_list|
-      token_layer_and_below.include?(mailing_list.group)
-    end
-
   end
 
   def define_invoice_abilities
@@ -88,6 +84,12 @@ class TokenAbility
 
     can :show, Invoice do |invoice|
       token.layer == invoice.group
+    end
+  end
+
+  def define_mailing_list_abilities
+    can :show, MailingList do |mailing_list|
+      token.layer == mailing_list.group
     end
   end
 

--- a/app/controllers/mailing_lists_controller.rb
+++ b/app/controllers/mailing_lists_controller.rb
@@ -27,6 +27,14 @@ class MailingListsController < CrudController
     super
   end
 
+  def show
+    super do |format|
+      format.json do
+        render json: MailingListSerializer.new(entry.decorate, controller: self)
+      end
+    end
+  end
+
   private
 
   def authorize_class

--- a/app/controllers/service_tokens_controller.rb
+++ b/app/controllers/service_tokens_controller.rb
@@ -15,7 +15,8 @@ class ServiceTokensController < CrudController
     :groups,
     :events,
     :invoices,
-    :event_participations
+    :event_participations,
+    :mailing_lists
   ]
 
   private

--- a/app/decorators/service_token_decorator.rb
+++ b/app/decorators/service_token_decorator.rb
@@ -7,7 +7,7 @@ class ServiceTokenDecorator < ApplicationDecorator
   decorates :service_token
 
   class_attribute :kinds
-  self.kinds = [:people, :people_below, :events, :groups, :invoices, :event_participations]
+  self.kinds = %i[people people_below events groups invoices event_participations mailing_lists]
 
   def abilities
     safe_join(kinds.map do |ability|

--- a/app/serializers/mailing_list_serializer.rb
+++ b/app/serializers/mailing_list_serializer.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+
+#  Copyright (c) 2020, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class MailingListSerializer < ApplicationSerializer
+  schema do
+    json_api_properties
+
+    map_properties :name,
+                   :description,
+                   :publisher,
+                   :mail_name,
+                   :additional_sender,
+                   :subscribable,
+                   :subscribers_may_post,
+                   :anyone_may_post,
+                   :preferred_labels,
+                   :delivery_report,
+                   :main_email
+
+    entity :group, item.group, GroupLinkSerializer
+    entities :subscribers,
+             item.people.includes(subscribers_includes),
+             MailingListSubscriberSerializer
+  end
+
+  private
+
+  def subscribers_includes
+    [:primary_group]
+  end
+end

--- a/app/serializers/mailing_list_subscriber_serializer.rb
+++ b/app/serializers/mailing_list_subscriber_serializer.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+
+#  Copyright (c) 2020, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class MailingListSubscriberSerializer < ContactSerializer
+  schema do
+    map_properties :primary_group_id
+    property :primary_group_name, item.primary_group.name
+  end
+end

--- a/app/views/service_tokens/_form.html.haml
+++ b/app/views/service_tokens/_form.html.haml
@@ -16,5 +16,6 @@
       - if parent.layer?
         = f.boolean_field(:invoices, caption: model_class.human_attribute_name(:invoices))
       = f.boolean_field(:event_participations, caption: model_class.human_attribute_name(:event_participations))
+      = f.boolean_field(:mailing_lists, caption: model_class.human_attribute_name(:mailing_lists))
 
       = render_extensions :fields, locals: { f: f }

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -796,6 +796,7 @@ de:
         events: Anlässe dieser und der darunterliegenden Ebenen
         invoices: Rechnungen dieser Ebene
         event_participations: Teilnehmende von Anlässen dieser Ebene
+        mailing_lists: Abonnent/innen von Mailinglisten dieser Ebene
 
   doorkeeper:
     scopes:

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -796,7 +796,7 @@ de:
         events: Anlässe dieser und der darunterliegenden Ebenen
         invoices: Rechnungen dieser Ebene
         event_participations: Teilnehmende von Anlässen dieser Ebene
-        mailing_lists: Abonnent/innen von Mailinglisten dieser Ebene
+        mailing_lists: Abonnent/-innen von Mailinglisten dieser Ebene
 
   doorkeeper:
     scopes:

--- a/db/migrate/20200602143959_add_mailing_lists_to_service_tokens.rb
+++ b/db/migrate/20200602143959_add_mailing_lists_to_service_tokens.rb
@@ -1,0 +1,12 @@
+# encoding: utf-8
+
+#  Copyright (c) 2020, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class AddMailingListsToServiceTokens < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:service_tokens, :mailing_lists, :boolean, default: false, null: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -633,6 +633,7 @@ ActiveRecord::Schema.define(version: 2020_06_25_114634) do
     t.datetime "updated_at", null: false
     t.boolean "invoices", default: false, null: false
     t.boolean "event_participations", default: false, null: false
+    t.boolean "mailing_lists", default: false, null: false
   end
 
   create_table "sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|

--- a/spec/abilities/token_ability_spec.rb
+++ b/spec/abilities/token_ability_spec.rb
@@ -300,6 +300,16 @@ describe TokenAbility do
       it 'may show' do
         is_expected.to be_able_to(:show, mailing_list)
       end
+
+      it 'may show for list below' do
+        list = groups(:top_group).mailing_lists.create!(name: 'list')
+        is_expected.to be_able_to(:show, list)
+      end
+
+      it 'may not show for list in sub layer' do
+        list = groups(:bottom_layer_one).mailing_lists.create!(name: 'list')
+        is_expected.not_to be_able_to(:show, list)
+      end
     end
 
     context 'unauthorized' do

--- a/spec/abilities/token_ability_spec.rb
+++ b/spec/abilities/token_ability_spec.rb
@@ -290,4 +290,24 @@ describe TokenAbility do
       end
     end
   end
+
+  describe :mailing_lists do
+    let(:mailing_list) { mailing_lists(:leaders) }
+
+    context 'authorized' do
+      let(:token) { service_tokens(:permitted_top_group_token) }
+
+      it 'may show' do
+        is_expected.to be_able_to(:show, mailing_list)
+      end
+    end
+
+    context 'unauthorized' do
+      let(:token) { service_tokens(:rejected_top_group_token) }
+
+      it 'may not show' do
+        is_expected.not_to be_able_to(:show, mailing_list)
+      end
+    end
+  end
 end

--- a/spec/controllers/service_tokens_controller_spec.rb
+++ b/spec/controllers/service_tokens_controller_spec.rb
@@ -37,7 +37,8 @@ describe ServiceTokensController do
         groups: true,
         events: true,
         invoices: true,
-        event_participations: true
+        event_participations: true,
+        mailing_lists: true
       } }
       expect(token.reload).to be_people
       expect(token.reload).to be_people_below
@@ -45,6 +46,7 @@ describe ServiceTokensController do
       expect(token.reload).to be_events
       expect(token.reload).to be_invoices
       expect(token.reload).to be_event_participations
+      expect(token.reload).to be_mailing_lists
     end
   end
 end

--- a/spec/fixtures/service_tokens.yml
+++ b/spec/fixtures/service_tokens.yml
@@ -34,6 +34,7 @@ permitted_top_group_token:
   events: true
   invoices: true
   event_participations: true
+  mailing_lists: true
 
 rejected_top_group_token:
   layer: top_layer

--- a/spec/regressions/mailing_lists_controller_spec.rb
+++ b/spec/regressions/mailing_lists_controller_spec.rb
@@ -35,4 +35,28 @@ describe MailingListsController, type: :controller do
 
   include_examples 'crud controller'
 
+  context 'show' do
+    it 'renders json' do
+      get :show, params: { group_id: group.id, id: test_entry.id }, format: :json
+      json = JSON.parse(response.body).deep_symbolize_keys
+      mailing_list = json[:mailing_lists].first
+      expect(mailing_list).to eq({
+        id: test_entry.id.to_s,
+        type: "mailing_lists",
+        name: "Leaders",
+        description: nil,
+        publisher: nil,
+        mail_name: "leaders",
+        additional_sender: nil,
+        subscribable: true,
+        subscribers_may_post: false,
+        anyone_may_post: false,
+        preferred_labels: [],
+        delivery_report: false,
+        main_email: false,
+        links: {group: group.id.to_s}
+      })
+    end
+  end
+
 end


### PR DESCRIPTION
### Absicht

Auf Abos und Abonnent*innen soll per API zugegriffen werden können. Dies soll unter anderem ermöglichen, dass weitere Versandmöglichkeiten / externe Mailanbieter integriert werden können.
👉 @diegosteiner 

### Lösungsvorschlag

Dieser PR öffnet `/groups/:group_id/mailing_lists/:mailing_list_id` für den Zugriff mit einem ServiceAccount und per JSON. Zusätzlich erweitert sie die API-Keys / service token um eine neue Berechtigung `mailing_lists` («Abonnent/innen von Mailinglisten dieser Ebene»), welche genau diesen Zugriff erlaubt.

### Verknüpfungen

* [PR #163 im PBS-Wagon auf Basis dieses PRs](https://github.com/hitobito/hitobito_pbs/pull/163), welcher zusätzliche PBS-spezifische Felder serialisiert
* [Issue im Trello «MiData Development»](https://trello.com/c/6EosZKkI/28-midata-z-30-schnittstellen-erweitern-api-f%C3%BCr-abos-und-abonnentinnen)
* [Diskussion im Trello «Team MiData Features»](https://trello.com/c/h5vyzHc6/107-schnittstellen-erweitern)
* Issue #242  