### PR TITLE
Simplify dev mail config

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,26 +36,16 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  # Mail sender
-  config.action_mailer.delivery_method = (ENV['RAILS_MAIL_DELIVERY_METHOD'].presence || :smtp).to_sym
-
-  if ENV['RAILS_MAIL_DELIVERY_CONFIG'].present?
-    case config.action_mailer.delivery_method
-    when :smtp
-      config.action_mailer.smtp_settings =
-          YAML.load("{ #{ENV['RAILS_MAIL_DELIVERY_CONFIG']} }").symbolize_keys
-    when :sendmail
-      config.action_mailer.sendmail_settings =
-          YAML.load("{ #{ENV['RAILS_MAIL_DELIVERY_CONFIG']} }").symbolize_keys
-    end
+  if ENV['RAILS_MAIL_DELIVERY_CONFIG'].present? && ENV['RAILS_HOST_NAME'].present?
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.default_url_options = {
+        host: ENV['RAILS_HOST_NAME'],
+        protocol: 'http',
+        locale: nil
+    }
+    config.action_mailer.smtp_settings =
+        YAML.load("{ #{ENV['RAILS_MAIL_DELIVERY_CONFIG']} }").symbolize_keys
   end
-
-  ssl = %w(true yes 1).include?(ENV['RAILS_HOST_SSL'])
-  config.action_mailer.default_url_options = {
-      host: (ENV['RAILS_HOST_NAME'] || raise("No environment variable RAILS_HOST_NAME set!")),
-      protocol: (ssl ? 'https' : 'http'),
-      locale: nil
-  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,16 +36,15 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  if ENV['RAILS_MAIL_DELIVERY_CONFIG'].present? && ENV['RAILS_HOST_NAME'].present?
+  if ENV['RAILS_MAIL_DELIVERY_CONFIG'].present?
     config.action_mailer.delivery_method = :smtp
-    config.action_mailer.default_url_options = {
-        host: ENV['RAILS_HOST_NAME'],
-        protocol: 'http',
-        locale: nil
-    }
     config.action_mailer.smtp_settings =
         YAML.load("{ #{ENV['RAILS_MAIL_DELIVERY_CONFIG']} }").symbolize_keys
   end
+
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch('RAILS_HOST_NAME', 'localhost:3000'),
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
`RAILS_HOST_NAME` is not required anymore if you are not using the Docker setup