### PR TITLE
Mailchimp-Synchronisierung: Option zum Einschliessen von Versandadressen (Z-38)

### DIFF
--- a/app/controllers/mailing_lists_controller.rb
+++ b/app/controllers/mailing_lists_controller.rb
@@ -13,7 +13,7 @@ class MailingListsController < CrudController
                           :additional_sender, :subscribable, :subscribers_may_post,
                           :anyone_may_post, :main_email, :delivery_report,
                           :mailchimp_list_id, :mailchimp_api_key,
-                          preferred_labels: []]
+                          :mailchimp_include_additional_emails, preferred_labels: []]
 
   decorates :group, :mailing_list
 

--- a/app/domain/synchronize/mailchimp/subscriber.rb
+++ b/app/domain/synchronize/mailchimp/subscriber.rb
@@ -64,11 +64,11 @@ module Synchronize
       def method_missing(method_name, *args, &block)
         super unless person.respond_to?(method_name)
 
-        person.send(method_name, *args, &block)
+        person.public_send(method_name, *args, &block)
       end
 
       def respond_to_missing?(method, *)
-        %i[email].include?(method) || person.respond_to?(method)
+        person.respond_to?(method)
       end
 
     end

--- a/app/domain/synchronize/mailchimp/subscriber.rb
+++ b/app/domain/synchronize/mailchimp/subscriber.rb
@@ -13,7 +13,7 @@ module Synchronize
 
     class Subscriber
       def self.mailing_list_subscribers(mailing_list)
-        if mailing_list.include_additional_emails
+        if mailing_list.mailchimp_include_additional_emails
           default_and_additional_addresses(mailing_list)
         else
           default_addresses(mailing_list)

--- a/app/domain/synchronize/mailchimp/subscriber.rb
+++ b/app/domain/synchronize/mailchimp/subscriber.rb
@@ -1,0 +1,48 @@
+#  Copyright (c) 2020, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+module Synchronize
+  module Mailchimp
+
+    # Subscriber represents a single entry of our data that should be synchronized.
+    # This entry always belongs to, but does not equal a Person: Depending on the mailing_list
+    # configuration the Persons additional_emails should be synchronized as well, leading to
+    # multiple Subscribers per Person.
+
+    class Subscriber
+      def self.mailing_list_subscribers(mailing_list)
+        mailing_list.people.map do |person|
+          self.new(person, person.email)
+        end
+      end
+
+      def self.mailing_list_tags(mailing_list)
+        people = mailing_list.people.includes(:tags).unscope(:select)
+        people.each_with_object({}) do |person, hash|
+          next unless person.email
+
+          person.tags.each do |tag|
+            value = tag.name
+            hash[value] ||= []
+            hash[value] << person.email
+          end
+        end
+      end
+
+      attr_reader :person, :email
+      def initialize(person, email)
+        @person = person
+        @email = email
+      end
+
+      # Delegate all other messages to person
+      def method_missing(method_name, *args, &block)
+        super unless person.respond_to?(method_name)
+
+        person.send(method_name, *args, &block)
+      end
+    end
+  end
+end

--- a/app/domain/synchronize/mailchimp/subscriber.rb
+++ b/app/domain/synchronize/mailchimp/subscriber.rb
@@ -66,6 +66,11 @@ module Synchronize
 
         person.send(method_name, *args, &block)
       end
+
+      def respond_to_missing?(method, *)
+        %i[email].include?(method) || person.respond_to?(method)
+      end
+
     end
   end
 end

--- a/app/models/mailing_list.rb
+++ b/app/models/mailing_list.rb
@@ -29,6 +29,8 @@
 
 class MailingList < ActiveRecord::Base
 
+  attr_accessor :include_additional_emails
+
   serialize :preferred_labels, Array
   attribute :mailchimp_result, Synchronize::Mailchimp::ResultType.new
 

--- a/app/models/mailing_list.rb
+++ b/app/models/mailing_list.rb
@@ -29,8 +29,6 @@
 
 class MailingList < ActiveRecord::Base
 
-  attr_accessor :include_additional_emails
-
   serialize :preferred_labels, Array
   attribute :mailchimp_result, Synchronize::Mailchimp::ResultType.new
 

--- a/app/views/mailing_lists/_attrs.html.haml
+++ b/app/views/mailing_lists/_attrs.html.haml
@@ -8,7 +8,9 @@
     = format_attr(entry, :description)
     = render_attrs(entry, :mail_address_link, :publisher)
     - if can?(:edit, entry)
-      = render_attrs(entry, :mailchimp_api_key, :mailchimp_list_id)
+      = render_attrs(entry, :mailchimp_api_key,
+                            :mailchimp_list_id,
+                            :mailchimp_include_additional_emails)
       - if entry.mailchimp? && entry.mailchimp_result
         = render_attrs(entry, :mailchimp_sync)
       = render_attrs(entry, :additional_sender)

--- a/app/views/mailing_lists/_form.html.haml
+++ b/app/views/mailing_lists/_form.html.haml
@@ -41,6 +41,7 @@
   %fieldset
     = f.labeled_input_fields(:mailchimp_list_id, help: t('.help_mailchimp_sync'))
     = f.labeled_input_fields(:mailchimp_api_key)
+    = f.labeled_boolean_field(:mailchimp_include_additional_emails)
 
   %fieldset
     = f.indented do

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -615,6 +615,7 @@ de:
           success: Aktualisiert
           partial: Teilweise
           failed: Fehlgeschlagen
+        mailchimp_include_additional_emails: 'Alle Versandadressen synchronisieren'
 
       subscription:
         related_role_types: Rollen

--- a/db/migrate/20200625114634_add_mailchimp_include_additional_emails_to_mailing_list.rb
+++ b/db/migrate/20200625114634_add_mailchimp_include_additional_emails_to_mailing_list.rb
@@ -1,0 +1,5 @@
+class AddMailchimpIncludeAdditionalEmailsToMailingList < ActiveRecord::Migration[6.0]
+  def change
+    add_column :mailing_lists, :mailchimp_include_additional_emails, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_19_075516) do
+ActiveRecord::Schema.define(version: 2020_06_25_114634) do
 
   create_table "additional_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "contactable_type", null: false
@@ -392,6 +392,7 @@ ActiveRecord::Schema.define(version: 2020_06_19_075516) do
     t.boolean "mailchimp_syncing", default: false
     t.datetime "mailchimp_last_synced_at"
     t.text "mailchimp_result"
+    t.boolean "mailchimp_include_additional_emails", default: false
     t.index ["group_id"], name: "index_mailing_lists_on_group_id"
   end
 

--- a/spec/domain/synchronize/mailchimp/subscriber_spec.rb
+++ b/spec/domain/synchronize/mailchimp/subscriber_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'digest/md5'
+
+describe Synchronize::Mailchimp::Subscriber do
+  let(:user)         { people(:top_leader) }
+  let(:mailing_list) { mailing_lists(:leaders) }
+
+  before do
+    mailing_list.subscriptions.create!(subscriber: user)
+  end
+
+  subject { described_class.mailing_list_subscribers(mailing_list) }
+
+  context 'basic mailing list' do
+    it 'returns all people once' do
+      expect(subject.count).to eq(1)
+    end
+
+    it 'returns subscriber containing person' do
+      expect(subject.first.email).to eq(user.email)
+      expect(subject.first.person).to eq(user)
+    end
+  end
+end

--- a/spec/domain/synchronize/mailchimp/subscriber_spec.rb
+++ b/spec/domain/synchronize/mailchimp/subscriber_spec.rb
@@ -2,11 +2,13 @@ require 'spec_helper'
 require 'digest/md5'
 
 describe Synchronize::Mailchimp::Subscriber do
-  let(:user)         { people(:top_leader) }
+  let(:person)       { people(:top_leader) }
   let(:mailing_list) { mailing_lists(:leaders) }
 
   before do
-    mailing_list.subscriptions.create!(subscriber: user)
+    mailing_list.subscriptions.create!(subscriber: person)
+    person.additional_emails <<
+      AdditionalEmail.new(label: 'vater', email: 'vater@example.com', mailings: true)
   end
 
   subject { described_class.mailing_list_subscribers(mailing_list) }
@@ -17,8 +19,19 @@ describe Synchronize::Mailchimp::Subscriber do
     end
 
     it 'returns subscriber containing person' do
-      expect(subject.first.email).to eq(user.email)
-      expect(subject.first.person).to eq(user)
+      expect(subject.first.email).to eq(person.email)
+      expect(subject.first.person).to eq(person)
+    end
+  end
+
+  context 'mailing list with include_additional_emails' do
+    before do
+      mailing_list.include_additional_emails = true
+    end
+
+    it 'returns an entry per people and address (default and additional)' do
+      expect(subject.count).to eq(2)
+      expect(subject.map(&:email)).to eq([person.email, 'vater@example.com'])
     end
   end
 end

--- a/spec/domain/synchronize/mailchimp/subscriber_spec.rb
+++ b/spec/domain/synchronize/mailchimp/subscriber_spec.rb
@@ -3,35 +3,50 @@ require 'digest/md5'
 
 describe Synchronize::Mailchimp::Subscriber do
   let(:person)       { people(:top_leader) }
-  let(:mailing_list) { mailing_lists(:leaders) }
 
-  before do
-    mailing_list.subscriptions.create!(subscriber: person)
-    person.additional_emails <<
-      AdditionalEmail.new(label: 'vater', email: 'vater@example.com', mailings: true)
-  end
+  context "subscriber instance" do
+    let(:subscriber) { described_class.new(person, "test@example.com") }
 
-  subject { described_class.mailing_list_subscribers(mailing_list) }
-
-  context 'basic mailing list' do
-    it 'returns all people once' do
-      expect(subject.count).to eq(1)
+    it "acts as proxy to person" do
+      expect(subscriber.id).to eq(person.id)
     end
 
-    it 'returns subscriber containing person' do
-      expect(subject.first.email).to eq(person.email)
-      expect(subject.first.person).to eq(person)
+    it "returns given email address instead of person's" do
+      expect(subscriber.email).to eq("test@example.com")
     end
   end
 
-  context 'mailing list with mailchimp_include_additional_emails' do
+  context '#mailing_list_subscribers (synchronization strategies)' do
+    let(:mailing_list) { mailing_lists(:leaders) }
+
     before do
-      mailing_list.mailchimp_include_additional_emails = true
+      mailing_list.subscriptions.create!(subscriber: person)
+      person.additional_emails <<
+        AdditionalEmail.new(label: 'vater', email: 'vater@example.com', mailings: true)
     end
 
-    it 'returns an entry per people and address (default and additional)' do
-      expect(subject.count).to eq(2)
-      expect(subject.map(&:email)).to eq([person.email, 'vater@example.com'])
+    subject { described_class.mailing_list_subscribers(mailing_list) }
+
+    context 'default strategy' do
+      it 'returns all people once' do
+        expect(subject.count).to eq(1)
+      end
+
+      it 'returns subscriber containing person' do
+        expect(subject.first.email).to eq(person.email)
+        expect(subject.first.person).to eq(person)
+      end
+    end
+
+    context 'strategy to include additional emails' do
+      before do
+        mailing_list.mailchimp_include_additional_emails = true
+      end
+
+      it 'returns an entry per person and email (default and additional)' do
+        expect(subject.count).to eq(2)
+        expect(subject.map(&:email)).to eq([person.email, 'vater@example.com'])
+      end
     end
   end
 end

--- a/spec/domain/synchronize/mailchimp/subscriber_spec.rb
+++ b/spec/domain/synchronize/mailchimp/subscriber_spec.rb
@@ -24,9 +24,9 @@ describe Synchronize::Mailchimp::Subscriber do
     end
   end
 
-  context 'mailing list with include_additional_emails' do
+  context 'mailing list with mailchimp_include_additional_emails' do
     before do
-      mailing_list.include_additional_emails = true
+      mailing_list.mailchimp_include_additional_emails = true
     end
 
     it 'returns an entry per people and address (default and additional)' do


### PR DESCRIPTION
### Absicht

Bei der PBS gibt es den Bedarf, dass gewisse Abo-Versände nicht nur an die Haupt-Email der Abonnent*innen, sondern auch an alle «weiteren Emails» mit der Option «Versand» geschickt werden. Das soll möglich, aber optional sein: Das Standardverhalten mit den Haupt-Emails soll nicht geändert werden.

### Lösungsvorschlag

Dieser PR verändert die Mailchimp-Synchronisierung so, dass sie nicht mehr jeweils eine Person und deren Haupt-Email direkt synchronisiert, sondern ein neues Daten-Paar (Person, Email). In einem zweiten Schritt wird dann über ein neues Flag `mailchimp_include_additional_emails` möglich, das Synchronisierungsverhalten vom bisherigen Standard (nur Haupt-Email) auf das neue Verhalten (Haupt-Email plus alle Versand-Emails) zu ändern. Die commit history sollte dies wiederspiegeln.

### Offene Fragen

1. Ist die Namenskollision `Subscriber` schlimm 😬? Gibt es einen besseren Namen für den «Eintrag zum Synchronisieren»?
1. Hat die `Subscriber`-Klasse zuviel Kompetenzen (Synchronisierungsstrategien, Proxy für Person)?
1. Sollen die Verhalten der Mailchimp-Synchronisierung und Abo-Export angenähert werden? Sie weichen bereits jetzt ab (preferred labels), aber divergieren halt mit dieser Änderung noch mehr.

### Verknüpfungen

* [Issue im Trello «MiData Development»](https://trello.com/c/04VlCKgC/35-midata-z-38-anpassungen-an-mailchimp-schnittstelle)