### PR TITLE
OAuth authorizations German spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 *  Icons in der Suche
 *  Neue API-Endpoints für Gruppen-Hierarchie und Abos
 *  Berechtigungen werden im OAuth-Profil mitgeliefert
-*  Eigene OAuth-Authorisierungen können entfernt werden
+*  Eigene OAuth-Autorisierungen können entfernt werden
 *  Generelle Validierung von E-Mail Adressen
 
 ## Version 1.21

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -830,7 +830,7 @@ de:
     courses: 'Kurse'
     admin: 'Einstellungen'
     admin/event_feed: 'Kalender integrieren'
-    admin/oauth_authorizations: 'OAuth-Authorisierungen'
+    admin/oauth_authorizations: 'OAuth-Autorisierungen'
     invoices: 'Rechnungen'
 
   notes:


### PR DESCRIPTION
The correct German spelling for authorizations is 'Autorisierungen' (without the 'h', I'm also confused by this). These are the only two places where I found it misspelt. Compare https://www.duden.de/rechtschreibung/Autorisierung.