### PR TITLE
feature-toggle für MailchimpSync

### DIFF
--- a/app/domain/synchronize/mailchimp/synchronizator.rb
+++ b/app/domain/synchronize/mailchimp/synchronizator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #  Copyright (c) 2018, Grünliberale Partei Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
@@ -14,7 +16,7 @@ module Synchronize
       self.member_fields = []
 
       self.merge_fields = [
-        [ 'Gender', 'dropdown', { choices: %w(m w) },  ->(p) { p.gender } ]
+        ['Gender', 'dropdown', { choices: %w(m w) }, ->(p) { p.gender }]
       ]
 
       def initialize(mailing_list)
@@ -56,7 +58,7 @@ module Synchronize
 
       def missing_merge_fields
         labels = client.fetch_merge_fields.collect { |field| field[:tag] }
-         merge_fields.reject { |name, _, _| labels.include?(name.upcase) }
+        merge_fields.reject { |name, _, _| labels.include?(name.upcase) }
       end
 
       def stale_segments

--- a/app/jobs/mailchimp_destruction_job.rb
+++ b/app/jobs/mailchimp_destruction_job.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2018, Grünliberale Partei Schweiz. This file is part of
+#  Copyright (c) 2018-2020, Grünliberale Partei Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -16,6 +16,8 @@ class MailchimpDestructionJob < BaseJob
   end
 
   def perform
+    return unless Settings.mailchimp.enabled?
+
     Synchronize::Mailchimp::Destroyer.new(@mailchimp_list_id,
                                           @mailchimp_api_key,
                                           @people_to_be_deleted).call

--- a/app/jobs/mailchimp_synchronization_job.rb
+++ b/app/jobs/mailchimp_synchronization_job.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2018, Grünliberale Partei Schweiz. This file is part of
+#  Copyright (c) 2018-2020, Grünliberale Partei Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -19,6 +19,8 @@ class MailchimpSynchronizationJob < BaseJob
   end
 
   def perform
+    return unless Settings.mailchimp.enabled?
+
     sync.perform
   end
 

--- a/app/jobs/mailchimp_synchronization_job.rb
+++ b/app/jobs/mailchimp_synchronization_job.rb
@@ -29,6 +29,7 @@ class MailchimpSynchronizationJob < BaseJob
                         mailchimp_result: sync.result,
                         mailchimp_last_synced_at: Time.zone.now)
   end
+
   def error(job, exception)
     sync.result.exception = exception
     mailing_list.update(mailchimp_syncing: false,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -192,3 +192,4 @@ table_displays: true
 
 mailchimp:
   max_attempts: 25
+  enabled: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -3,3 +3,5 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
+mailchimp:
+  enabled: false


### PR DESCRIPTION
Wenn man lokal zu debugging-Zwecken eine produktions-Datenbank hat, können dort auch Mailchimp-Credentials hinterlegt sein. Da man für einige Export die Background-Worker braucht, werde alle Jobs ausgeführt. Dazu gehört auch der Mailchimp-Sync. Da man in development aber nicht mit dem produktiven Mailchimp-Account reden möchte, ist hier ein Feature-Toggle angebracht.

Dieser PR fügt genau das hinzu.

Standardmässig wird nun im Development kein Sync mehr gemacht, man kann dies aber wie üblich lokal überschreiben, wenn man an diesem Feature arbeitet und entsprechende Daten hat. Für test habe ich keine besondere Config gemacht, da hier eh immer generierte Daten in der DB sind.