### PR TITLE
Feature/z 23 wagon specific help texts

### DIFF
--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -273,13 +273,17 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
   #   labeled(:attr, content)
   #   labeled(:attr, 'Caption') { #content }
   #   labeled(:attr, 'Caption', content)
-  def labeled(attr, caption_or_content = nil, content = nil, html_options = {}, &block)
+  def labeled(attr, caption_or_content = nil, content = nil, html_options = {}, field_help = nil,
+              &block)
     if block_given?
       content = capture(&block)
     elsif content.nil?
       content = caption_or_content
       caption_or_content = nil
     end
+    content << help_texts.render_field(attr)
+    content << field_help if field_help.present?
+
     caption_or_content ||= captionize(attr, klass)
     add_css_class(html_options, 'controls')
     css_classes = { 'control-group' => true, error: errors_on?(attr), required: required?(attr) }
@@ -426,15 +430,13 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
     label = options.delete(:label)
     addon = options.delete(:addon)
 
-    labeled_args = [args.first]
-    labeled_args << label if label.present?
+    content = send(field_method, *(args << options))
+    content = with_addon(addon, content) if addon.present?
 
-    text = send(field_method, *(args << options))
-    text = with_addon(addon, text) if addon.present?
-    with_labeled_field_help(args.first, options) { |help| text << help }
+    field_help = ActiveSupport::SafeBuffer.new("")
+    with_labeled_field_help(args.first, options) { |help| field_help << help }
 
-    labeled_args << text
-    labeled(*labeled_args)
+    labeled(args.first, label, content, {}, field_help)
   end
 
   def with_labeled_field_help(field, options)
@@ -445,7 +447,6 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
       yield help_inline(help_inline) if help_inline.present?
       yield help_block(help)
     else
-      yield help_texts.render_field(field)
       yield help_inline(help_inline) if help_inline.present?
     end
   end

--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -281,7 +281,7 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
       content = caption_or_content
       caption_or_content = nil
     end
-    content << help_texts.render_field(attr)
+    content << render_help_text(attr)
     content << field_help if field_help.present?
 
     caption_or_content ||= captionize(attr, klass)
@@ -378,6 +378,10 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
       (block_given? ? yield : content) +
         content_tag(:span, addon, class: 'add-on')
     end
+  end
+
+  def render_help_text(attr)
+    help_texts.render_field(attr)
   end
 
   private

--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -381,7 +381,7 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def render_help_text(attr)
-    help_texts.render_field(attr)
+    help_texts.render_field(attr) || help_texts.render_field("#{attr}_id")
   end
 
   private


### PR DESCRIPTION
### Absicht

Für alle (Wagon-spezifischen) Felder soll es möglich sein, Hilfetexte zu erfassen (Issue #931).

### Lösungsvorschlag

Dieser PR:
* extrahiert die Methode `render_help_text(attr)`, um sie Views für individuelle Anzeigelogik zugänglich zu machen
* rendert die Hilfetexte neu in `labeled()`, um sie in mehr Fällen automatisch zu rendern
* unterscheidet bezüglich Hilfetexten nicht mehr zwischen `attr` und `attr_id`, um Hilfetexte für Personen-Dropdowns anzuzeigen

### Verknüpfungen

* Issue #931
* [Issue im Trello «MiData Development»](https://trello.com/c/wPCdANW8/19-midata-z-23-hilfetexte-pbs-spezifische-felder)
* [Issue um Trello «Team MiData Features»](https://trello.com/c/26D65dax/255-kontexthilfe-hilfetexte-pbs-spezifische-felder-kompatibel-machen)