### PR TITLE
Allow custom content creation in new language

### DIFF
--- a/app/controllers/custom_contents_controller.rb
+++ b/app/controllers/custom_contents_controller.rb
@@ -7,7 +7,7 @@
 
 class CustomContentsController < SimpleCrudController
 
-  self.permitted_attrs = [:body, :subject]
+  self.permitted_attrs = [:label, :body, :subject]
 
   self.sort_mappings = { label: 'custom_content_translations.label',
                          subject: 'custom_content_translations.subject',

--- a/app/controllers/custom_contents_controller.rb
+++ b/app/controllers/custom_contents_controller.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2020, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -9,9 +9,9 @@ class CustomContentsController < SimpleCrudController
 
   self.permitted_attrs = [:body, :subject]
 
-  self.sort_mappings = { label:   'custom_content_translations.label',
+  self.sort_mappings = { label: 'custom_content_translations.label',
                          subject: 'custom_content_translations.subject',
-                         body:    'custom_content_translations.body' }
+                         body: 'custom_content_translations.body' }
 
   decorates :custom_content
 

--- a/app/decorators/custom_content_decorator.rb
+++ b/app/decorators/custom_content_decorator.rb
@@ -8,7 +8,6 @@
 class CustomContentDecorator < ApplicationDecorator
   decorates :custom_content
 
-
   def available_placeholders
     if placeholders_required? || placeholders_optional?
       list = placeholders_list.collect do |ph|

--- a/app/views/custom_contents/_form.html.haml
+++ b/app/views/custom_contents/_form.html.haml
@@ -5,6 +5,7 @@
 
 
 = entry_form(buttons_bottom: false) do |f|
+  = f.hidden_field :label, value: entry.label
   = f.labeled_input_field :subject
   = f.labeled_text_area :body, class: 'span8 wysiwyg', rows: 20, help: entry.available_placeholders
 


### PR DESCRIPTION
There exists a bug when custom contents are not existing in all available languages. A new translation is created when translated text should be stored. This however fails because the label is not transferred with the form. Therefore it was also never permitted to send it.

This PR fixes this.