### PR TITLE
Set root password in development

### DIFF
--- a/db/seeds/development/root.rb
+++ b/db/seeds/development/root.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+
+#  Copyright (c) 2020, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+Person.first.update!(password: 'hito42bito', first_name: 'Puzzle', last_name: 'ITC', birthday: '1999-09-09')


### PR DESCRIPTION
Replaces #993 
Better to only do this in the development seeds. Thanks @kronn 
The other fields (firstname, lastname, birth date) are necessary to set because they are required in some wagons.

See hitobito/development#3