### PR TITLE
Only show relevant roles in filtered people list

### DIFF
--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -72,4 +72,9 @@ class GroupDecorator < ApplicationDecorator
     klass.label
   end
 
+  def subgroup_ids
+    @subgroups ||= Group.where('lft >= :lft AND rgt <= :rgt', lft: group.lft, rgt: group.rgt)
+                        .pluck(:id)
+  end
+
 end

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -73,12 +73,17 @@ class PersonDecorator < ApplicationDecorator
 
   # render a list of all roles
   # if a group is given, only render the roles of this group
-  def roles_short(group = nil)
-    functions_short(filtered_roles(group), group)
+  def roles_short(group, multiple_groups = false)
+    functions_short(filtered_roles(group, multiple_groups), multiple_groups)
   end
 
-  def filtered_roles(group = nil)
-    filtered_functions(roles.to_a, :group, group)
+  def filtered_roles(group, multiple_groups = false)
+    filtered_roles = filtered_functions(roles.to_a, :group, multiple_groups ? nil : group)
+    if multiple_groups
+      filtered_roles.select { |r| group.subgroup_ids.include? r.group_id }
+    else
+      filtered_roles
+    end
   end
 
   # returns roles grouped by their group
@@ -153,15 +158,15 @@ class PersonDecorator < ApplicationDecorator
     end
   end
 
-  def functions_short(functions, scope = nil)
+  def functions_short(functions, multiple_groups)
     h.safe_join(functions) do |f|
-      content_tag(:p, function_short(f, scope), id: h.dom_id(f))
+      content_tag(:p, function_short(f, multiple_groups), id: h.dom_id(f))
     end
   end
 
-  def function_short(function, scope = nil)
+  def function_short(function, multiple_groups)
     html = [function.to_s]
-    html << h.muted(h.safe_join(function.group.with_layer, ' / ')) if scope.nil?
+    html << h.muted(h.safe_join(function.group.with_layer, ' / ')) if multiple_groups
     html << popover_edit_link(function) if h.can?(:update, function)
     h.safe_join(html, ' ')
   end

--- a/app/views/people/_list.html.haml
+++ b/app/views/people/_list.html.haml
@@ -38,7 +38,7 @@
         %br/
         = muted p.additional_name
     - t.col(t.sort_header(:roles, Role.model_name.human(count: 2))) do |p|
-      = p.roles_short(@person_filter.multiple_groups ? nil : @group)
+      = p.roles_short(@group, @person_filter.multiple_groups)
     - t.col(Person.human_attribute_name(:emails)) do |p|
       = p.all_emails(!index_full_ability?)
     - t.col(PhoneNumber.model_name.human(count: 2)) do |p|

--- a/app/views/roles/create.js.haml
+++ b/app/views/roles/create.js.haml
@@ -1,6 +1,7 @@
+- group ||= defined?(@group) ? @group : nil
 - if entry.persisted?
   $($('body').data('popover')).parent().hide()
-  $($('body').data('popover')).popover('destroy').replaceWith('#{j(PersonDecorator.new(entry.person).roles_short)}')
+  $($('body').data('popover')).popover('destroy').replaceWith('#{j(PersonDecorator.new(entry.person).roles_short(group, true))}')
   $('##{dom_id(entry)}').parent().toggle('highlight', {duration: 1000})
 - else
   - @person_id = entry.person_id

--- a/app/views/roles/update.js.haml
+++ b/app/views/roles/update.js.haml
@@ -1,4 +1,16 @@
 - group ||= defined?(@group) ? @group : nil
-$('##{dom_id(@old_role || @role)}').parent().hide()
-$('##{dom_id(@old_role || @role)}').popover('destroy').replaceWith('#{j(PersonDecorator.new(entry.person).roles_short(group))}')
-$('##{dom_id(entry)}').parent().toggle('highlight', {duration: 1000})
+- oldRoleId = dom_id(@old_role || @role)
+parentEl = $('##{oldRoleId}').parent().hide()
+multiple_groups = $('##{oldRoleId}').children('span.muted').length > 0
+if (!#{(@old_role || @role).group_id == entry.group_id} && !multiple_groups) {
+$('##{oldRoleId}').popover('destroy').remove()
+parentEl.children('p').length === 0 ? $('tr##{dom_id(entry.person)}').remove() : parentEl.toggle('highlight', {duration: 1000})
+} else {
+rolesWithSubgroups = $($.parseHTML('#{j(PersonDecorator.new(entry.person).roles_short(group, true))}'))
+rolesWithoutSubgroups = $($.parseHTML('#{j(PersonDecorator.new(entry.person).roles_short(group))}'))
+roles = multiple_groups ? rolesWithSubgroups : rolesWithoutSubgroups
+filteredRoles = roles.filter(function() {return this.id !== '#{dom_id(entry)}' && this.id !== '#{oldRoleId}'})
+filteredRoles.each(function() { $('#' + this.id).remove() })
+$('##{oldRoleId}').popover('destroy').replaceWith(roles)
+parentEl.toggle('highlight', {duration: 1000})
+}

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -326,20 +326,6 @@ describe RolesController do
     end
   end
 
-  describe 'XHR PATCH inline update' do
-
-    before { role } # create it
-    render_views
-
-    it 'displays only roles in group after updating' do
-      patch :update, xhr: true, params: { group_id: group.id, id: role.id,
-                                          role: { type: role.type, group_id: group.id, label: 'label' } }
-
-      expect(response.body).not_to include('muted')
-    end
-
-  end
-
   describe 'DELETE destroy' do
     let(:notice) { "Rolle <i>Member</i> für <i>#{person}</i> in <i>TopGroup</i> wurde erfolgreich gelöscht." }
 

--- a/spec/decorators/group_decorator_spec.rb
+++ b/spec/decorators/group_decorator_spec.rb
@@ -65,4 +65,17 @@ describe GroupDecorator, :draper_with_helpers do
     end
   end
 
+  describe 'subgroups' do
+    let(:model) { groups(:bottom_layer_one) }
+
+    its(:subgroup_ids) do
+      should match_array(
+        [ groups(:bottom_layer_one),
+          groups(:bottom_group_one_one),
+          groups(:bottom_group_one_one_one),
+          groups(:bottom_group_one_two)
+        ].collect(&:id))
+    end
+  end
+
 end

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -60,6 +60,43 @@ describe PersonDecorator, :draper_with_helpers do
     end
   end
 
+  context 'roles short' do
+    before do
+      Fabricate(Group::TopLayer::TopAdmin.name.to_sym, group: groups(:top_layer), person: person)
+      Fabricate(Group::BottomLayer::LocalGuide.name.to_sym, group: groups(:bottom_layer_one), person: person)
+    end
+
+    it 'displays only roles of the group without group name' do
+      roles_short = PersonDecorator.new(person).roles_short(groups(:top_layer))
+      expect(roles_short).to include('Admin')
+      expect(roles_short).not_to include('<span class="muted">Top</span>')
+      expect(roles_short).not_to include('Leader')
+      expect(roles_short).not_to include('<span class="muted">Top / TopGroup</span>')
+      expect(roles_short).not_to include('Local Guide')
+      expect(roles_short).not_to include('<span class="muted">Bottom One</span>')
+    end
+
+    it 'displays roles of the group and its subgroups including the group name' do
+      roles_short = PersonDecorator.new(person).roles_short(groups(:top_layer).decorate, true)
+      expect(roles_short).to include('Admin')
+      expect(roles_short).to include('<span class="muted">Top</span>')
+      expect(roles_short).to include('Leader')
+      expect(roles_short).to include('<span class="muted">Top / TopGroup</span>')
+      expect(roles_short).to include('Local Guide')
+      expect(roles_short).to include('<span class="muted">Bottom One</span>')
+    end
+
+    it 'does not display roles in groups which are not subgroups' do
+      roles_short = PersonDecorator.new(person).roles_short(groups(:bottom_layer_one).decorate, true)
+      expect(roles_short).not_to include('Admin')
+      expect(roles_short).not_to include('<span class="muted">Top</span>')
+      expect(roles_short).not_to include('Leader')
+      expect(roles_short).not_to include('<span class="muted">Top / TopGroup</span>')
+      expect(roles_short).to include('Local Guide')
+      expect(roles_short).to include('<span class="muted">Bottom One</span>')
+    end
+  end
+
 
   context 'participations' do
     it 'pending_applications returns participations that are not active' do


### PR DESCRIPTION
Follow-up to #1006 

Expected result: When indexing people with `range = layer` or `range = deep` (so that the group name is shown in addition to the role type), only the roles belonging to the current group or one of its subgroups should be displayed.

I also changed the logic of the inline create / update code a bit:
- update (inline role editing in people list): Detects whether we are in 'deep' or 'layer' mode by checking on the current DOM node (I found no other way) and updates the role with or without the group name accordingly. If we are in 'group' mode and the updated role belongs to a subgroup instead instead of the current group (possible by changing the group in the popup dialog) and there are no other roles in the current group, the entire row is removed from the DOM (the people count will be wrong in that case, but I guess this is ok).
- create (re-adding a role from the "no roles" view): No actual changes. The group names are shown by default (as before).

This also fixes a bug: If a person has two or more roles in the same group and you inline update one of these, all the other roles in this group are displayed duplicated (although they still exist only once in the database).

Note: When indexing people with  `range = layer` or `range = deep` and also filtering by role type, it could still happen that some roles which are not in the filter are displayed. This is the case if a person has a role of a type which is in the filter, but also some other roles whose type is not in the filter. This is not addressed in this PR, and it may even be desirable to leave it as is because the action is 'filter people by role type' and not 'filter roles by role type'.