### PR TITLE
Sichtbarkeit von Abos (Z-35)

### DIFF
--- a/app/abilities/mailing_list_ability.rb
+++ b/app/abilities/mailing_list_ability.rb
@@ -12,29 +12,30 @@ class MailingListAbility < AbilityDsl::Base
   on(::MailingList) do
     permission(:any).may(:show).subscribable_mailing_lists
 
-    permission(:group_full).may(:show).all
-    permission(:group_full).may(:index_subscriptions, :create, :update, :destroy).in_same_group
+    permission(:group_full).
+      may(:show, :index_subscriptions, :create, :update, :destroy).
+      in_same_group
     permission(:group_full).
       may(:export_subscriptions).
       in_same_group_if_no_subscriptions_in_below_groups
 
-    permission(:group_and_below_full).may(:show).all
     permission(:group_and_below_full).
-      may(:index_subscriptions, :create, :update, :destroy).
+      may(:show, :index_subscriptions, :create, :update, :destroy).
       in_same_group_or_below
     permission(:group_and_below_full).
       may(:export_subscriptions).
       in_same_group_or_below_if_no_subscriptions_in_below_layers
 
-    permission(:layer_full).may(:show).all
-    permission(:layer_full).may(:index_subscriptions, :create, :update, :destroy).in_same_layer
+    permission(:layer_full).
+      may(:show, :index_subscriptions, :create, :update, :destroy).
+      in_same_layer
     permission(:layer_full).
       may(:export_subscriptions).
       in_same_layer_if_no_subscriptions_in_below_layers
 
-    permission(:layer_and_below_full).may(:show).all
     permission(:layer_and_below_full).
-      may(:index_subscriptions, :export_subscriptions, :create, :update, :destroy).in_same_layer
+      may(:show, :index_subscriptions, :export_subscriptions, :create, :update, :destroy).
+      in_same_layer
 
     general.group_not_deleted
   end

--- a/app/abilities/mailing_list_ability.rb
+++ b/app/abilities/mailing_list_ability.rb
@@ -10,7 +10,7 @@ class MailingListAbility < AbilityDsl::Base
   include AbilityDsl::Constraints::Group
 
   on(::MailingList) do
-    permission(:any).may(:show).subscribable_mailing_lists
+    permission(:any).may(:show).subscribable
 
     permission(:group_full).
       may(:show, :index_subscriptions, :create, :update, :destroy).
@@ -57,7 +57,7 @@ class MailingListAbility < AbilityDsl::Base
       local_event_subscription_count == total_event_subscription_count
   end
 
-  def subscribable_mailing_lists
+  def subscribable
     subject.subscribable
   end
 

--- a/app/abilities/mailing_list_ability.rb
+++ b/app/abilities/mailing_list_ability.rb
@@ -10,13 +10,15 @@ class MailingListAbility < AbilityDsl::Base
   include AbilityDsl::Constraints::Group
 
   on(::MailingList) do
-    permission(:any).may(:show).all
+    permission(:any).may(:show).subscribable_mailing_lists
 
+    permission(:group_full).may(:show).all
     permission(:group_full).may(:index_subscriptions, :create, :update, :destroy).in_same_group
     permission(:group_full).
       may(:export_subscriptions).
       in_same_group_if_no_subscriptions_in_below_groups
 
+    permission(:group_and_below_full).may(:show).all
     permission(:group_and_below_full).
       may(:index_subscriptions, :create, :update, :destroy).
       in_same_group_or_below
@@ -24,11 +26,13 @@ class MailingListAbility < AbilityDsl::Base
       may(:export_subscriptions).
       in_same_group_or_below_if_no_subscriptions_in_below_layers
 
+    permission(:layer_full).may(:show).all
     permission(:layer_full).may(:index_subscriptions, :create, :update, :destroy).in_same_layer
     permission(:layer_full).
       may(:export_subscriptions).
       in_same_layer_if_no_subscriptions_in_below_layers
 
+    permission(:layer_and_below_full).may(:show).all
     permission(:layer_and_below_full).
       may(:index_subscriptions, :export_subscriptions, :create, :update, :destroy).in_same_layer
 
@@ -50,6 +54,10 @@ class MailingListAbility < AbilityDsl::Base
   def no_subscriptions_below
     !group_subscriptions_with_below_role_types? &&
       local_event_subscription_count == total_event_subscription_count
+  end
+
+  def subscribable_mailing_lists
+    subject.subscribable
   end
 
   private

--- a/app/controllers/mailing_lists_controller.rb
+++ b/app/controllers/mailing_lists_controller.rb
@@ -37,22 +37,8 @@ class MailingListsController < CrudController
 
   private
 
-  def entries
-    MailingList.where("subscribable = ? OR group_id IN (?)", true, accessible_mailing_lists_groups.flatten)
-  end
-
-  def accessible_mailing_lists_groups
-    current_user.roles.map do |role|
-      if role.permissions.include?(:group_full)
-        [group.id]
-      elsif role.permissions.include?(:group_and_below_full)
-        group.self_and_descendants.pluck(:id)
-      elsif role.permissions.include?(:layer_full)
-        group.groups_in_same_layer.pluck(:id)
-      elsif role.permissions.include?(:layer_and_below_full)
-        group.groups_in_same_layer.map { |g| g.self_and_descendants.pluck(:id) }.flatten
-      end
-    end
+  def list_entries
+    can?(:update, parent) ? super : super.subscribable
   end
 
   def authorize_class

--- a/spec/abilities/mailing_list_ability_spec.rb
+++ b/spec/abilities/mailing_list_ability_spec.rb
@@ -91,8 +91,8 @@ describe MailingListAbility do
     context 'in group in lower layer' do
       let(:group) { groups(:bottom_layer_one) }
 
-      it 'may show mailing lists' do
-        is_expected.to be_able_to(:show, list)
+      it 'may not show mailing lists' do
+        is_expected.not_to be_able_to(:show, list)
       end
 
       it 'may not update mailing lists' do
@@ -116,8 +116,8 @@ describe MailingListAbility do
       let(:role) { Fabricate(Group::BottomLayer::Leader.name.to_sym, group: groups(:bottom_layer_one)) }
       let(:group) { groups(:top_layer) }
 
-      it 'may show mailing lists' do
-        is_expected.to be_able_to(:show, list)
+      it 'may not show mailing lists' do
+        is_expected.not_to be_able_to(:show, list)
       end
 
       it 'may not update mailing lists' do
@@ -324,8 +324,8 @@ describe MailingListAbility do
     context 'in group in lower layer' do
       let(:group) { groups(:bottom_layer_one) }
 
-      it 'may show mailing lists' do
-        is_expected.to be_able_to(:show, list)
+      it 'may not show mailing lists' do
+        is_expected.not_to be_able_to(:show, list)
       end
 
       it 'may not update mailing lists' do
@@ -431,8 +431,8 @@ describe MailingListAbility do
     context 'in group in same layer' do
       let(:group) { groups(:top_group) }
 
-      it 'may show mailing lists' do
-        is_expected.to be_able_to(:show, list)
+      it 'may not show mailing lists' do
+        is_expected.not_to be_able_to(:show, list)
       end
 
       it 'may not update mailing lists' do
@@ -451,8 +451,8 @@ describe MailingListAbility do
     context 'in group in lower layer' do
       let(:group) { groups(:bottom_layer_one) }
 
-      it 'may show mailing lists' do
-        is_expected.to be_able_to(:show, list)
+      it 'may not show mailing lists' do
+        is_expected.not_to be_able_to(:show, list)
       end
 
       it 'may not update mailing lists' do

--- a/spec/controllers/mailing_lists_controller_spec.rb
+++ b/spec/controllers/mailing_lists_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe MailingListsController do
+  let(:top_leader) { people(:top_leader) }
+  let(:bottom_member) { people(:bottom_member) }
+
+  describe 'GET #index' do
+    let(:group) { groups(:top_layer) }
+
+    it 'includes mailing list when person can update group' do
+      sign_in(top_leader)
+      get :index, params: { group_id: group.id }
+      expect(assigns(:mailing_lists)).to have(1).item
+    end
+
+    it 'shows mailing list when person cannot update group but mailing list is subscribable' do
+      sign_in(bottom_member)
+      get :index, params: { group_id: group.id }
+      expect(assigns(:mailing_lists)).to have(1).item
+    end
+
+    it 'hides mailing list when person cannot update group' do
+      sign_in(bottom_member)
+      mailing_lists(:leaders).update(subscribable: false)
+      get :index, params: { group_id: group.id }
+      expect(assigns(:mailing_lists)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
### Absicht

Abos sollen neu nur noch für Personen angezeigt werden, welche Schreibrecht auf das Abo haben. Abos mit der Option «Abonnenten dürfen sich selbst an-/abmelden» werden allen Personen angezeigt.

### Lösungsvorschlag

Der PR ändert die Permissions in `MailingListAbility` und fügt zusätzliche Logik im `MailingListController` hinzu, um in der Übersichtsliste nur die sichtbaren Abos anzuzeigen.

### Offene Fragen

1. Wir gehen davon aus, dass diese Anpassung von generellem Interesse ist – Abos anzuzeigen, mit denen man nicht interagieren kann, scheint uns nicht sinnvoll. Stimmt das so oder soll das Feature in einen Wagon gezügelt werden?
1. In der aktuellen Lösung verdoppelt die Logik im Controller die Angaben der `MailingListAbility`. Ich habe versucht, letztere direkt zu verwenden mit etwas wie `MailingList.accessible_by`, aber war bisher erfolglos. Gibt es hier eine bessere Lösung ohne diese Duplizierung?

### Verknüpfungen

* [Issue im Trello «MiData Development»](https://trello.com/c/IGmm7nlZ/31-midata-z-35-sichtbarkeit-von-abos)
* [Diskussion im Trello «Team MiData Features»](https://trello.com/c/sFpomCq4/140-sichtbarkeit-von-anl%C3%A4ssen-kursen-lagern)