### PR TITLE
API-Endpunkt für die komplette Gruppen-Hierarchie (Z-43)

### DIFF
--- a/app/abilities/token_ability.rb
+++ b/app/abilities/token_ability.rb
@@ -21,11 +21,16 @@ class TokenAbility
   private
 
   def define_token_abilities
+    define_base_abilities
     define_person_abilities if token.people? || token.people_below?
     define_event_abilities if token.events?
     define_group_abilities if token.groups?
     define_invoice_abilities if token.invoices?
     define_event_participation_abilities if token.event_participations?
+  end
+
+  def define_base_abilities
+    can :index, Group
   end
 
   def define_person_abilities

--- a/app/controllers/group/lists_controller.rb
+++ b/app/controllers/group/lists_controller.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+
+#  Copyright (c) 2020, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+class Group::ListsController < ApplicationController
+
+  def index
+    authorize!(:index, Group)
+
+    respond_to do |format|
+      format.json do
+        render json: ListSerializer.new(groups, serializer: GroupListSerializer, controller: self)
+      end
+    end
+  end
+
+  private
+
+  def groups
+    @groups ||= Group.all
+  end
+
+end

--- a/app/serializers/group_list_serializer.rb
+++ b/app/serializers/group_list_serializer.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+
+#  Copyright (c) 2020, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+class GroupListSerializer < ApplicationSerializer
+  schema do
+    type 'group'
+    property :id, item.id
+    property :parent_id, item.parent_id
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Hitobito::Application.routes.draw do
     get '/people/:id' => 'person/top#show', as: :person
     get '/events/:id' => 'event/top#show', as: :event
 
+    get 'list_groups' => 'group/lists#index', as: :list_groups
+
     resources :groups do
       member do
         get :deleted_subgroups


### PR DESCRIPTION
### Absicht

Die heutigen API-Endpunkte erlauben nur das Auslesen einzelner Gruppen, nicht der kompletten Hierarchie. Damit eine externe Applikation die gesamte Gruppen-Hierarchie sieht, muss sie zeit- und ressourcenintensiv alle Gruppen traversieren, was einzelne Applikationen bereits heute machen.

### Lösungsvorschlag

Dieser PR fügt einen `list_groups`-Endpunkt hinzu, der jede Gruppe mit den Feldern `id` und `parent_id` serialisiert, womit die Hierarchie konstruiert werden kann. Zusätzlich wird allen API-Keys der Zugriff auf diesen Endpunkt erlaubt. 

### Verknüpfungen

* [Issue im Trello «MiData Development»](https://trello.com/c/77eXssvr/44-midata-z-43-endpunkt-f%C3%BCr-alle-gruppen-mit-hierarchie)