### PR TITLE
Zahlungsreferenzen für QR Rechnungen

### DIFF
--- a/app/domain/invoice/qrcode.rb
+++ b/app/domain/invoice/qrcode.rb
@@ -57,7 +57,8 @@ class Invoice::Qrcode
   end
 
   def payment_reference
-    { type: 'NON', ref: nil }
+    type = @invoice.reference.starts_with?('RF') ? 'SCOR' : 'QRR'
+    { type: type, reference: @invoice.reference }
   end
 
   def additional_infos

--- a/app/domain/invoice/reference.rb
+++ b/app/domain/invoice/reference.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cvp.
+
+class Invoice::Reference
+
+  QR_ID_RANGE = (30_000..31_999).freeze
+  SEPARATOR_SUBSTITUTE = 'ZZ'
+
+  def self.create(invoice)
+    new(invoice).create
+  end
+
+  def initialize(invoice)
+    @invoice = invoice
+  end
+
+  def create
+    if qr_without_qr_iban?
+      scor_reference
+    else
+      @invoice.esr_number.delete(' ')
+    end
+  end
+
+  def scor_reference
+    value = @invoice.sequence_number.tr(Invoice::SEQUENCE_NR_SEPARATOR, SEPARATOR_SUBSTITUTE)
+    Invoice::ScorReference.create(value)
+  end
+
+  def qr_without_qr_iban?
+    @invoice.iban && @invoice.qr? && !QR_ID_RANGE.include?(qr_id)
+  end
+
+  def qr_id
+    @invoice.iban.delete(' ')[4..8].to_i
+  end
+end

--- a/app/domain/invoice/scor_reference.rb
+++ b/app/domain/invoice/scor_reference.rb
@@ -11,7 +11,7 @@ class Invoice::ScorReference
   # https://www.mobilefish.com/services/creditor_reference/creditor_reference.php
 
   PREFIX = 'RF'
-  REGEXP = /^[\d|[a-z]]+$/i.freeze
+  REGEXP = /^[\d[a-z]]+$/i.freeze
 
   def self.create(reference)
     new(reference).create

--- a/app/domain/invoice/scor_reference.rb
+++ b/app/domain/invoice/scor_reference.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cvp.
+
+class Invoice::ScorReference
+
+  # Simple Creditor Reference ISO 11649 generator
+  # https://www.mobilefish.com/services/creditor_reference/creditor_reference.php
+
+  PREFIX = 'RF'
+  REGEXP = /^[\d|[a-z]]+$/i.freeze
+
+  def self.create(reference)
+    new(reference).create
+  end
+
+  def initialize(reference)
+    @reference = reference.to_s
+    @chars = reference.split('')
+  end
+
+  def create
+    raise 'Invalid size' unless right_size?
+    raise 'Invalid characters' unless right_chars?
+
+    mapped = @chars.collect { |char| map(char).to_s }.join
+    mapped += map('R') + map('F') + '00'
+
+    PREFIX + checksum(mapped).to_s + @reference.upcase
+  end
+
+  def map(char)
+    mapping.fetch(char.upcase, char.to_s).to_s
+  end
+
+  def mapping
+    @mapping ||= ('A'..'Z').to_a.zip((10..35).to_a).to_h
+  end
+
+  def checksum(string)
+    val = 98 - (string.to_i % 97)
+    val < 10 ? val.to_s.prepend('0') : val
+  end
+
+  def right_size?
+    (1..21).include?(@chars.size)
+  end
+
+  def right_chars?
+    REGEXP.match(@reference)
+  end
+
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+#
 #  Copyright (c) 2017-2020, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
@@ -44,6 +46,8 @@ class Invoice < ActiveRecord::Base
 
   ROUND_TO = BigDecimal('0.05')
 
+  SEQUENCE_NR_SEPARATOR = '-'
+
   STATES = %w(draft issued sent payed reminded cancelled).freeze
   STATES_REMINDABLE = %w(issued sent reminded).freeze
   STATES_PAYABLE = %w(issued sent reminded).freeze
@@ -61,6 +65,7 @@ class Invoice < ActiveRecord::Base
 
   before_validation :set_sequence_number, on: :create, if: :group
   before_validation :set_esr_number, on: :create, if: :group
+  before_validation :set_reference_number, on: :create, if: :group
   before_validation :set_payment_attributes, on: :create, if: :group
   before_validation :set_dates, on: :update
   before_validation :set_self_in_nested
@@ -202,11 +207,15 @@ class Invoice < ActiveRecord::Base
   end
 
   def set_sequence_number
-    self.sequence_number = [group_id, invoice_config.sequence_number].join('-')
+    self.sequence_number = [group_id, invoice_config.sequence_number].join(SEQUENCE_NR_SEPARATOR)
   end
 
   def set_esr_number
     self.esr_number = Invoice::PaymentSlip.new(self).esr_number
+  end
+
+  def set_reference_number
+    self.reference = Invoice::Reference.create(self)
   end
 
   def set_payment_attributes

--- a/db/migrate/20201214202413_add_reference_to_invoices.rb
+++ b/db/migrate/20201214202413_add_reference_to_invoices.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cvp.
+
+class AddReferenceToInvoices < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:invoices, :reference, :string)
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE invoices SET reference = replace(esr_number, ' ', '')"
+      end
+    end
+    change_column_null(:invoices, :reference, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_03_223107) do
+ActiveRecord::Schema.define(version: 2020_12_14_202413) do
 
   create_table "additional_emails", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "contactable_type", null: false
@@ -336,6 +336,7 @@ ActiveRecord::Schema.define(version: 2020_12_03_223107) do
     t.string "participant_number_internal"
     t.string "vat_number"
     t.string "currency", default: "CHF", null: false
+    t.string "reference", null: false
     t.index ["esr_number"], name: "index_invoices_on_esr_number"
     t.index ["group_id"], name: "index_invoices_on_group_id"
     t.index ["recipient_id"], name: "index_invoices_on_recipient_id"

--- a/spec/controllers/payment_processes_controller_spec.rb
+++ b/spec/controllers/payment_processes_controller_spec.rb
@@ -38,7 +38,7 @@ describe PaymentProcessesController do
   end
 
   it 'POST#create with file informs about valid and invalid payments' do
-    invoice.update_columns(esr_number: '00 00000 00000 10000 00000 00905')
+    invoice.update_columns(reference: '000000000000100000000000905')
     post :create, params: { group_id: group.id, payment_process: { file: file } }
     expect(response).to be_successful
     expect(flash[:alert]).to be_present
@@ -46,7 +46,7 @@ describe PaymentProcessesController do
   end
 
   it 'POST#create with data persists valid payments' do
-    invoice.update_columns(esr_number: '00 00000 00000 10000 00000 00905')
+    invoice.update_columns(reference: '000000000000100000000000905')
     expect do
       post :create, params: { group_id: group.id, data: xmlfile.read }
     end.to change { invoice.payments.count }.by(1)

--- a/spec/domain/export/pdf/invoice_spec.rb
+++ b/spec/domain/export/pdf/invoice_spec.rb
@@ -128,11 +128,11 @@ describe Export::Pdf::Invoice do
         payment_slip: :qr,
         total: 1500,
         iban: 'CH93 0076 2011 6238 5295 7',
+        reference: 'RF561A',
         payee: "Acme Corp\nHallesche Str. 37\n3007 Hinterdupfing\nCH",
         recipient_address: "Max Mustermann\nMusterweg 2\n8000 Alt Tylerland\nCH"
       )
     end
-
 
     subject do
       pdf = described_class.render(invoice, payment_slip: true)

--- a/spec/domain/invoice/payment_processor_spec.rb
+++ b/spec/domain/invoice/payment_processor_spec.rb
@@ -17,13 +17,13 @@ describe Invoice::PaymentProcessor do
   end
 
   it 'first payment is marked as valid' do
-    invoice.update_columns(esr_number: '00 00000 00000 10000 00000 00905')
+    invoice.update_columns(reference: '000000000000100000000000905')
     payment = parser.payments.first
     expect(payment).to be_valid
   end
 
   it 'creates payment and marks invoice as payed' do
-    invoice.update_columns(esr_number: '00 00000 00000 10000 00000 00905',
+    invoice.update_columns(reference: '000000000000100000000000905',
                            total: 710.82)
     expect do
       expect(parser.process).to eq 1
@@ -37,7 +37,7 @@ describe Invoice::PaymentProcessor do
   end
 
   it 'invalid and valid payments set alert and notice' do
-    invoice.update_columns(esr_number: '00 00000 00000 10000 00000 00905')
+    invoice.update_columns(reference: '000000000000100000000000905')
     expect(parser.alert).to be_present
     expect(parser.notice).to be_present
   end

--- a/spec/domain/invoice/qrcode_spec.rb
+++ b/spec/domain/invoice/qrcode_spec.rb
@@ -16,7 +16,8 @@ describe Invoice::Qrcode do
       total: 1500,
       iban: 'CH93 0076 2011 6238 5295 7',
       payee: "Acme Corp\nHallesche Str. 37\n3007 Hinterdupfing\nCH",
-      recipient_address: "Max Mustermann\nMusterweg 2\n8000 Alt Tylerland\nCH"
+      recipient_address: "Max Mustermann\nMusterweg 2\n8000 Alt Tylerland\nCH",
+      reference: 'RF561A1'
     )
   end
 
@@ -78,9 +79,9 @@ describe Invoice::Qrcode do
       expect(subject[26]).to eq 'CH'
     end
 
-    it 'has blank reference' do
-      expect(subject[27]).to eq 'NON'
-      expect(subject[28]).to be_blank
+    it 'has CORS reference' do
+      expect(subject[27]).to eq 'SCOR'
+      expect(subject[28]).to eq 'RF561A1'
     end
 
     it 'has blank additional information ' do

--- a/spec/domain/invoice/qrcode_spec.rb
+++ b/spec/domain/invoice/qrcode_spec.rb
@@ -79,7 +79,7 @@ describe Invoice::Qrcode do
       expect(subject[26]).to eq 'CH'
     end
 
-    it 'has CORS reference' do
+    it 'has SCOR reference' do
       expect(subject[27]).to eq 'SCOR'
       expect(subject[28]).to eq 'RF561A1'
     end

--- a/spec/domain/invoice/scor_reference_spec.rb
+++ b/spec/domain/invoice/scor_reference_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cvp.
+
+require 'spec_helper'
+
+describe Invoice::ScorReference do
+
+  it 'succeeds for valid sequence value' do
+    expect(described_class.create('test')).to eq 'RF55TEST'
+  end
+
+  it 'fails for invalid char' do
+    expect { described_class.create('test-1') }.to raise_error(/^Invalid characters/)
+  end
+
+  it 'fails if string is blank' do
+    expect { described_class.create('') }.to raise_error(/^Invalid size/)
+  end
+
+  it 'fails if string is too long' do
+    expect { described_class.create('A' * 26) }.to raise_error(/^Invalid size/)
+  end
+
+end

--- a/spec/fixtures/invoices.yml
+++ b/spec/fixtures/invoices.yml
@@ -40,6 +40,7 @@ invoice:
   payment_slip: ch_esr
   sequence_number: <%= ActiveRecord::FixtureSet.identify(:bottom_layer_one) %>-2
   esr_number: '00 00376 80338 90000 00000 00021'
+  reference: 000037680338900000000000021
   account_number: <%= ActiveRecord::FixtureSet.identify(:bottom_layer_one) %>-3
   participant_number: <%= ActiveRecord::FixtureSet.identify(:bottom_layer_one) %>-4
   total: 5.35
@@ -52,6 +53,7 @@ sent:
   payment_slip: ch_esr
   sequence_number: <%= ActiveRecord::FixtureSet.identify(:bottom_layer_one) %>-3
   esr_number: '00 00376 80338 90000 00000 00036'
+  reference: 000037680338900000000000036
   issued_at: <%= 20.days.ago.to_date %>
   sent_at: <%= 10.days.ago.to_date %>
   due_at: <%= 20.days.from_now.to_date %>

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -156,6 +156,23 @@ describe Invoice do
     expect(invoice.vat_number).to eq invoice_config.vat_number
   end
 
+  context 'reference' do
+    let(:iban)               { 'CH12 2134 1234 1234 1234' }
+    let(:qr_iban)            { 'CH053 0000 0013 0003 6664' }
+    let(:esr_without_blanks) { '000083496356700000000000019' }
+
+    it 'sets esr without blanks per default' do
+      expect(create_invoice.reference).to eq esr_without_blanks
+    end
+
+    it 'sets esr without blanks for qr invoice with qr iban' do
+      expect(create_invoice(payment_slip: :qr, iban: qr_iban).reference).to eq esr_without_blanks
+    end
+
+    it 'sets cors for qr invoice without qr iban' do
+      expect(create_invoice(payment_slip: :qr, iban: iban).reference).to eq 'RF29834963567Z1'
+    end
+  end
 
   context 'state changes' do
     include ActiveSupport::Testing::TimeHelpers


### PR DESCRIPTION
Fügt dem QR Code eine Referenz hinzu. Vereinfacht das Einlesen von Rechnnungen

closes #1109 