### PR TITLE
Import existing note stylesheet (Z-37)

### DIFF
--- a/app/assets/stylesheets/hitobito/_main.scss
+++ b/app/assets/stylesheets/hitobito/_main.scss
@@ -25,6 +25,7 @@
 @import "hitobito/modules/legend";
 @import "hitobito/modules/log";
 @import "hitobito/modules/nav_left";
+@import "hitobito/modules/note";
 @import "hitobito/modules/person_tags";
 @import "hitobito/modules/profil";
 @import "hitobito/modules/step_wizard";


### PR DESCRIPTION
### Absicht

Ich bin einer Anfrage nachgegangen, die Notizen-Ansicht zu «reparieren». Die Personen-Bilder und -Icons werden auf der PBS-Testinstanz und bei mir lokal in voller Breite angezeigt:

![grafik](https://user-images.githubusercontent.com/656013/84014164-2d56f800-a97a-11ea-9499-24ba85b4510f.png)

### Lösungsvorschlag

Dieser PR importiert das existierende `_note.scss`-Stylesheet in `_main.scss`, was bei mir das «Problem» löst und die Ansicht folgendermassen ändert:

![grafik](https://user-images.githubusercontent.com/656013/84014250-4eb7e400-a97a-11ea-8bfc-467bb2f333e3.png)

Ich habe nicht herausgefunden, ob das aus Versehen oder absichtlich nicht importiert wurde 🤷 Auf jeden Fall scheint diese einfache Anpassung die Ansicht wiederherzustellen.

### Verknüpfungen

* [Issue im Trello «MiData Development»](https://trello.com/c/wzB3lXMx/36-midata-z-37-ansicht-notizen-reparieren)
