### PR TITLE
Mailchimp export without Names

### DIFF
--- a/app/controllers/mailing_lists_controller.rb
+++ b/app/controllers/mailing_lists_controller.rb
@@ -13,7 +13,8 @@ class MailingListsController < CrudController
                           :additional_sender, :subscribable, :subscribers_may_post,
                           :anyone_may_post, :main_email, :delivery_report,
                           :mailchimp_list_id, :mailchimp_api_key,
-                          :mailchimp_include_additional_emails, preferred_labels: []]
+                          :mailchimp_include_additional_emails, :mailchimp_include_names,
+                          preferred_labels: []]
 
   decorates :group, :mailing_list
 

--- a/app/domain/synchronize/mailchimp/subscriber.rb
+++ b/app/domain/synchronize/mailchimp/subscriber.rb
@@ -26,6 +26,7 @@ module Synchronize
                                                   contactable_id: people.collect(&:id),
                                                   mailings: true).to_a
         people.flat_map do |person|
+          check_hiding_names(person, mailing_list)
           additional_email_subscribers = additional_emails.select do |additional_email|
             additional_email.contactable_id == person.id
           end.map do |additional_email|
@@ -37,6 +38,7 @@ module Synchronize
 
       def self.default_addresses(mailing_list)
         mailing_list.people.map do |person|
+          check_hiding_names(person, mailing_list)
           self.new(person, person.email)
         end
       end
@@ -51,6 +53,13 @@ module Synchronize
             hash[value] ||= []
             hash[value] << person.email
           end
+        end
+      end
+
+      def self.check_hiding_names(person, mailing_list)
+        if !mailing_list.mailchimp_include_names
+          person.first_name = ""
+          person.last_name = ""
         end
       end
 

--- a/app/views/mailing_lists/_attrs.html.haml
+++ b/app/views/mailing_lists/_attrs.html.haml
@@ -10,7 +10,8 @@
     - if can?(:edit, entry)
       = render_attrs(entry, :mailchimp_api_key,
                             :mailchimp_list_id,
-                            :mailchimp_include_additional_emails)
+                            :mailchimp_include_additional_emails,
+                            :mailchimp_include_names)
       - if entry.mailchimp? && entry.mailchimp_result
         = render_attrs(entry, :mailchimp_sync)
       = render_attrs(entry, :additional_sender)

--- a/app/views/mailing_lists/_form.html.haml
+++ b/app/views/mailing_lists/_form.html.haml
@@ -42,6 +42,7 @@
     = f.labeled_input_fields(:mailchimp_list_id, help: t('.help_mailchimp_sync'))
     = f.labeled_input_fields(:mailchimp_api_key)
     = f.labeled_boolean_field(:mailchimp_include_additional_emails)
+    = f.labeled_boolean_field(:mailchimp_include_names)
 
   %fieldset
     = f.indented do

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -615,6 +615,7 @@ de:
           partial: Teilweise
           failed: Fehlgeschlagen
         mailchimp_include_additional_emails: 'Alle Versandadressen synchronisieren'
+        mailchimp_include_names: 'Vor- und Nachname synchronisieren'
 
       mail_log:
         updated_at: Bearbeitet am

--- a/db/migrate/20200926193601_add_mailchimp_include_names_to_mailing_list.rb
+++ b/db/migrate/20200926193601_add_mailchimp_include_names_to_mailing_list.rb
@@ -1,0 +1,5 @@
+class AddMailchimpIncludeNamesToMailingList < ActiveRecord::Migration[6.0]
+  def change
+    add_column :mailing_lists, :mailchimp_include_names, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_18_085541) do
+ActiveRecord::Schema.define(version: 2020_09_26_193601) do
 
   create_table "additional_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "contactable_type", null: false
@@ -393,6 +393,7 @@ ActiveRecord::Schema.define(version: 2020_08_18_085541) do
     t.datetime "mailchimp_last_synced_at"
     t.text "mailchimp_result"
     t.boolean "mailchimp_include_additional_emails", default: false
+    t.boolean "mailchimp_include_names", default: false
     t.index ["group_id"], name: "index_mailing_lists_on_group_id"
   end
 


### PR DESCRIPTION
Including the option to only synchronize the mail address to Mailchimp