### PR TITLE
Administration der API-Keys einschränken auf `admin`-Berechtigung (Z-39)

### DIFF
--- a/app/abilities/service_token_ability.rb
+++ b/app/abilities/service_token_ability.rb
@@ -10,8 +10,7 @@ class ServiceTokenAbility < AbilityDsl::Base
   include AbilityDsl::Constraints::Group
 
   on(ServiceToken) do
-    permission(:layer_and_below_full).may(:manage).in_same_layer
-    permission(:layer_full).may(:manage).in_same_layer
+    permission(:admin).may(:manage).in_same_layer
   end
 
   private


### PR DESCRIPTION
### Absicht

Mit API-Keys können externen Applikationen weitgehende Zugriffe auf die Daten in Hitobito gegeben werden. Um den Kreis der Personen einzuschränken, die diese Zugriffe vergeben können, soll die Administration der API-Keys nur mit `admin`-Berechtigungen möglich sein.

Zu klären ist, ob diese Anpassung von generellem Interesse ist oder in den PBS-Wagon verschoben werden soll.

### Verknüpfungen

* [Issue im Trello «MiData Development»](https://trello.com/c/5ajurzrz/37-midata-z-39-beschr%C3%A4nkung-auf-admin-rollen-f%C3%BCr-api-keys-der-bundesebene)