### PR TITLE
Don't use heading font for breadcrumb

### DIFF
--- a/app/assets/stylesheets/hitobito/_navigation.scss
+++ b/app/assets/stylesheets/hitobito/_navigation.scss
@@ -72,7 +72,6 @@
   list-style: none;
   background: none;
   border: none;
-  font-family: $headingFontFamily;
 
   ul {
     margin: 0;
@@ -207,4 +206,3 @@
   white-space: pre-wrap;
   font-size: 0.8em;
 }
-


### PR DESCRIPTION
Ein kleines Detail, das ich beim Styling für SJAS festgestellt habe. Für das Breadcrumb (im Screenshot oben rechts) wird die Heading Font verwendet – im Beispiel von SJAS wäre das eine Serifenschriftart (siehe «GR» oder «Anlass 352):

![image](https://user-images.githubusercontent.com/66047/98785128-6a795780-23fc-11eb-8aa2-0596bb2c1fed.png)

Da dies aber keine Überschrift ist und auch nicht Überschriftencharakter hat, schlage ich vor für das Breadcrumb die normale Content Font zu verwenden – im Beispiel von SJAS wäre das eine serifenlose Schriftart:
![image](https://user-images.githubusercontent.com/66047/98785192-811fae80-23fc-11eb-92c8-9e10513481b1.png)
