### PR TITLE
Re-enable configuring dev mail setting via env variables

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,27 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Mail sender
+  config.action_mailer.delivery_method = (ENV['RAILS_MAIL_DELIVERY_METHOD'].presence || :smtp).to_sym
+
+  if ENV['RAILS_MAIL_DELIVERY_CONFIG'].present?
+    case config.action_mailer.delivery_method
+    when :smtp
+      config.action_mailer.smtp_settings =
+          YAML.load("{ #{ENV['RAILS_MAIL_DELIVERY_CONFIG']} }").symbolize_keys
+    when :sendmail
+      config.action_mailer.sendmail_settings =
+          YAML.load("{ #{ENV['RAILS_MAIL_DELIVERY_CONFIG']} }").symbolize_keys
+    end
+  end
+
+  ssl = %w(true yes 1).include?(ENV['RAILS_HOST_SSL'])
+  config.action_mailer.default_url_options = {
+      host: (ENV['RAILS_HOST_NAME'] || raise("No environment variable RAILS_HOST_NAME set!")),
+      protocol: (ssl ? 'https' : 'http'),
+      locale: nil
+  }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 


### PR DESCRIPTION
In https://github.com/hitobito/hitobito/commit/3c63e9062e13693d294bcbc410a8f0daee35ed23#diff-a2f09e1db7a47eb67c5849478a97f3d7 support for configuring mail via environment variables was removed during the Rails 6 upgrade. This PR reinstates this possibility, since it is needed for both the [old](https://github.com/nxt-engineering/hitobito-docker/commit/b399f2bb800954385d0f29827dfaaf3f1583a562) and [new](https://github.com/hitobito/development/issues/5) Docker setups.

This re-introduces the need for an environment variable `RAILS_HOST_NAME` - is there a better way of doing this? Would a default of `localhost:3000` be sufficient for general non-Docker-based setups?