### PR TITLE
Allow editing group / role subscriptions in mailing lists

### DIFF
--- a/app/controllers/subscriber/base_controller.rb
+++ b/app/controllers/subscriber/base_controller.rb
@@ -62,7 +62,11 @@ module Subscriber
     end
 
     def authorize!
-      super(:create, @subscription || @mailing_list.subscriptions.new)
+      if ['edit', 'update'].include? action_name
+        super(:update, entry)
+      else
+        super(:create, @subscription || @mailing_list.subscriptions.new)
+      end
     end
 
     class << self

--- a/app/controllers/subscriber/group_controller.rb
+++ b/app/controllers/subscriber/group_controller.rb
@@ -29,6 +29,19 @@ module Subscriber
       load_role_types
     end
 
+    def edit
+      @selected_group ||= Group.find(entry.subscriber_id)
+      load_role_types
+    end
+
+    def update
+      super do |format|
+        format.html do
+          redirect_to(group_mailing_list_subscriptions_path(mailing_list.group, mailing_list))
+        end
+      end
+    end
+
     private
 
     def groups_query

--- a/app/views/subscriber/group/_roles.html.haml
+++ b/app/views/subscriber/group/_roles.html.haml
@@ -15,7 +15,7 @@
                         class: 'checkbox inline') do
               = check_box_tag("subscription[role_types][]",
                               role_type.sti_name,
-                              false,
+                              defined?(selected) && selected.include?(role_type.sti_name),
                               id: "subscription_role_types_#{role_type.sti_name.downcase}")
               = role_type.label
 

--- a/app/views/subscriber/group/edit.html.haml
+++ b/app/views/subscriber/group/edit.html.haml
@@ -1,0 +1,19 @@
+-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+- title t('.title')
+
+= entry_form(url: group_mailing_list_group_path(@group, @mailing_list, entry.id),
+             cancel_url: group_mailing_list_subscriptions_path(@group, @mailing_list),
+             noindent: true) do |f|
+
+  = field_set_tag Group.model_name.human do
+    = f.string_field(:subscriber, readonly: true)
+
+  = field_set_tag Role.model_name.human(count: 2) do
+    #roles.label-columns= render 'roles', selected: entry.related_role_types.map(&:role_type)
+
+  = field_set_tag ActsAsTaggableOn::Tag.model_name.human(count: 2) do
+    = render 'tags', f: f

--- a/app/views/subscriptions/_list.html.haml
+++ b/app/views/subscriptions/_list.html.haml
@@ -12,6 +12,6 @@
   = render 'person/add_requests/body_list'
 
 = render('subs_table', title: Person.model_name.human(count: 2), subs: @person_subs)
-= render('subs_table', title: [Group.model_name.human(count: 2), Role.model_name.human(count: 2)].join(' / '), subs: @group_subs)
+= render('subs_table', title: [Group.model_name.human(count: 2), Role.model_name.human(count: 2)].join(' / '), subs: @group_subs, edit_controller: 'group')
 = render('subs_table', title: Event.model_name.human(count: 2), subs: @event_subs)
 = render('subs_table', title: t('.excluded_people'), subs: @excluded_person_subs)

--- a/app/views/subscriptions/_subs_table.html.haml
+++ b/app/views/subscriptions/_subs_table.html.haml
@@ -6,7 +6,7 @@
 %h2= title
 
 = table(subs, class: 'table table-striped') do |t|
-  - t.col('', width: '98%') { |e| render 'subscription', subscription: e }
+  - t.col('') { |e| render 'subscription', subscription: e }
   - t.col('', style: 'text-align: right; padding-right: 8px') do |e|
     - if can?(:edit, e) && defined?(edit_controller) && edit_controller.present?
       = link_action_edit(send("edit_group_mailing_list_#{edit_controller.to_s}_path", @group.id, e.mailing_list.id, e.id))

--- a/app/views/subscriptions/_subs_table.html.haml
+++ b/app/views/subscriptions/_subs_table.html.haml
@@ -7,6 +7,8 @@
 
 = table(subs, class: 'table table-striped') do |t|
   - t.col('', width: '98%') { |e| render 'subscription', subscription: e }
-  - t.col('') do |e|
+  - t.col('', style: 'text-align: right; padding-right: 8px') do |e|
+    - if can?(:edit, e) && defined?(edit_controller) && edit_controller.present?
+      = link_action_edit(send("edit_group_mailing_list_#{edit_controller.to_s}_path", @group.id, e.mailing_list.id, e.id))
     - if can?(:destroy, e)
       = link_action_destroy(group_mailing_list_subscription_path(@group.id, e.mailing_list.id, e.id))

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -1314,6 +1314,8 @@ de:
 
   subscriber:
     group:
+      edit:
+        title: Abonnenten bearbeiten
       form:
         subgroups_selectable: 'Es können nur Gruppen unterhalb der Abogruppe ausgewählt werden'
         subgroups_and_siblings_selectable: 'Es können nur Gruppen unterhalb der Abogruppe oder unterhalb der benachbarten Gruppen vom Typ %{type} ausgewählt werden'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,7 +194,7 @@ Hitobito::Application.routes.draw do
             resources :exclude_person, only: [:new, :create], controller: 'subscriber/exclude_person'
             get 'exclude_person' => 'subscriber/exclude_person#new' # route required for language switch
 
-            resources :group, only: [:new, :create], controller: 'subscriber/group' do
+            resources :group, only: [:new, :create, :edit, :update], controller: 'subscriber/group' do
               collection do
                 get :query
                 get :roles


### PR DESCRIPTION
So far, subscriptions in mailing lists can only be created and deleted. In the case of group subscriptions, entering the data is tedious, and also prone to errors and change over time, when new groups are founded, roles are newly used in a group, or new roles are even added to hitobito. This PR adds the capability to edit group subscriptions.

Thanks to @tobifra for the suggestion :)