### PR TITLE
Human-readable VERSION for Sentry

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -111,7 +111,9 @@ module Hitobito
     end
 
     def self.versions(file = Rails.root.join('WAGON_VERSIONS'))
-      @versions ||= file.exist? ? file.read.lines.reject(&:blank?) : []
+      @versions ||= {}
+      @versions[file] ||= (file.exist? ? file.read.lines.reject(&:blank?) : nil)
+      @versions[file].to_a
     end
 
     def self.build_info

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,9 +1,7 @@
 Raven.configure do |config|
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 
-  if ENV['OPENSHIFT_BUILD_COMMIT']
-    config.release = ENV['OPENSHIFT_BUILD_COMMIT']
-  end
+  config.release = Rails.application.class.versions(Rails.root.join('VERSION')).first.chomp
 
   if ENV['SENTRY_CURRENT_ENV'].blank?
     project, stage = [


### PR DESCRIPTION
While the OPENSHIFT_BUILD_COMMIT is technically correct and unique, it is far from human-parseable. Since we now update the VERSION with every release, we can use that as release-information.