### PR TITLE
Time travel to middle of the year before testing

### DIFF
--- a/spec/controllers/invoice_lists_controller_spec.rb
+++ b/spec/controllers/invoice_lists_controller_spec.rb
@@ -38,8 +38,6 @@ describe InvoiceListsController do
   end
 
   context 'authorized' do
-    include ActiveSupport::Testing::TimeHelpers
-
     before { sign_in(person) }
 
     it 'GET#new assigns_attributes and renders crud/new template' do

--- a/spec/controllers/invoices_controller_spec.rb
+++ b/spec/controllers/invoices_controller_spec.rb
@@ -8,8 +8,6 @@
 require 'spec_helper'
 
 describe InvoicesController do
-  include ActiveSupport::Testing::TimeHelpers
-
   let(:group) { groups(:bottom_layer_one) }
   let(:person) { people(:bottom_member) }
   let(:invoice) { invoices(:invoice) }

--- a/spec/controllers/oauth/active_authorizations_controller_spec.rb
+++ b/spec/controllers/oauth/active_authorizations_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Oauth::ActiveAuthorizationsController do
-  include ActiveSupport::Testing::TimeHelpers
   let(:top_leader)   { people(:top_leader) }
   let(:redirect_uri) { 'urn:ietf:wg:oauth:2.0:oob' }
   let(:application) { Oauth::Application.create!(name: 'MyApp', redirect_uri: redirect_uri) }

--- a/spec/domain/event/api_filter_spec.rb
+++ b/spec/domain/event/api_filter_spec.rb
@@ -13,6 +13,7 @@ describe Event::ApiFilter do
   let(:today)  { Date.today }
 
   before do
+    travel_to Time.zone.local(2020,7,1,12)
     @g1 = Fabricate(Group::TopGroup.name.to_sym, name: 'g1', parent: groups(:top_group))
     Fabricate(:event_date, event: Fabricate(:event, groups: [@g1]))
   end

--- a/spec/domain/invoice/batch_update_spec.rb
+++ b/spec/domain/invoice/batch_update_spec.rb
@@ -9,8 +9,6 @@
 require 'spec_helper'
 
 describe Invoice::BatchUpdate do
-  include ActiveSupport::Testing::TimeHelpers
-
   let(:person)  { people(:top_leader) }
   let(:draft)   { invoices(:invoice) }
   let(:sent)    { invoices(:sent) }

--- a/spec/domain/invoice/filter_spec.rb
+++ b/spec/domain/invoice/filter_spec.rb
@@ -6,8 +6,6 @@
 require 'spec_helper'
 
 describe Invoice::Filter do
-  include ActiveSupport::Testing::TimeHelpers
-
   let(:invoice) { invoices(:invoice) }
   let(:today)   { Time.zone.parse('2019-12-16 10:00:00') }
 

--- a/spec/domain/person/filter/role_spec.rb
+++ b/spec/domain/person/filter/role_spec.rb
@@ -161,8 +161,6 @@ describe Person::Filter::Role do
   end
 
   context 'filering specific timeframe' do
-    include ActiveSupport::Testing::TimeHelpers
-
     let(:person)      { people(:top_leader) }
     let(:now)         { Time.zone.parse('2017-02-01 10:00:00') }
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -175,8 +175,6 @@ describe Invoice do
   end
 
   context 'state changes' do
-    include ActiveSupport::Testing::TimeHelpers
-
     let(:now)     { Time.zone.parse('2017-09-18 14:00:00') }
     let(:invoice) { invoices(:invoice) }
     before        { travel_to(now) }
@@ -281,8 +279,6 @@ describe Invoice do
   end
 
   context '.draft_or_issued_in' do
-    include ActiveSupport::Testing::TimeHelpers
-
     let(:today)   { Time.zone.parse('2019-12-16 10:00:00') }
     let(:invoice) { invoices(:invoice) }
     let(:issued)  { invoices(:sent) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,6 +117,10 @@ RSpec.configure do |config|
     printer.print(File.open(filename, 'w'))
   end
 
+  RSpec.configure do |config|
+    config.include ActiveSupport::Testing::TimeHelpers
+  end
+
   unless RSpec.configuration.exclusion_filter[:type] == 'feature'
     config.include Warden::Test::Helpers
     Warden.test_mode!

--- a/spec/utils/cookie_spec.rb
+++ b/spec/utils/cookie_spec.rb
@@ -6,8 +6,6 @@
 require 'spec_helper'
 
 describe Cookie do
-  include ActiveSupport::Testing::TimeHelpers
-
   let(:cookie_jar) { ActionDispatch::Request.new({}).cookie_jar }
   let(:value)      { JSON.parse(cookie_jar[:cookie]) }
   let(:subject)    { described_class.new(cookie_jar, 'cookie', [:name]) }

--- a/spec/utils/cookies/async_download_spec.rb
+++ b/spec/utils/cookies/async_download_spec.rb
@@ -6,8 +6,6 @@
 require 'spec_helper'
 
 describe Cookies::AsyncDownload do
-  include ActiveSupport::Testing::TimeHelpers
-
   let(:cookie_jar) { ActionDispatch::Request.new({}).cookie_jar }
   let(:value)      { JSON.parse(cookie_jar[:async_downloads]) }
   let(:subject)    { described_class.new(cookie_jar) }

--- a/spec/utils/cookies/async_synchronization_spec.rb
+++ b/spec/utils/cookies/async_synchronization_spec.rb
@@ -6,8 +6,6 @@
 require 'spec_helper'
 
 describe Cookies::AsyncSynchronization do
-  include ActiveSupport::Testing::TimeHelpers
-
   let(:cookie_jar) { ActionDispatch::Request.new({}).cookie_jar }
   let(:value)      { JSON.parse(cookie_jar[:async_synchronizations]) }
   let(:subject)    { described_class.new(cookie_jar) }


### PR DESCRIPTION
`api_filter_spec` schlagen rund ums Jahresende fehl, z.B. weil ein Event mit Startdatum in 5 Tagen erstellt und mit Defaultfilter gesucht wird. Wenn in 5 Tagen das neue Jahr schon begonnen hat, wird dieses Event aber mit dem Defaultfilter nicht mehr gefunden (Defaultfilter sucht vom 1. Januar bis 31. Dezember).

Dieser Fix setzt das für die Specs verwendete `Date.today` auf 1. Juni 2020, so dass keine derartigen Effekte auftreten.