### PR TITLE
Exception bei fehlenden Übersetzungen

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,8 +51,8 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
-  #
+  config.action_view.raise_on_missing_translations = true
+
   locales_path = Dir[Rails.root.join('spec', 'support', 'locales', '**', '*.{rb,yml}')]
   config.i18n.load_path += locales_path
 


### PR DESCRIPTION
Als Diskussionsgrundlage rege ich hier mal an, dass wir bei fehlenden Übersetzungen direkt eine Exception werfen anstatt nur einen Tooltip zu rendern. Ich habe dafür die entsprechenden Settings in Rails aktiviert. Wenn ein `I18n.t`-call ein default definiert, greift das aber nicht mehr.

Was meint ihr zu dem Thema allgemein und auch im konkreten zu den Einschränkungen?