### PR TITLE
Convert to utf8mb4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hitobito Changelog
 
+## unreleased
+
+*  Datenbank kann nun Emoji (also: alles aus Unicode) speichern
+
 ## Version 1.22
 
 *  Bugfix: Vergangene Anlässe werden nicht mehr auf der Person angezeigt (#847)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -305,15 +305,6 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
     end
   end
 
-  # Overwrite to handle improper characters
-  def save(*args)
-    super
-  rescue ActiveRecord::StatementInvalid => e
-    raise e unless e.cause.message =~ /Incorrect string value/
-    errors.add(:base, :emoji_suspected)
-    false
-  end
-
   private
 
   def assert_type_is_allowed_for_groups

--- a/app/models/event/participation.rb
+++ b/app/models/event/participation.rb
@@ -117,15 +117,6 @@ class Event::Participation < ActiveRecord::Base
     event.supports_applications && (application_id || role && role.class.participant?)
   end
 
-  # Overwrite to handle improper characters
-  def save(*args)
-    super
-  rescue ActiveRecord::StatementInvalid => e
-    raise e unless e.cause.message =~ /Incorrect string value/
-    errors.add(:base, :emoji_suspected)
-    false
-  end
-
   private
 
   def set_self_in_nested

--- a/app/models/mail_log.rb
+++ b/app/models/mail_log.rb
@@ -61,11 +61,6 @@ class MailLog < ActiveRecord::Base
     self.mail_hash = md5_hash(mail)
   end
 
-  def mail_subject=(value)
-    value = I18n.transliterate(value, '?') if value.present?
-    super(value)
-  end
-
   private
 
   def md5_hash(mail)

--- a/app/models/mail_log.rb
+++ b/app/models/mail_log.rb
@@ -1,5 +1,10 @@
 # encoding: utf-8
 
+#  Copyright (c) 2018-2020, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
 # == Schema Information
 #
 # Table name: mail_logs
@@ -14,12 +19,6 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #
-
-
-#  Copyright (c) 2018, Hitobito AG. This file is part of
-#  hitobito and licensed under the Affero General Public License version 3
-#  or later. See the COPYING file at the top-level directory or at
-#  https://github.com/hitobito/hitobito.
 
 class MailLog < ActiveRecord::Base
 
@@ -52,6 +51,7 @@ class MailLog < ActiveRecord::Base
 
   def exists?
     return false unless mail_hash
+
     self.class.exists?(mail_hash: mail_hash)
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -287,15 +287,11 @@ class Person < ActiveRecord::Base
     email == Settings.root_email
   end
 
-  # Overwrite to handle uniquness validation race conditions and improper characters
+  # Overwrite to handle uniquness validation race conditions
   def save(*args)
     super
   rescue ActiveRecord::RecordNotUnique
     errors.add(:email, :taken)
-    false
-  rescue ActiveRecord::StatementInvalid => e
-    raise e unless e.cause.message =~ /Incorrect string value/
-    errors.add(:base, :emoji_suspected)
     false
   end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ base: &generic
   timeout: 5000
 <% if ENV.fetch('RAILS_DB_ADAPTER', 'sqlite3') =~ /mysql/ %>
   encoding: 'utf8mb4'
-  collation: 'utf8mb4_bin'
+  collation: 'utf8mb4_general_ci' # case insensitive search is a feature
 <% else %>
   encoding: 'utf8'
 <% end %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,12 @@ base: &generic
   adapter: <%= ENV['RAILS_DB_ADAPTER'] || 'sqlite3' %>
   pool: 20
   timeout: 5000
-  encoding: utf8
+<% if ENV.fetch('RAILS_DB_ADAPTER', 'sqlite3') =~ /mysql/ %>
+  encoding: 'utf8mb4'
+  collation: 'utf8mb4_bin'
+<% else %>
+  encoding: 'utf8'
+<% end %>
 <% %w(host port username password socket).each do |option| %>
   <% value = ENV["RAILS_DB_#{option.upcase}"] %>
   <%= "#{option}: #{value}" if value.present? %>

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -56,7 +56,6 @@ de:
             choices:
               requires_more_than_one_choice: 'muss mindestens zwei Anworten enthalten'
         event/participation:
-          emoji_suspected: 'Bitte keine Sonderzeichen (insbesondere Emoji) verwenden'
           attributes:
             person_id:
               taken: ist bereits angemeldet
@@ -71,7 +70,6 @@ de:
               not_match_configured: "stimmen nicht mit denen am server hinterlegten überein."
         person:
           name_missing: 'Bitte geben Sie einen Namen ein'
-          emoji_suspected: 'Bitte keine Sonderzeichen (insbesondere Emoji) verwenden'
           readonly: ": Du hast nicht auf alle Personen aus dem Haushalt Schreibrechte. Entferne %{name} aus dem Haushalt, um die Adresse anzupassen."
           attributes:
             email:

--- a/config/locales/models.en.yml
+++ b/config/locales/models.en.yml
@@ -52,13 +52,11 @@ en:
             choices:
               requires_more_than_one_choice: 'needs at least two picks'
         event/participation:
-          emoji_suspected: 'Please don''t use any special characters (especially emojis).'
           attributes:
             person_id:
               taken: is already registered
         person:
           name_missing: 'Please enter a name'
-          emoji_suspected: 'Please don''t use any special characters (especially emojis).'
           attributes:
             email:
               taken: >

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -52,7 +52,6 @@ fr:
             choices:
               requires_more_than_one_choice: 'doit au moins contenir deux réponses'
         event/participation:
-          emoji_suspected: 'Prière de ne pas utiliser de caractères spéciaux (en particulier, des emoji)'
           attributes:
             person_id:
               taken: est déjà annoncé
@@ -62,7 +61,6 @@ fr:
               not_match_configured: "ne correspondent pas à celles du serveur."
         person:
           name_missing: 'Veuillez entrer votre nom'
-          emoji_suspected: 'Prière de ne pas utiliser de caractères spéciaux (en particulier, des emoji)'
           readonly: ": Tu n'as pas les droits d'écriture pour toutes les personnes du foyer. Sors %{name} du foyer pour ajuster l'adresse."
           attributes:
             email:

--- a/config/locales/models.it.yml
+++ b/config/locales/models.it.yml
@@ -52,7 +52,6 @@ it:
             choices:
               requires_more_than_one_choice: 'deve contenere almeno due risposte'
         event/participation:
-          emoji_suspected: 'Non utilizzare simboli speciali (in particolare Emoji)'
           attributes:
             person_id:
               taken: è già iscritto
@@ -62,7 +61,6 @@ it:
               not_match_configured: "non coincidono con quelle depositate sul server."
         person:
           name_missing: 'Inserire un nome'
-          emoji_suspected: 'Non utilizzare simboli speciali (in particolare Emoji)'
           readonly: "Non hai diritto di scrittura per tutte le persone del nucleo famigliare. Elimina %{name} dal nucleo famigliare per cambiare l'indirizzo."
           attributes:
             email:

--- a/db/migrate/20201012121723_convert_database_to_utf8mb4.rb
+++ b/db/migrate/20201012121723_convert_database_to_utf8mb4.rb
@@ -1,48 +1,11 @@
-# frozen_string_literal: true
-
 class ConvertDatabaseToUtf8mb4 < ActiveRecord::Migration[6.0]
   def up
-    conn = ActiveRecord::Base.connection
-
-    charset = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_bin'
-
-    conn.tables.each do |table|
-      next if table == 'ar_internal_metadata'
-
-      execute "ALTER TABLE #{table} CONVERT TO #{charset}"
-
-      conn.columns(table).each do |column|
-        case column.sql_type.downcase
-        when 'varchar(255)'
-          length = if has_index?(conn, table, column.name)
-                     191
-                   else
-                     255
-                   end
-
-          execute "ALTER TABLE #{table} MODIFY COLUMN #{conn.quote_column_name(column.name)} VARCHAR(#{length}) #{charset}"
-        when /varchar\(\d*\)/, 'text'
-          if column.limit > 191 && has_index?(conn, table, column.name)
-            raise <<~ERROR_MESSAGE
-              big column with index: #{table}.#{column.name}
-
-              we need to change the table-options to include ROW_FORMAT=DYNAMIC
-            ERROR_MESSAGE
-          end
-
-          execute "ALTER TABLE #{table} MODIFY COLUMN #{conn.quote_column_name(column.name)} #{column.sql_type.upcase} #{charset}"
-        end
-      end
+    ActiveRecord::Base.connection.tables.each do |table|
+      execute "ALTER TABLE #{table} CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin"
     end
   end
 
   def down
     # could raise ActiveRecord::IrreversibleMigration, but there is no point
-  end
-
-  def has_index?(conn, table_name, column_name)
-    conn.indexes(table_name).any? do |idx|
-      idx.columns.include?(column_name)
-    end
   end
 end

--- a/db/migrate/20201012121723_convert_database_to_utf8mb4.rb
+++ b/db/migrate/20201012121723_convert_database_to_utf8mb4.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class ConvertDatabaseToUtf8mb4 < ActiveRecord::Migration[6.0]
+  def up
+    conn = ActiveRecord::Base.connection
+
+    charset = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_bin'
+
+    conn.tables.each do |table|
+      next if table == 'ar_internal_metadata'
+
+      execute "ALTER TABLE #{table} CONVERT TO #{charset}"
+
+      conn.columns(table).each do |column|
+        case column.sql_type.downcase
+        when 'varchar(255)'
+          length = if has_index?(conn, table, column.name)
+                     191
+                   else
+                     255
+                   end
+
+          execute "ALTER TABLE #{table} MODIFY COLUMN #{conn.quote_column_name(column.name)} VARCHAR(#{length}) #{charset}"
+        when /varchar\(\d*\)/, 'text'
+          if column.limit > 191 && has_index?(conn, table, column.name)
+            raise <<~ERROR_MESSAGE
+              big column with index: #{table}.#{column.name}
+
+              we need to change the table-options to include ROW_FORMAT=DYNAMIC
+            ERROR_MESSAGE
+          end
+
+          execute "ALTER TABLE #{table} MODIFY COLUMN #{conn.quote_column_name(column.name)} #{column.sql_type.upcase} #{charset}"
+        end
+      end
+    end
+  end
+
+  def down
+    # could raise ActiveRecord::IrreversibleMigration, but there is no point
+  end
+
+  def has_index?(conn, table_name, column_name)
+    conn.indexes(table_name).any? do |idx|
+      idx.columns.include?(column_name)
+    end
+  end
+end

--- a/db/migrate/20201012121723_convert_database_to_utf8mb4.rb
+++ b/db/migrate/20201012121723_convert_database_to_utf8mb4.rb
@@ -1,7 +1,7 @@
 class ConvertDatabaseToUtf8mb4 < ActiveRecord::Migration[6.0]
   def up
     ActiveRecord::Base.connection.tables.each do |table|
-      execute "ALTER TABLE #{table} CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin"
+      execute "ALTER TABLE #{table} CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci"
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_084559) do
+ActiveRecord::Schema.define(version: 2020_10_12_121723) do
 
-  create_table "additional_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "additional_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "contactable_type", null: false
     t.integer "contactable_id", null: false
     t.string "email", null: false
@@ -22,29 +22,29 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["contactable_id", "contactable_type"], name: "index_additional_emails_on_contactable_id_and_contactable_type"
   end
 
-  create_table "custom_content_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "custom_content_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "custom_content_id", null: false
     t.string "locale", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "label", null: false
     t.string "subject"
-    t.text "body"
+    t.text "body", size: :medium
     t.index ["custom_content_id"], name: "index_custom_content_translations_on_custom_content_id"
     t.index ["locale"], name: "index_custom_content_translations_on_locale"
   end
 
-  create_table "custom_contents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "custom_contents", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "key", null: false
     t.string "placeholders_required"
     t.string "placeholders_optional"
   end
 
-  create_table "delayed_jobs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "delayed_jobs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "priority", default: 0
     t.integer "attempts", default: 0
-    t.text "handler"
-    t.text "last_error"
+    t.text "handler", size: :medium
+    t.text "last_error", size: :medium
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "delayed_workers", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "delayed_workers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name"
     t.string "version"
     t.datetime "last_heartbeat_at"
@@ -63,30 +63,30 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.string "label"
   end
 
-  create_table "event_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "event_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "participation_id", null: false
     t.integer "question_id", null: false
     t.string "answer"
     t.index ["participation_id", "question_id"], name: "index_event_answers_on_participation_id_and_question_id", unique: true
   end
 
-  create_table "event_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "event_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "priority_1_id", null: false
     t.integer "priority_2_id"
     t.integer "priority_3_id"
     t.boolean "approved", default: false, null: false
     t.boolean "rejected", default: false, null: false
     t.boolean "waiting_list", default: false, null: false
-    t.text "waiting_list_comment"
+    t.text "waiting_list_comment", size: :medium
   end
 
-  create_table "event_attachments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "event_attachments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "event_id", null: false
     t.string "file", null: false
     t.index ["event_id"], name: "index_event_attachments_on_event_id"
   end
 
-  create_table "event_dates", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "event_dates", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "event_id", null: false
     t.string "label"
     t.datetime "start_at"
@@ -96,7 +96,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["event_id"], name: "index_event_dates_on_event_id"
   end
 
-  create_table "event_kind_qualification_kinds", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "event_kind_qualification_kinds", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "event_kind_id", null: false
     t.integer "qualification_kind_id", null: false
     t.string "category", null: false
@@ -106,30 +106,30 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["role"], name: "index_event_kind_qualification_kinds_on_role"
   end
 
-  create_table "event_kind_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "event_kind_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "event_kind_id", null: false
     t.string "locale", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "label", null: false
     t.string "short_name"
-    t.text "general_information"
-    t.text "application_conditions"
+    t.text "general_information", size: :medium
+    t.text "application_conditions", size: :medium
     t.index ["event_kind_id"], name: "index_event_kind_translations_on_event_kind_id"
     t.index ["locale"], name: "index_event_kind_translations_on_locale"
   end
 
-  create_table "event_kinds", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "event_kinds", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
     t.integer "minimum_age"
   end
 
-  create_table "event_participations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "event_participations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "event_id", null: false
     t.integer "person_id", null: false
-    t.text "additional_information"
+    t.text "additional_information", size: :medium
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "active", default: false, null: false
@@ -141,7 +141,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["person_id"], name: "index_event_participations_on_person_id"
   end
 
-  create_table "event_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "event_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "event_id"
     t.string "question"
     t.string "choices"
@@ -151,7 +151,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["event_id"], name: "index_event_questions_on_event_id"
   end
 
-  create_table "event_roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "event_roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "type", null: false
     t.integer "participation_id", null: false
     t.string "label"
@@ -159,7 +159,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["type"], name: "index_event_roles_on_type"
   end
 
-  create_table "events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "type"
     t.string "name", null: false
     t.string "number"
@@ -167,11 +167,11 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.string "cost"
     t.integer "maximum_participants"
     t.integer "contact_id"
-    t.text "description"
-    t.text "location"
+    t.text "description", size: :medium
+    t.text "location", size: :medium
     t.date "application_opening_at"
     t.date "application_closing_at"
-    t.text "application_conditions"
+    t.text "application_conditions", size: :medium
     t.integer "kind_id"
     t.string "state", limit: 60
     t.boolean "priorization", default: false, null: false
@@ -189,19 +189,19 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.integer "creator_id"
     t.integer "updater_id"
     t.boolean "applications_cancelable", default: false, null: false
-    t.text "required_contact_attrs"
-    t.text "hidden_contact_attrs"
+    t.text "required_contact_attrs", size: :medium
+    t.text "hidden_contact_attrs", size: :medium
     t.boolean "display_booking_info", default: true, null: false
     t.index ["kind_id"], name: "index_events_on_kind_id"
   end
 
-  create_table "events_groups", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "events_groups", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "event_id"
     t.integer "group_id"
     t.index ["event_id", "group_id"], name: "index_events_groups_on_event_id_and_group_id", unique: true
   end
 
-  create_table "groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "groups", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "parent_id"
     t.integer "lft"
     t.integer "rgt"
@@ -222,7 +222,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.integer "updater_id"
     t.integer "deleter_id"
     t.boolean "require_person_add_requests", default: false, null: false
-    t.text "description"
+    t.text "description", size: :medium
     t.string "logo"
     t.index ["layer_group_id"], name: "index_groups_on_layer_group_id"
     t.index ["lft", "rgt"], name: "index_groups_on_lft_and_rgt"
@@ -230,17 +230,17 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["type"], name: "index_groups_on_type"
   end
 
-  create_table "help_text_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "help_text_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "help_text_id", null: false
     t.string "locale", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.text "body"
+    t.text "body", size: :medium
     t.index ["help_text_id"], name: "index_help_text_translations_on_help_text_id"
     t.index ["locale"], name: "index_help_text_translations_on_locale"
   end
 
-  create_table "help_texts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "help_texts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "controller", limit: 100, null: false
     t.string "model", limit: 100
     t.string "kind", limit: 100, null: false
@@ -248,10 +248,10 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["controller", "model", "kind", "name"], name: "index_help_texts_fields", unique: true
   end
 
-  create_table "invoice_articles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "invoice_articles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "number"
     t.string "name", null: false
-    t.text "description"
+    t.text "description", size: :medium
     t.string "category"
     t.decimal "unit_cost", precision: 12, scale: 2
     t.decimal "vat_rate", precision: 5, scale: 2
@@ -263,17 +263,17 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["number", "group_id"], name: "index_invoice_articles_on_number_and_group_id", unique: true
   end
 
-  create_table "invoice_configs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "invoice_configs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "sequence_number", default: 1, null: false
     t.integer "due_days", default: 30, null: false
     t.integer "group_id", null: false
-    t.text "address"
-    t.text "payment_information"
+    t.text "address", size: :medium
+    t.text "payment_information", size: :medium
     t.string "account_number"
     t.string "iban"
     t.string "payment_slip", default: "ch_es", null: false
-    t.text "beneficiary"
-    t.text "payee"
+    t.text "beneficiary", size: :medium
+    t.text "payee", size: :medium
     t.string "participant_number"
     t.string "email"
     t.string "participant_number_internal"
@@ -282,10 +282,10 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["group_id"], name: "index_invoice_configs_on_group_id"
   end
 
-  create_table "invoice_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "invoice_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "invoice_id", null: false
     t.string "name", null: false
-    t.text "description"
+    t.text "description", size: :medium
     t.decimal "vat_rate", precision: 5, scale: 2
     t.decimal "unit_cost", precision: 12, scale: 2, null: false
     t.integer "count", default: 1, null: false
@@ -294,14 +294,14 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["invoice_id"], name: "index_invoice_items_on_invoice_id"
   end
 
-  create_table "invoices", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "invoices", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", null: false
     t.string "sequence_number", null: false
     t.string "state", default: "draft", null: false
     t.string "esr_number", null: false
-    t.text "description"
+    t.text "description", size: :medium
     t.string "recipient_email"
-    t.text "recipient_address"
+    t.text "recipient_address", size: :medium
     t.date "sent_at"
     t.date "due_at"
     t.integer "group_id", null: false
@@ -310,14 +310,14 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "account_number"
-    t.text "address"
+    t.text "address", size: :medium
     t.date "issued_at"
     t.string "iban"
-    t.text "payment_purpose"
-    t.text "payment_information"
+    t.text "payment_purpose", size: :medium
+    t.text "payment_information", size: :medium
     t.string "payment_slip", default: "ch_es", null: false
-    t.text "beneficiary"
-    t.text "payee"
+    t.text "beneficiary", size: :medium
+    t.text "payee", size: :medium
     t.string "participant_number"
     t.integer "creator_id"
     t.string "participant_number_internal"
@@ -329,7 +329,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["sequence_number"], name: "index_invoices_on_sequence_number"
   end
 
-  create_table "label_format_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "label_format_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "label_format_id", null: false
     t.string "locale", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -339,7 +339,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["locale"], name: "index_label_format_translations_on_locale"
   end
 
-  create_table "label_formats", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "label_formats", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "page_size", default: "A4", null: false
     t.boolean "landscape", default: false, null: false
     t.float "font_size", default: 11.0, null: false
@@ -354,14 +354,14 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.string "pp_post", limit: 23
   end
 
-  create_table "locations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "locations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "canton", limit: 2, null: false
     t.string "zip_code", null: false
     t.index ["zip_code", "canton", "name"], name: "index_locations_on_zip_code_and_canton_and_name", unique: true
   end
 
-  create_table "mail_logs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "mail_logs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "mail_from"
     t.string "mail_subject"
     t.string "mail_hash"
@@ -374,10 +374,10 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["mailing_list_id"], name: "index_mail_logs_on_mailing_list_id"
   end
 
-  create_table "mailing_lists", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "mailing_lists", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.integer "group_id", null: false
-    t.text "description"
+    t.text "description", size: :medium
     t.string "publisher"
     t.string "mail_name"
     t.string "additional_sender"
@@ -391,27 +391,27 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.string "mailchimp_list_id"
     t.boolean "mailchimp_syncing", default: false
     t.datetime "mailchimp_last_synced_at"
-    t.text "mailchimp_result"
+    t.text "mailchimp_result", size: :medium
     t.boolean "mailchimp_include_additional_emails", default: false
     t.index ["group_id"], name: "index_mailing_lists_on_group_id"
   end
 
-  create_table "notes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "notes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "subject_id", null: false
     t.integer "author_id", null: false
-    t.text "text"
+    t.text "text", size: :medium
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "subject_type"
     t.index ["subject_id"], name: "index_notes_on_subject_id"
   end
 
-  create_table "oauth_access_grants", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "oauth_access_grants", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
     t.integer "application_id", null: false
     t.string "token", null: false
     t.integer "expires_in", null: false
-    t.text "redirect_uri", null: false
+    t.text "redirect_uri", size: :medium, null: false
     t.datetime "created_at", null: false
     t.datetime "revoked_at"
     t.string "scopes"
@@ -419,7 +419,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
-  create_table "oauth_access_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "oauth_access_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "resource_owner_id"
     t.integer "application_id"
     t.string "token", null: false
@@ -435,11 +435,11 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
   end
 
-  create_table "oauth_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "oauth_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "uid", null: false
     t.string "secret", null: false
-    t.text "redirect_uri", null: false
+    t.text "redirect_uri", size: :medium, null: false
     t.string "scopes", default: "", null: false
     t.boolean "confidential", default: true, null: false
     t.datetime "created_at", null: false
@@ -447,13 +447,13 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  create_table "oauth_openid_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "oauth_openid_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "access_grant_id", null: false
     t.string "nonce", null: false
     t.index ["access_grant_id"], name: "fk_rails_77114b3b09"
   end
 
-  create_table "payment_reminder_configs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "payment_reminder_configs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "invoice_config_id", null: false
     t.string "title", null: false
     t.string "text", null: false
@@ -462,7 +462,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["invoice_config_id"], name: "index_payment_reminder_configs_on_invoice_config_id"
   end
 
-  create_table "payment_reminders", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "payment_reminders", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "invoice_id", null: false
     t.date "due_at", null: false
     t.datetime "created_at", null: false
@@ -473,7 +473,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["invoice_id"], name: "index_payment_reminders_on_invoice_id"
   end
 
-  create_table "payments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "payments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "invoice_id", null: false
     t.decimal "amount", precision: 12, scale: 2, null: false
     t.date "received_at", null: false
@@ -481,7 +481,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["invoice_id"], name: "index_payments_on_invoice_id"
   end
 
-  create_table "people", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "people", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.string "company_name"
@@ -494,7 +494,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.string "country"
     t.string "gender", limit: 1
     t.date "birthday"
-    t.text "additional_information"
+    t.text "additional_information", size: :medium
     t.boolean "contact_data_visible", default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -527,18 +527,18 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["unlock_token"], name: "index_people_on_unlock_token", unique: true
   end
 
-  create_table "people_filters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "people_filters", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.integer "group_id"
     t.string "group_type"
-    t.text "filter_chain"
+    t.text "filter_chain", size: :medium
     t.string "range", default: "deep"
     t.timestamp "created_at"
     t.timestamp "updated_at"
     t.index ["group_id", "group_type"], name: "index_people_filters_on_group_id_and_group_type"
   end
 
-  create_table "people_relations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "people_relations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "head_id", null: false
     t.integer "tail_id", null: false
     t.string "kind", null: false
@@ -546,13 +546,13 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["tail_id"], name: "index_people_relations_on_tail_id"
   end
 
-  create_table "person_add_request_ignored_approvers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "person_add_request_ignored_approvers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "group_id", null: false
     t.integer "person_id", null: false
     t.index ["group_id", "person_id"], name: "person_add_request_ignored_approvers_index", unique: true
   end
 
-  create_table "person_add_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "person_add_requests", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "person_id", null: false
     t.integer "requester_id", null: false
     t.string "type", null: false
@@ -563,7 +563,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["type", "body_id"], name: "index_person_add_requests_on_type_and_body_id"
   end
 
-  create_table "phone_numbers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "phone_numbers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "contactable_type", null: false
     t.integer "contactable_id", null: false
     t.string "number", null: false
@@ -572,7 +572,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["contactable_id", "contactable_type"], name: "index_phone_numbers_on_contactable_id_and_contactable_type"
   end
 
-  create_table "qualification_kind_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "qualification_kind_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "qualification_kind_id", null: false
     t.string "locale", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -583,7 +583,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["qualification_kind_id"], name: "index_qualification_kind_translations_on_qualification_kind_id"
   end
 
-  create_table "qualification_kinds", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "qualification_kinds", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "validity"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -591,7 +591,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.integer "reactivateable"
   end
 
-  create_table "qualifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "qualifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "person_id", null: false
     t.integer "qualification_kind_id", null: false
     t.date "start_at", null: false
@@ -601,7 +601,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["qualification_kind_id"], name: "index_qualifications_on_qualification_kind_id"
   end
 
-  create_table "related_role_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "related_role_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "relation_id"
     t.string "role_type", null: false
     t.string "relation_type"
@@ -609,7 +609,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["role_type"], name: "index_related_role_types_on_role_type"
   end
 
-  create_table "roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "roles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "person_id", null: false
     t.integer "group_id", null: false
     t.string "type", null: false
@@ -621,10 +621,10 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["type"], name: "index_roles_on_type"
   end
 
-  create_table "service_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "service_tokens", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "layer_group_id", null: false
     t.string "name", null: false
-    t.text "description"
+    t.text "description", size: :medium
     t.string "token", null: false
     t.datetime "last_access"
     t.boolean "people", default: false
@@ -638,16 +638,16 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.boolean "mailing_lists", default: false, null: false
   end
 
-  create_table "sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "sessions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "session_id", null: false
-    t.text "data"
+    t.text "data", size: :medium
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["session_id"], name: "index_sessions_on_session_id"
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "social_accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "social_accounts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "contactable_type", null: false
     t.integer "contactable_id", null: false
     t.string "name", null: false
@@ -656,7 +656,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["contactable_id", "contactable_type"], name: "index_social_accounts_on_contactable_id_and_contactable_type"
   end
 
-  create_table "subscriptions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "subscriptions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "mailing_list_id", null: false
     t.string "subscriber_type", null: false
     t.integer "subscriber_id", null: false
@@ -665,14 +665,14 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["subscriber_id", "subscriber_type"], name: "index_subscriptions_on_subscriber_id_and_subscriber_type"
   end
 
-  create_table "table_displays", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "table_displays", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "type", null: false
     t.integer "person_id", null: false
-    t.text "selected"
+    t.text "selected", size: :medium
     t.index ["person_id", "type"], name: "index_table_displays_on_person_id_and_type", unique: true
   end
 
-  create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "tag_id"
     t.string "taggable_type"
     t.integer "taggable_id"
@@ -685,19 +685,19 @@ ActiveRecord::Schema.define(version: 2020_09_24_084559) do
     t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
   end
 
-  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
-    t.string "name", collation: "utf8_bin"
+  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name"
     t.integer "taggings_count", default: 0
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
-  create_table "versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "versions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
-    t.text "object"
-    t.text "object_changes"
+    t.text "object", size: :medium
+    t.text "object_changes", size: :medium
     t.string "main_type"
     t.integer "main_id"
     t.datetime "created_at"

--- a/spec/controllers/event/participations_controller_spec.rb
+++ b/spec/controllers/event/participations_controller_spec.rb
@@ -515,12 +515,11 @@ describe Event::ParticipationsController do
         expect(assigns(:participation).additional_information).to eq('Vegetarier')
       end
 
-      it 'handles DB-errors for too wide unicode characters (emoji)', :mysql do
-        expect do
-          post :create, params: { group_id: group.id, event_id: course.id, event_participation: { additional_information: 'Vegetarier😝'} }
+      it 'can handle wide unicode characters (esp. emoji)', :mysql do
+        post :create, params: { group_id: group.id, event_id: course.id, event_participation: { additional_information: 'Vegetarier😝'} }
 
-          expect(assigns(:participation).errors.messages).to have(1).keys
-        end.to_not raise_error
+        expect(assigns(:participation)).to be_valid
+        expect(assigns(:participation).additional_information).to eq('Vegetarier😝')
       end
     end
 

--- a/spec/domain/mail_relay/base_spec.rb
+++ b/spec/domain/mail_relay/base_spec.rb
@@ -225,7 +225,6 @@ describe MailRelay::Base do
       expect(mail_log.status).to eq('completed')
     end
 
-    # our mysql instances to not support storeing emojis
     it 'creates mail log entry for mail with emoji in subject' do
       emoji_subject = "⛴ Unvergessliche Erlebnisse"
       simple.subject = emoji_subject
@@ -239,7 +238,7 @@ describe MailRelay::Base do
       end.to change { MailLog.count }.by(1)
 
       mail_log = MailLog.find_by(mail_hash: 'e63f22f5d97d8030174951265555794f')
-      expect(mail_log.mail_subject).to eq("? Unvergessliche Erlebnisse")
+      expect(mail_log.mail_subject).to eq("⛴ Unvergessliche Erlebnisse")
       expect(mail_log.mail_from).to eq(simple.from.first)
       expect(mail_log.status).to eq('completed')
     end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -72,11 +72,10 @@ describe Person do
     expect(Person.new(company: false, company_name: 'foo')).to have(1).errors_on(:base)
   end
 
-  it 'cannot be saved with emoji', :mysql do
+  it 'can be saved with emoji', :mysql do
     person = Person.new(company: false, nickname: 'foo', additional_information: ' Vegetarier😝 ')
-    expect(person.save).to be false
-    expect(person.errors.messages[:base].size).to be 1
-    expect(person.errors.messages[:base].first).to match /emoji/i
+    expect(person.save).to be true
+    expect(person.errors.messages[:base].size).to be_zero
   end
 
   it 'with login role does not require email' do


### PR DESCRIPTION
Fixes #98, #864, #398 

Bei einer verhältinismäßig großen DB gab es keine deutlich sichtbare Vergrößerung des Speicherplatzbedarfs, die Migration lief (lokal) in unter einer Minute fehlerfrei durch. Da utf8mb4 ein klares superset von utf8 und damit auch von latin1 ist, gibt es keine Konvertierungsprobleme. Es kann einfach mehr gespeichert werden.