### PR TITLE
Doorkeeper issuer must be URL

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,7 +23,10 @@ application:
 
 <% mail_domain = ENV['RAILS_MAIL_DOMAIN'].presence ||
                  ENV['RAILS_HOST_NAME'].presence ||
-                 'localhost' %>
+                 'localhost'
+   hostname    = ENV['RAILS_HOST_NAME'].presence || 'localhost:3000'
+   protocol    = %w(true yes 1).include?(ENV['RAILS_HOST_SSL']) ? 'https' : 'http'
+%>
 currency:
   unit: CHF
 
@@ -182,7 +185,7 @@ worker_heartbeats:
     interval: 60
 
 oidc:
-  issuer: <%= ENV['RAILS_HOST_NAME'].presence || 'http://localhost:3000' %>
+  issuer: <%= protocol + "://" + hostname %>
   signing_key: <%= ENV['JWT_SIGNING_KEY'].to_s.lines %>
 
 table_displays: true


### PR DESCRIPTION
Gemäss RFC 8414 (https://tools.ietf.org/html/rfc8414)  und doorkeeper-gem (https://github.com/doorkeeper-gem/doorkeeper-openid_connect) muss `issuer` eine URL (eigentlich fix mit `https://`) sein.
Bisher wurde entweder `http://localhost:3000` oder `ENV['RAILS_HOST_NAME']` verwendet, was in beiden Fällen streng genommen falsch ist: die erste Variante ist ungültig wegen `http` statt `https`; die zweite ist ungültig, weil `https` fehlt.

Dieser Fix berücksichtigt allerdings `ENV['RAILS_HOST_SSL']` und erlaubt somit für Testing-Zwecke auch Issuers mit `http`-Protokoll.