### PR TITLE
Fix two course merging bugs

### DIFF
--- a/app/domain/event/participant_assigner.rb
+++ b/app/domain/event/participant_assigner.rb
@@ -97,11 +97,16 @@ class Event::ParticipantAssigner
   def update_answers
     current_answers = participation.answers.includes(:question)
     event.questions.each do |q|
-      exists = current_answers.any? do |a|
+      existing = current_answers.find do |a|
         a.question.question == q.question &&
-        a.question.choice_items == q.choice_items
+        a.question.choice_items == q.choice_items &&
+        a.question.multiple_choices == q.question.multiple_choices
       end
-      participation.answers.create(question_id: q.id) unless exists
+      if existing
+        existing.update(question: q)
+      else
+        participation.answers.create(question_id: q.id)
+      end
     end
   end
 

--- a/app/domain/event/participant_assigner.rb
+++ b/app/domain/event/participant_assigner.rb
@@ -100,7 +100,7 @@ class Event::ParticipantAssigner
       existing = current_answers.find do |a|
         a.question.question == q.question &&
         a.question.choice_items == q.choice_items &&
-        a.question.multiple_choices == q.question.multiple_choices
+        a.question.multiple_choices? == q.multiple_choices?
       end
       if existing
         existing.update(question: q)

--- a/app/domain/event/participant_assigner.rb
+++ b/app/domain/event/participant_assigner.rb
@@ -42,7 +42,7 @@ class Event::ParticipantAssigner
       set_active(false)
       # destroy all other roles when removing a participant
       participation.roles.where.not(type: event.participant_types.collect(&:sti_name)).destroy_all
-      original_event = participation.application.priority_1
+      original_event = participation.application.priority_1 || participation.event
       update_participation_event(original_event)
       original_event.refresh_participant_counts!
     end

--- a/spec/domain/event/participant_assigner_spec.rb
+++ b/spec/domain/event/participant_assigner_spec.rb
@@ -59,8 +59,9 @@ describe Event::ParticipantAssigner do
         expect { subject.add_participant }.to change { Event::Answer.count }.by(1)
 
         expect(participation.answers.count).to eq(3)
+        answered = participation.reload.answers.map {|answer| answer.question.id}
         event.questions.each do |question|
-          expect(participation.answers.map {|answer| answer.question.id}).to include(question.id)
+          expect(answered).to include(question.id)
         end
       end
 

--- a/spec/domain/event/participant_assigner_spec.rb
+++ b/spec/domain/event/participant_assigner_spec.rb
@@ -45,14 +45,23 @@ describe Event::ParticipantAssigner do
         quest = course.questions.first
         other = Fabricate(:course, groups: [groups(:top_layer)])
         other.questions << Fabricate(:event_question, event: other)
-        other.questions << Fabricate(:event_question, event: other, question: quest.question, choices: quest.choices)
+        other.questions << Fabricate(:event_question, event: other, question: quest.question, choices: quest.choices, multiple_choices: quest.multiple_choices)
         other
       end
 
-      it 'updates answers for other event' do
-        expect { subject.add_participant }.to change { Event::Answer.count }.by(1)
+      it 'updates participation' do
+        subject.add_participant
 
         expect(participation.event_id).to eq(event.id)
+      end
+
+      it 'updates answers so that every question of the new course has an answer' do
+        expect { subject.add_participant }.to change { Event::Answer.count }.by(1)
+
+        expect(participation.answers.count).to eq(3)
+        event.questions.each do |question|
+          expect(participation.answers.map {|answer| answer.question.id}).to include(question.id)
+        end
       end
 
       it 'raises error on existing participation' do

--- a/spec/domain/event/participant_assigner_spec.rb
+++ b/spec/domain/event/participant_assigner_spec.rb
@@ -81,6 +81,14 @@ describe Event::ParticipantAssigner do
       expect(Event::Participation.where(id: participation.id).exists?).to be_truthy
     end
 
+    it 'works even when the course in priority_1 does not exist anymore' do
+      participation.application.update_attribute('priority_1_id', '99999')
+      subject.remove_participant
+      participation.reload
+      expect(participation).not_to be_active
+      expect(Event::Participation.where(id: participation.id).exists?).to be_truthy
+    end
+
     context 'roundtrip' do
       let(:event) { Fabricate(:course, groups: [groups(:top_layer)]) }
 


### PR DESCRIPTION
Beim Zusammenlegen von zwei Kursen wurden zwei Bugs bemerkt, die hier gefixt werden sollen.

Die TN wurden im abgesagten Kurs in die Warteliste verschoben, dann im zusammengelegten Kurs aus der Warteliste hinzugefügt. Der abgesagte Kurs wurde dann gelöscht. Die verschobenen TN hatten dann aber immer noch die id des gelöschten Events in ihrer application.priority_1_id. Versucht man dann einen solchen TN von "zugeteilte Teilnehmende" zurück auf "Anmeldungen" zu verschieben, wird versucht den TN in den priority_1 Kurs zu verschieben, was fehlschlägt. Die Lösung ist, den TN in einem solchen Fall im Kurs zu belassen (in der Spalte "angemeldet", nicht "zugeteilt").

Ein zweiter, Bug sind fehlende Answers (Anmelde- und Administrationsangaben) nach dem Verschieben via Warteliste und Löschen des alten Kurses. Dieser tritt nur in sehr spezifischen Umständen auf. Wenn die TN via Warteliste in einen neuen Kurs verschoben werden, werden die Questions des alten Kurses mit denen des neuen Kurses verglichen. Questions die in "question" und "choice_items" zwischen den Kursen übereinstimmen werden als gleichwertig betrachtet, und die dazugehörige Answer wurde bisher nicht abgeändert. So gehörte die Answer aber immer noch zur alten Question im alten Kurs, und wenn alte Question oder alter Kurs gelöscht wurde, dann wurde auch die Answer mitgelöscht. Neu werden die gematchten Answers auf die neue Question im neuen Kurs übertragen. Ausserdem muss nun zusätzlich zu "question" und "choice_items" auch noch "multiple_choices" übereinstimmen, damit eine Frage als gleichwertig angesehen wird.