### PR TITLE
Move Log-Tagging to production only

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,8 @@
+#  Copyright (c) 2012-2020, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
 require_relative 'boot'
 
 require 'rails/all'
@@ -61,8 +66,6 @@ module Hitobito
     config.active_job.queue_adapter = :delayed_job
 
     config.middleware.insert_before Rack::ETag, Rack::Deflater
-
-    config.log_tags = [:uuid]
 
     config.cache_store = :dalli_store, { compress: true,
                                          namespace: ENV['RAILS_HOST_NAME'] || 'hitobito' }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2019, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2020, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -99,6 +99,9 @@ Rails.application.configure do
     }
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  # allow to identify requests in the log
+  config.log_tags = [:uuid]
 
   config.lograge.enabled = true
   # Use a different logger for distributed setups.


### PR DESCRIPTION
Essentially: move it away from development, because there is it not as
helpful. Also, it generates a lot of noise in the test-log that no-one
ever will look at.

Am I missing something here?