### PR TITLE
Berechtigungen im OAuth «Profil» mitserialisieren (Z-25)

### DIFF
--- a/app/controllers/oauth/profiles_controller.rb
+++ b/app/controllers/oauth/profiles_controller.rb
@@ -44,7 +44,8 @@ module Oauth
         {
           group_id: role.group_id,
           group_name: role.group.name,
-          role_name: role.class.model_name.human
+          role_name: role.class.model_name.human,
+          permissions: role.class.permissions
         }
       end
       person.attributes.slice(*Person::PUBLIC_ATTRS.collect(&:to_s)).merge(roles: roles)

--- a/app/domain/person/subscriptions.rb
+++ b/app/domain/person/subscriptions.rb
@@ -1,8 +1,3 @@
-#  Copyright (c) 2020, Grünliberale Partei Schweiz. This file is part of
-#  hitobito and licensed under the Affero General Public License version 3
-#  or later. See the COPYING file at the top-level directory or at
-#  https://github.com/hitobito/hitobito.
-
 class Person::Subscriptions
 
   def initialize(person)

--- a/spec/domain/person/subscriptions_spec.rb
+++ b/spec/domain/person/subscriptions_spec.rb
@@ -1,9 +1,5 @@
-#  Copyright (c) 2020, Grünliberale Partei Schweiz. This file is part of
-#  hitobito and licensed under the Affero General Public License version 3
-#  or later. See the COPYING file at the top-level directory or at
-#  https://github.com/hitobito/hitobito.
-
 require 'spec_helper'
+
 
 describe Person::Subscriptions do
 


### PR DESCRIPTION
### Absicht

Damit externe Applikationen zusätzlich zur OAuth-Authentifizierung auch die bestehenden Hitobito-Strukturen zur Authorisierung nutzen können, sollen beim Login die Berechtigungen pro Rolle der Person mitserialisiert werden.

### Lösungsvorschlag

Dieser PR ergänzt die Rollen-Serialisierung im `Oauth::ProfilesController` mit den Permissions der Rolle. In meinem – zugegebenermassen limitierten – Verständnis der OAuth-Prozesse sollte das den Applikationen, die Hitobito per OAuth anbinden, Zugriff auf diese Information geben.

### Verknüpfungen

* [Issue im Trello «MiData Development»](https://trello.com/c/zDbvbGec/22-midata-z-25-anbindung-pbs-portal-in-der-midata-sauber-aufgleisen)