### PR TITLE
Sammelrechnungen für Abos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 *  Tägliche Validierung der Adressen einer Person (hitobito_cvp#19)
 *  Anlässen können den Teilnehmern erlauben, sich gegenseitig in der Teilnehmerliste zu sehen (#878)
 *  Personen / Duplikate zusammenführen (hitobito_cvp#23)
+*  Erstellen von Rechungen für Abonnenten von Abos
 
 ## Version 1.22
 

--- a/app/abilities/invoice_ability.rb
+++ b/app/abilities/invoice_ability.rb
@@ -12,7 +12,7 @@ class InvoiceAbility < AbilityDsl::Base
   end
 
   on(InvoiceList) do
-    permission(:finance).may(:create, :show, :edit, :update, :destroy).in_layer
+    permission(:finance).may(:create, :show, :edit, :update, :destroy).in_layer_with_receiver
   end
 
   on(InvoiceArticle) do
@@ -35,8 +35,13 @@ class InvoiceAbility < AbilityDsl::Base
     user.finance_groups.present?
   end
 
-  def in_layer
-    user.groups_with_permission(:finance).collect(&:layer_group).include?(subject.group)
+  def in_layer(group = subject.group)
+    user.groups_with_permission(:finance).collect(&:layer_group).include?(group)
+  end
+
+  def in_layer_with_receiver
+    return in_layer unless subject.receiver
+    in_layer && in_layer(subject.receiver.group.layer_group)
   end
 
 end

--- a/app/abilities/invoice_ability.rb
+++ b/app/abilities/invoice_ability.rb
@@ -12,7 +12,7 @@ class InvoiceAbility < AbilityDsl::Base
   end
 
   on(InvoiceList) do
-    permission(:finance).may(:create, :show, :edit, :update, :destroy).in_layer_with_receiver
+    permission(:finance).may(:create, :index_invoices).in_layer_with_receiver
   end
 
   on(InvoiceArticle) do

--- a/app/abilities/invoice_ability.rb
+++ b/app/abilities/invoice_ability.rb
@@ -11,6 +11,10 @@ class InvoiceAbility < AbilityDsl::Base
     permission(:finance).may(:create, :show, :edit, :update, :destroy).in_layer
   end
 
+  on(InvoiceList) do
+    permission(:finance).may(:create, :show, :edit, :update, :destroy).in_layer
+  end
+
   on(InvoiceArticle) do
     permission(:finance).may(:new, :create, :show, :edit, :update, :destroy).in_layer
   end

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -41,7 +41,8 @@ class InvoiceListsController < CrudController
   def create
     assign_attributes
 
-    if entry.multi_create
+    if entry.prepare_for_batch_create
+      Invoice::BatchCreate.new(entry).call
       message = flash_message(count: entry.recipient_ids_count, title: entry.title)
       redirect_to return_path, notice: message
       session.delete :invoice_referer

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -102,7 +102,9 @@ class InvoiceListsController < CrudController
   end
 
   def assign_attributes
-    entry.attributes = permitted_params.slice(:receiver_id, :receiver_type, :recipient_ids).merge(creator_id: current_user.id)
+    entry.attributes = permitted_params.slice(:receiver_id,
+                                              :receiver_type,
+                                              :recipient_ids).merge(creator_id: current_user.id)
     entry.invoice = parent.invoices.build(permitted_params[:invoice])
   end
 

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -40,9 +40,10 @@ class InvoiceListsController < CrudController
 
   def create
     assign_attributes
+    entry.title = entry.invoice.title
 
-    if entry.prepare_for_batch_create
-      Invoice::BatchCreate.new(entry).call
+    if entry.valid?
+      result = Invoice::BatchCreate.call(entry)
       message = flash_message(count: entry.recipient_ids_count, title: entry.title)
       redirect_to return_path, notice: message
       session.delete :invoice_referer

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -76,7 +76,7 @@ class InvoiceListsController < CrudController
   private
 
   def list_entries
-    super.includes(:receiver, :invoice).list.where(created_at: Date.new(year, 1, 1).all_year)
+    super.includes(:receiver).list.where(created_at: Date.new(year, 1, 1).all_year)
   end
 
   def return_path

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -6,6 +6,7 @@
 #  https://github.com/hitobito/hitobito.
 
 class InvoiceListsController < CrudController
+  include YearBasedPaging
   self.nesting = Group
   self.permitted_attrs = [
     :receiver_id,
@@ -70,6 +71,10 @@ class InvoiceListsController < CrudController
   end
 
   private
+
+  def list_entries
+    super.includes(:receiver, :invoice).list
+  end
 
   def return_path
     invoice_list_id = params[:invoice_list_id].presence

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -72,6 +72,8 @@ class InvoiceListsController < CrudController
   def return_path
     if params[:singular]
       group_invoice_path(parent, invoices.first)
+    elsif params.dig(:invoice_list, :receiver_id)
+      group_invoice_lists_path(parent)
     else
       group_invoices_path(parent)
     end
@@ -81,11 +83,6 @@ class InvoiceListsController < CrudController
     params[:mail] == 'true' && current_user
   end
 
-  # Ouch
-  # def list_entries
-  #   super.includes(recipient: [:groups, :roles])
-  # end
-  #
   def invoices
     parent.invoices.where(id: list_param(:ids))
   end

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -60,7 +60,7 @@ class InvoiceListsController < CrudController
   def destroy
     count = invoices.update_all(state: :cancelled, updated_at: Time.zone.now)
     key = count > 0 ? :notice : :alert
-    redirect_to(group_invoices_path(parent), key => flash_message(count: count))
+    redirect_to(group_invoices_path(parent, returning: true), key => flash_message(count: count))
   end
 
   def show
@@ -75,7 +75,7 @@ class InvoiceListsController < CrudController
     elsif params.dig(:invoice_list, :receiver_id)
       group_invoice_lists_path(parent)
     else
-      group_invoices_path(parent)
+      group_invoices_path(parent, returning: true)
     end
   end
 

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -73,7 +73,7 @@ class InvoiceListsController < CrudController
   private
 
   def list_entries
-    super.includes(:receiver, :invoice).list
+    super.includes(:receiver, :invoice).list.where(created_at: Date.new(year, 1, 1).all_year)
   end
 
   def return_path

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -113,6 +113,7 @@ class InvoiceListsController < CrudController
     entry.attributes = permitted_params.slice(:receiver_id,
                                               :receiver_type,
                                               :recipient_ids).merge(creator_id: current_user.id)
+    entry.recipient_ids = params[:ids] if params[:ids].present?
     entry.invoice = parent.invoices.build(permitted_params[:invoice])
   end
 

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -123,7 +123,8 @@ class InvoiceListsController < CrudController
 
   def recipient_ids_from_people_filter
     group = Group.find(params.dig(:filter, :group_id))
-    filter = Person::Filter::List.new(group, current_user, params[:filter])
+    filter_params = params[:filter].to_unsafe_h.transform_values(&:presence)
+    filter = Person::Filter::List.new(group, current_user, filter_params)
     filter.entries.pluck(:id).join(',')
   end
 

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -72,10 +72,13 @@ class InvoiceListsController < CrudController
   private
 
   def return_path
+    invoice_list_id = params[:invoice_list_id].presence
     if params[:singular]
       group_invoice_path(parent, invoices.first)
     elsif params.dig(:invoice_list, :receiver_id)
       group_invoice_lists_path(parent)
+    elsif invoice_list_id
+      group_invoice_list_invoices_path(parent, invoice_list_id: invoice_list_id, returning: true)
     else
       group_invoices_path(parent, returning: true)
     end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -13,7 +13,7 @@ class InvoicesController < CrudController
   self.nesting = Group
   self.sort_mappings = { recipient: Person.order_by_name_statement,
                          sequence_number: Invoice.order_by_sequence_number_statement }
-  self.remember_params += [:year, :state, :due_since]
+  self.remember_params += [:year, :state, :due_since, :invoice_list_id]
 
   self.search_columns = [:title, :sequence_number, 'people.last_name', 'people.email']
   self.permitted_attrs = [:title, :description, :state, :due_at,

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -15,11 +15,14 @@ class PaymentsController < CrudController
   def create
     assign_attributes
 
-    if entry.save
-      redirect_to(group_invoice_path(*parents), notice: flash_message)
-    else
-      flash[:payment] = permitted_params.to_h
-      redirect_to(group_invoice_path(*parents))
+    Payment.transaction do
+      if entry.save
+        parent.invoice_list&.update_paid
+        redirect_to(group_invoice_path(*parents), notice: flash_message)
+      else
+        flash[:payment] = permitted_params.to_h
+        redirect_to(group_invoice_path(*parents))
+      end
     end
   end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -45,6 +45,8 @@ class PeopleController < CrudController
   before_render_show :load_grouped_person_tags, if: -> { html_request? }
   before_render_index :load_people_add_requests, if: -> { html_request? }
 
+  helper_method :list_filter_args
+
   def index # rubocop:disable Metrics/AbcSize we support a lot of formats, hence many code-branches
     respond_to do |format|
       format.html  { @people = prepare_entries(filter_entries).page(params[:page]) }

--- a/app/domain/invoice/batch_create.rb
+++ b/app/domain/invoice/batch_create.rb
@@ -8,14 +8,14 @@
 class Invoice::BatchCreate
   attr_reader :invoice_list, :invoice
 
-  def self.call(invoice_list, limit = 100)
+  def self.call(invoice_list, limit = InvoiceListsController::LIMIT_CREATE)
     invoice_parameters = invoice_list.invoice_parameters
-    if invoice_list.recipient_ids_count > limit
-      invoice_list.save
-      Invoice::BatchCreateJob.new(invoice_list.id, invoice_parameters).enqueue!
-    else
+    if invoice_list.recipient_ids_count < limit
       invoice_list.invoice = Invoice.new(invoice_parameters)
       Invoice::BatchCreate.new(invoice_list).call
+    else
+      invoice_list.save
+      Invoice::BatchCreateJob.new(invoice_list.id, invoice_parameters).enqueue!
     end
   end
 

--- a/app/domain/invoice/batch_create.rb
+++ b/app/domain/invoice/batch_create.rb
@@ -28,7 +28,7 @@ class Invoice::BatchCreate
     Invoice.transaction do
       invoice_list.save! if receiver? && invoice_list.new_record?
       create_invoices.tap do
-        update_total if receiver?
+        invoice_list.update_total if receiver?
       end
     end
   end
@@ -56,11 +56,5 @@ class Invoice::BatchCreate
       invoice_list_id: invoice_list.id,
       creator_id: invoice_list.creator_id
     )
-  end
-
-  def update_total
-    total_sum = invoice_list.invoices.sum(&:total)
-    total_count = invoice_list.invoices.pluck(:recipient_id).count
-    invoice_list.update(amount_total: total_sum, recipients_total: total_count)
   end
 end

--- a/app/domain/invoice/batch_create.rb
+++ b/app/domain/invoice/batch_create.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 
 #  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
-#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
-#  https://github.com/hitobito/hitobito_cvp.
+#  https://github.com/hitobito/hitobito.
 
 class Invoice::BatchCreate
   attr_reader :invoice_list, :invoice

--- a/app/domain/invoice/batch_create.rb
+++ b/app/domain/invoice/batch_create.rb
@@ -1,0 +1,50 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cvp.
+
+class Invoice::BatchCreate
+  attr_reader :invoice_list, :invoice
+
+  def initialize(invoice_list)
+    @invoice_list = invoice_list
+    @invoice = invoice_list.invoice
+  end
+
+  def call
+    Invoice.transaction do
+      invoice_list.save! if receiver?
+      create_invoices
+      update_total if receiver?
+    end
+  end
+
+  private
+
+  def receiver?
+    invoice_list.receiver
+  end
+
+  def create_invoices
+    invoice_list.recipients.all? do |recipient|
+      invoice_list.group.invoices.build(attributes(recipient)).save
+    end || (raise ActiveRecord::Rollback)
+  end
+
+  def attributes(recipient)
+    invoice.attributes.merge(
+      invoice_items_attributes: invoice.invoice_items.collect(&:attributes),
+      recipient_id: recipient.id,
+      invoice_list_id: invoice_list.id,
+      creator_id: invoice_list.creator_id
+    )
+  end
+
+  def update_total
+    total_sum = invoice_list.invoices.sum(&:total)
+    total_count = invoice_list.invoices.pluck(:recipient_id).count
+    invoice_list.update(amount_total: total_sum, recipients_total: total_count)
+  end
+end

--- a/app/domain/invoice/filter.rb
+++ b/app/domain/invoice/filter.rb
@@ -17,6 +17,7 @@ class Invoice::Filter
     scope = apply_scope(scope, params[:state], Invoice::STATES)
     scope = apply_scope(scope, params[:due_since], Invoice::DUE_SINCE)
     scope = filter_by_ids(scope)
+    scope = filter_by_invoice_list_id(scope)
     scope = scope.draft_or_issued_in(params[:year])
     cancelled? ? scope : scope.visible
   end
@@ -30,6 +31,11 @@ class Invoice::Filter
 
   def cancelled?
     params[:state] == 'cancelled'
+  end
+
+  def filter_by_invoice_list_id(relation)
+    return relation if params[:invoice_list_id].blank?
+    relation.where(invoice_list_id: params[:invoice_list_id])
   end
 
   def filter_by_ids(relation)

--- a/app/domain/invoice/payment_processor.rb
+++ b/app/domain/invoice/payment_processor.rb
@@ -30,6 +30,7 @@ class Invoice::PaymentProcessor
   def process
     Payment.transaction do
       valid_payments.all?(&:save) || (raise ActiveRecord::Rollback)
+      invoice_lists.each(&:update_paid)
       valid_payments.count
     end
   end
@@ -62,6 +63,10 @@ class Invoice::PaymentProcessor
                   invoice: invoices[reference(s)],
                   reference: fetch('Refs', 'AcctSvcrRef', s))
     end
+  end
+
+  def invoice_lists
+    InvoiceList.where(id: invoices.values.collect(&:invoice_list_id))
   end
 
   def invoices

--- a/app/domain/invoice/qrcode.rb
+++ b/app/domain/invoice/qrcode.rb
@@ -63,7 +63,7 @@ class Invoice::Qrcode
 
   def additional_infos
     {
-      purpose: @invoice.payment_information.to_s.gsub("\n", " ").truncate(120),
+      purpose: @invoice.payment_purpose.to_s.gsub("\n", " ").truncate(120),
       trailer: 'EPD',
       infos: nil
     }

--- a/app/domain/invoice/qrcode.rb
+++ b/app/domain/invoice/qrcode.rb
@@ -63,9 +63,9 @@ class Invoice::Qrcode
 
   def additional_infos
     {
-      purpose: @invoice.payment_purpose.to_s.truncate(60),
+      purpose: @invoice.payment_information.to_s.gsub("\n", " ").truncate(120),
       trailer: 'EPD',
-      infos: @invoice.payment_information.to_s.truncate(60)
+      infos: nil
     }
   end
 

--- a/app/domain/mail_relay/base.rb
+++ b/app/domain/mail_relay/base.rb
@@ -8,7 +8,7 @@
 
 module MailRelay
   # A generic email relay object. Retrieves messages from a mail server and resends
-  # them to a list of recievers.
+  # them to a list of receivers.
   # In subclasses, override the methods #relay_address?, #sender_allowed? and #receivers
   # to constrain which mails are sent to whom.
   #

--- a/app/helpers/dropdown/invoice_new.rb
+++ b/app/helpers/dropdown/invoice_new.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 #  Copyright (c) 2017, Jungwacht Blauring Schweiz. This file is part of
@@ -8,26 +7,56 @@
 
 module Dropdown
   class InvoiceNew < Base
+    attr_reader :people, :mailing_list
 
-    # attr_reader :params
-
-    def initialize(template, label, finance_groups, people, icon)
-      super(template, label, icon)
-      @finance_groups = finance_groups
+    def initialize(template, people: [], mailing_list: nil)
+      super(template, label, :plus)
       @people = people
+      @mailing_list = mailing_list
       init_items
+    end
+
+    def button_or_dropdown
+      if finance_groups.one?
+        single_button
+      else
+        to_s
+      end
     end
 
     private
 
-    def init_items
-      finance_group_links
+    def label
+      I18n.t('crud.new.title', model: Invoice.model_name.human)
     end
 
-    def finance_group_links
-      @finance_groups.each do |group|
-        add_item(group.name, template.new_invoices_for_people_path(group, @people))
+    def single_button
+      data = { checkable: true } if template.action_name == 'index'
+      template.action_button(label, path(finance_groups.first), :plus, data: data)
+    end
+
+    def path(finance_group) # rubocop:disable Metrics/MethodLength
+      if mailing_list
+        template.new_group_invoice_list_path(
+          finance_group,
+          invoice_list: { receiver_id: mailing_list.id, receiver_type: mailing_list.class }
+        )
+      else
+        template.new_group_invoice_list_path(
+          finance_group,
+          invoice_list: { recipient_ids: people.collect(&:id).join(',') }
+        )
       end
+    end
+
+    def init_items
+      finance_groups.each do |finance_group|
+        add_item(finance_group.name, path(finance_group))
+      end
+    end
+
+    def finance_groups
+      template.current_user.finance_groups
     end
   end
 end

--- a/app/helpers/dropdown/invoice_new.rb
+++ b/app/helpers/dropdown/invoice_new.rb
@@ -7,12 +7,14 @@
 
 module Dropdown
   class InvoiceNew < Base
-    attr_reader :people, :mailing_list
-
-    def initialize(template, people: [], mailing_list: nil)
+    def initialize(template, people: [], mailing_list: nil, filter: nil)
       super(template, label, :plus)
       @people = people
       @mailing_list = mailing_list
+      @filter = filter
+      if @filter.is_a?(ActionController::Parameters)
+        @filter = filter.to_unsafe_h.slice(:group_id, :range, :filters)
+      end
       init_items
     end
 
@@ -36,15 +38,20 @@ module Dropdown
     end
 
     def path(finance_group) # rubocop:disable Metrics/MethodLength
-      if mailing_list
+      if @mailing_list
         template.new_group_invoice_list_path(
           finance_group,
-          invoice_list: { receiver_id: mailing_list.id, receiver_type: mailing_list.class }
+          invoice_list: { receiver_id: @mailing_list.id, receiver_type: @mailing_list.class }
+        )
+      elsif @filter
+        template.new_group_invoice_list_path(
+          finance_group,
+          filter: @filter, invoice_list: { recipient_ids: '' }
         )
       else
         template.new_group_invoice_list_path(
           finance_group,
-          invoice_list: { recipient_ids: people.collect(&:id).join(',') }
+          invoice_list: { recipient_ids: @people.collect(&:id).join(',') }
         )
       end
     end

--- a/app/helpers/dropdown/invoice_sending.rb
+++ b/app/helpers/dropdown/invoice_sending.rb
@@ -9,12 +9,12 @@
 module Dropdown
   class InvoiceSending < Base
 
-    attr_reader :params
+    attr_reader :params, :path, :invoice_list_id
 
-    def initialize(template, params, path_method)
+    def initialize(template, params)
       super(template, translate(:button), :envelope)
       @params      = params
-      @path_method = path_method
+      @invoice_list_id = template.invoice_list&.id
       init_items
     end
 
@@ -25,12 +25,12 @@ module Dropdown
     end
 
     def send_links
-      add_item(:set_state, mail: false)
-      add_item(:send_mail, mail: true)
+      add_item(:set_state, mail: false, invoice_list_id: invoice_list_id)
+      add_item(:send_mail, mail: true, invoice_list_id: invoice_list_id)
     end
 
     def add_item(key, options = {})
-      path = @template.send(@path_method, options)
+      path = template.group_invoice_list_path(template.parent, options)
       super(translate(key), path, data: { method: :put, checkable: true })
     end
 

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -38,8 +38,12 @@ module InvoicesHelper
   end
 
   def new_invoices_for_people_path(group, people)
-    ids = people.collect(&:id).join(',')
-    new_group_invoice_list_path(group, invoice: { recipient_ids: ids })
+    if people.is_a?(MailingList)
+      new_group_invoice_list_path(group, invoice_list: { receiver_id: people.id, receiver_type: people.class })
+    else
+      ids = people.collect(&:id).join(',')
+      new_group_invoice_list_path(group, invoice_list: { recipient_ids: ids })
+    end
   end
 
   def invoices_export_dropdown

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -49,7 +49,9 @@ module InvoicesHelper
 
   def new_invoices_for_people_path(group, people)
     if people.is_a?(MailingList)
-      new_group_invoice_list_path(group, invoice_list: { receiver_id: people.id, receiver_type: people.class })
+      new_group_invoice_list_path(group, {
+        invoice_list: { receiver_id: people.id, receiver_type: people.class }
+      })
     else
       ids = people.collect(&:id).join(',')
       new_group_invoice_list_path(group, invoice_list: { recipient_ids: ids })

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -47,8 +47,12 @@ module InvoicesHelper
     end
   end
 
-  def invoice_button(people: [], mailing_list: nil)
-    Dropdown::InvoiceNew.new(self, people: people, mailing_list: mailing_list).button_or_dropdown
+  def invoice_button(people: [], mailing_list: nil, filter: nil)
+    Dropdown::InvoiceNew.new(self, {
+      people: people,
+      mailing_list: mailing_list,
+      filter: filter
+    }).button_or_dropdown
   end
 
   def invoices_export_dropdown

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -8,13 +8,13 @@
 module InvoicesHelper
 
   def format_invoice_list_amount_paid(invoice_list)
-    invoice = invoice_list.invoices.first.decorate
-    invoice.format_currency(invoice_list.amount_paid)
+    invoice = invoice_list.invoices.first
+    invoice.decorate.format_currency(invoice_list.amount_paid) if invoice
   end
 
   def format_invoice_list_amount_total(invoice_list)
-    invoice = invoice_list.invoices.first.decorate
-    invoice.format_currency(invoice_list.amount_total)
+    invoice = invoice_list.invoices.first
+    invoice.decorate.format_currency(invoice_list.amount_total) if invoice
   end
 
   def format_invoice_state(invoice)

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -7,6 +7,16 @@
 
 module InvoicesHelper
 
+  def format_invoice_list_amount_paid(invoice_list)
+    invoice = invoice_list.invoices.first.decorate
+    invoice.format_currency(invoice_list.amount_paid)
+  end
+
+  def format_invoice_list_amount_total(invoice_list)
+    invoice = invoice_list.invoices.first.decorate
+    invoice.format_currency(invoice_list.amount_total)
+  end
+
   def format_invoice_state(invoice)
     type = case invoice.state
            when /draft|cancelled/ then 'info'

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -8,12 +8,12 @@
 module InvoicesHelper
 
   def format_invoice_list_amount_paid(invoice_list)
-    invoice = invoice_list.invoice
-    invoice_list.invoice.decorate.format_currency(invoice_list.amount_paid) if invoice
+    invoice = invoice_list.invoice || invoice_list.group.invoices.build
+    invoice.decorate.format_currency(invoice_list.amount_paid)
   end
 
   def format_invoice_list_amount_total(invoice_list)
-    invoice = invoice_list.invoice
+    invoice = invoice_list.invoice || invoice_list.group.invoices.build
     invoice.decorate.format_currency(invoice_list.amount_total) if invoice
   end
 

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -7,6 +7,10 @@
 
 module InvoicesHelper
 
+  def format_invoice_list_recipients_total(invoice_list)
+    [invoice_list.recipients_processed, invoice_list.recipients_total].uniq.join(' / ')
+  end
+
   def format_invoice_list_amount_paid(invoice_list)
     invoice = invoice_list.invoice || invoice_list.group.invoices.build
     invoice.decorate.format_currency(invoice_list.amount_paid)

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -47,15 +47,8 @@ module InvoicesHelper
     end
   end
 
-  def new_invoices_for_people_path(group, people)
-    if people.is_a?(MailingList)
-      new_group_invoice_list_path(group, {
-        invoice_list: { receiver_id: people.id, receiver_type: people.class }
-      })
-    else
-      ids = people.collect(&:id).join(',')
-      new_group_invoice_list_path(group, invoice_list: { recipient_ids: ids })
-    end
+  def invoice_button(people: [], mailing_list: nil)
+    Dropdown::InvoiceNew.new(self, people: people, mailing_list: mailing_list).button_or_dropdown
   end
 
   def invoices_export_dropdown

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -8,12 +8,12 @@
 module InvoicesHelper
 
   def format_invoice_list_amount_paid(invoice_list)
-    invoice = invoice_list.invoices.first
-    invoice.decorate.format_currency(invoice_list.amount_paid) if invoice
+    invoice = invoice_list.invoice
+    invoice_list.invoice.decorate.format_currency(invoice_list.amount_paid) if invoice
   end
 
   def format_invoice_list_amount_total(invoice_list)
-    invoice = invoice_list.invoices.first
+    invoice = invoice_list.invoice
     invoice.decorate.format_currency(invoice_list.amount_total) if invoice
   end
 
@@ -66,8 +66,8 @@ module InvoicesHelper
     Dropdown::Invoices.new(self, params, :print).print
   end
 
-  def invoice_sending_dropdown(path_meth)
-    Dropdown::InvoiceSending.new(self, params, path_meth)
+  def invoice_sending_dropdown
+    Dropdown::InvoiceSending.new(self, params)
   end
 
   def invoice_history(invoice)

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -12,7 +12,7 @@ module NavigationHelper
       url: :groups_path,
       icon_name: 'users',
       active_for: %w(groups people),
-      inactive_for: %w(invoices invoice_articles invoice_config payment_process) },
+      inactive_for: %w(invoices invoice_articles invoice_config payment_process invoice_lists) },
 
     { label: :events,
       url: :list_events_path,
@@ -30,7 +30,7 @@ module NavigationHelper
       url: :first_group_invoices_or_root_path,
       icon_name: 'money-bill-alt',
       if: ->(_) { current_user.finance_groups.any? },
-      active_for: %w(invoices invoice_articles invoice_config payment_process) },
+      active_for: %w(invoices invoice_articles invoice_config payment_process invoice_lists) },
 
     { label: :admin,
       url: :label_formats_path,

--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -22,23 +22,6 @@ module PeopleHelper
                                                            households: households).to_s
   end
 
-  def invoice_button(people)
-    finance_groups = current_user.finance_groups
-    if finance_groups.size == 1
-      invoice_button_single(people, finance_groups.first)
-    elsif finance_groups.size > 1
-      Dropdown::InvoiceNew.new(self,
-                               t('crud.new.title', model: Invoice.model_name.human),
-                               finance_groups, people, :plus).to_s
-    end
-  end
-
-  def invoice_button_single(people, finance_group)
-    action_button(t('crud.new.title', model: Invoice.model_name.human),
-                  new_invoices_for_people_path(finance_group, people),
-                  :plus, data: { checkable: true })
-  end
-
   def format_birthday(person)
     if person.birthday?
       f(person.birthday) << ' ' << t('people.years_old', years: person.years)

--- a/app/helpers/sheet/invoice.rb
+++ b/app/helpers/sheet/invoice.rb
@@ -7,13 +7,17 @@
 
 module Sheet
   class Invoice < Base
-
     def title
-      ::Invoice.model_name.human(count: 2)
+      title = ::Invoice.model_name.human(count: 2)
+      invoice_list ? invoice_list.title : ::Invoice.model_name.human(count: 2)
     end
 
-    def self.parent_sheet
-      nil
+    def parent_sheet
+      @parent_sheet ||= invoice_list ? create_parent(Sheet::InvoiceList) : nil
+    end
+
+    def invoice_list
+      @invoice_list ||= ::InvoiceList.find_by(id: view.params[:invoice_list_id])
     end
 
     def left_nav?

--- a/app/helpers/sheet/invoice_list.rb
+++ b/app/helpers/sheet/invoice_list.rb
@@ -18,7 +18,11 @@ module Sheet
     end
 
     def render_left_nav
-      view.render('invoices/nav_left')
+      if form?
+        parent_sheet.render_left_nav
+      else
+        view.render('invoices/nav_left')
+      end
     end
 
     # Needs spacing because parent has no tabs
@@ -28,6 +32,14 @@ module Sheet
 
     def link_url
       view.group_invoice_lists_path(view.group, returning: true)
+    end
+
+    def parent_sheet
+      create_parent(Sheet::Group) if form?
+    end
+
+    def form?
+      %w(new create).include?(view.action_name)
     end
 
   end

--- a/app/helpers/sheet/invoice_list.rb
+++ b/app/helpers/sheet/invoice_list.rb
@@ -1,11 +1,20 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
-#  hitobito and licensed under the Affero General Public License version 3
+#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
-#  https://github.com/hitobito/hitobito.
+#  https://github.com/hitobito/hitobito_cvp.
+
 
 module Sheet
   class InvoiceList < Sheet::Invoice
+
+    def title
+      ::InvoiceList.model_name.human(count: 2)
+    end
+
+    def render_left_nav
+      view.render('invoices/nav_left')
+    end
   end
 end

--- a/app/helpers/sheet/invoice_list.rb
+++ b/app/helpers/sheet/invoice_list.rb
@@ -10,7 +10,11 @@ module Sheet
   class InvoiceList < Sheet::Base
 
     def title
-      ::InvoiceList.model_name.human(count: 2)
+      if entry && !entry.receiver
+        ::Invoice.model_name.human
+      else
+        ::InvoiceList.model_name.human(count: 2)
+      end
     end
 
     def left_nav?

--- a/app/helpers/sheet/invoice_list.rb
+++ b/app/helpers/sheet/invoice_list.rb
@@ -7,14 +7,28 @@
 
 
 module Sheet
-  class InvoiceList < Sheet::Invoice
+  class InvoiceList < Sheet::Base
 
     def title
       ::InvoiceList.model_name.human(count: 2)
     end
 
+    def left_nav?
+      true
+    end
+
     def render_left_nav
       view.render('invoices/nav_left')
     end
+
+    # Needs spacing because parent has no tabs
+    def render_parent_title
+      content_tag(:div, super, style: 'padding-bottom: 1em')
+    end
+
+    def link_url
+      view.group_invoice_lists_path(view.group, returning: true)
+    end
+
   end
 end

--- a/app/jobs/invoice/batch_create_job.rb
+++ b/app/jobs/invoice/batch_create_job.rb
@@ -1,0 +1,16 @@
+class Invoice::BatchCreateJob < BaseJob
+  self.parameters = [:invoice_list_id, :invoice_attributes]
+
+  def initialize(invoice_list_id, invoice_attributes)
+    super()
+    @invoice_list_id = invoice_list_id
+    @invoice_attributes = invoice_attributes
+  end
+
+  def perform
+    invoice_list = InvoiceList.find(@invoice_list_id)
+    invoice_list.invoice = Invoice.new(@invoice_attributes)
+    Invoice::BatchCreate.new(invoice_list).call
+  end
+
+end

--- a/app/models/concerns/payment_slips.rb
+++ b/app/models/concerns/payment_slips.rb
@@ -27,10 +27,6 @@ module PaymentSlips
       ch_esr? || ch_besr?
     end
 
-    def without_reference?
-      !with_reference?
-    end
-
     def bank_with_reference?
       bank? && with_reference?
     end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -92,6 +92,7 @@ class Group < ActiveRecord::Base
 
   has_one :invoice_config, dependent: :destroy
   has_many :invoices
+  has_many :invoice_lists
   has_many :invoice_articles, dependent: :destroy
   has_many :invoice_items, through: :invoices
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -62,8 +62,8 @@ class Invoice < ActiveRecord::Base
 
   before_validation :set_sequence_number, on: :create, if: :group
   before_validation :set_esr_number, on: :create, if: :group
-  before_validation :set_reference_number, on: :create, if: :group
   before_validation :set_payment_attributes, on: :create, if: :group
+  before_validation :set_reference_number, on: :create, if: :group
   before_validation :set_dates, on: :update
   before_validation :set_self_in_nested
   before_validation :recalculate

--- a/app/models/invoice_config.rb
+++ b/app/models/invoice_config.rb
@@ -45,7 +45,7 @@ class InvoiceConfig < ActiveRecord::Base
   validates :email, format: Devise.email_regexp, allow_blank: true
 
   # TODO: probably the if condition is not correct, verification needed
-  validates :iban, presence: true, on: :update, if: :without_reference?
+  validates :iban, presence: true, on: :update, if: :qr?
   validates :iban, format: { with: IBAN_REGEX },
                    on: :update, allow_blank: true
 

--- a/app/models/invoice_list.rb
+++ b/app/models/invoice_list.rb
@@ -26,6 +26,12 @@ class InvoiceList < ActiveRecord::Base
     update(amount_paid: invoices.sum(&:amount_paid), recipients_paid: invoices.payed.count)
   end
 
+  def update_total
+    total_sum = invoices.sum(&:total)
+    total_count = invoices.pluck(:recipient_id).count
+    update(amount_total: total_sum, recipients_total: total_count)
+  end
+
   def receiver_label
     "#{receiver} (#{receiver.model_name.human})"
   end

--- a/app/models/invoice_list.rb
+++ b/app/models/invoice_list.rb
@@ -16,10 +16,9 @@ class InvoiceList < ActiveRecord::Base
 
   validates_by_schema
 
-  def prepare_for_batch_create
-    self.title = invoice.title
-    invoice.recipient = first_recipient
-    invoice.valid?
+  def invoice_parameters
+    invoice_item_attributes = invoice.invoice_items.collect { |item| item.attributes.compact }
+    invoice.attributes.compact.merge(invoice_items_attributes: invoice_item_attributes)
   end
 
   def update_paid

--- a/app/models/invoice_list.rb
+++ b/app/models/invoice_list.rb
@@ -1,0 +1,76 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cvp.
+
+
+class InvoiceList < ActiveRecord::Base
+  belongs_to :group
+  belongs_to :receiver, polymorphic: true
+  belongs_to :creator, class_name: 'Person'
+  has_many :invoices, dependent: :destroy
+
+  attr_accessor :recipient_ids, :invoice
+
+  validates_by_schema
+
+  def receiver_label
+    "#{receiver} (#{receiver.model_name.human})"
+  end
+
+  def multi_create
+    invoice.recipient = first_recipient
+    if invoice.valid?
+      self.title = invoice.title
+      save!
+      Invoice.transaction do
+        create_invoices
+      end
+      save!
+    end
+  end
+
+  def create_invoices
+    recipients.all? do |recipient|
+      attributes = invoice.attributes.merge(
+        invoice_items_attributes: invoice.invoice_items.collect(&:attributes),
+        recipient_id: recipient.id,
+        invoice_list_id: id,
+        creator_id: creator_id
+      )
+      invoice = group.invoices.build(attributes)
+      invoice.save.tap do |result|
+        next unless result
+        self.recipients_total += 1
+        self.amount_total += invoice.total
+      end
+    end || (raise ActiveRecord::Rollback)
+  end
+
+
+  def recipient_ids_count
+    if receiver
+      receiver.people.unscope(:select).count
+    else
+      recipient_ids.split(',').count
+    end
+  end
+
+  def first_recipient
+    if receiver
+      receiver.people.first
+    else
+      Person.find(recipient_ids.split(',').first)
+    end
+  end
+
+  def recipients
+    if receiver
+      receiver.people
+    else
+      Person.where(id: recipient_ids.split(','))
+    end
+  end
+end

--- a/app/models/invoice_list.rb
+++ b/app/models/invoice_list.rb
@@ -13,6 +13,7 @@ class InvoiceList < ActiveRecord::Base
   has_many :invoices, dependent: :destroy
 
   attr_accessor :recipient_ids, :invoice
+  validates :receiver_type, inclusion: %w(MailingList), allow_blank: true
 
   validates_by_schema
 
@@ -52,6 +53,4 @@ class InvoiceList < ActiveRecord::Base
       Person.where(id: recipient_ids.split(','))
     end
   end
-
-
 end

--- a/app/models/invoice_list.rb
+++ b/app/models/invoice_list.rb
@@ -10,10 +10,13 @@ class InvoiceList < ActiveRecord::Base
   belongs_to :group
   belongs_to :receiver, polymorphic: true
   belongs_to :creator, class_name: 'Person'
+  has_one :invoice
   has_many :invoices, dependent: :destroy
 
   attr_accessor :recipient_ids, :invoice
   validates :receiver_type, inclusion: %w(MailingList), allow_blank: true
+
+  scope :list, -> { order(:created_at) }
 
   validates_by_schema
 

--- a/app/models/invoice_list.rb
+++ b/app/models/invoice_list.rb
@@ -7,10 +7,11 @@
 
 
 class InvoiceList < ActiveRecord::Base
+  serialize :invalid_recipient_ids, Array
   belongs_to :group
   belongs_to :receiver, polymorphic: true
   belongs_to :creator, class_name: 'Person'
-  has_one :invoice
+  has_one :invoice, dependent: :destroy
   has_many :invoices, dependent: :destroy
 
   attr_accessor :recipient_ids, :invoice
@@ -18,7 +19,7 @@ class InvoiceList < ActiveRecord::Base
 
   scope :list, -> { order(:created_at) }
 
-  validates_by_schema
+  validates_by_schema except: :invalid_recipient_ids
 
   def invoice_parameters
     invoice_item_attributes = invoice.invoice_items.collect { |item| item.attributes.compact }

--- a/app/views/event/participations/_actions_index.html.haml
+++ b/app/views/event/participations/_actions_index.html.haml
@@ -7,7 +7,7 @@
   = Dropdown::Event::RoleAdd.new(self, @group, @event)
 
 - if can?(:create_invoices_from_list, @group)
-  = invoice_button(entries.collect(&:person))
+  = invoice_button(people: entries.collect(&:person))
 
 = dropdown_people_export(can?(:show_details, entries.first))
 

--- a/app/views/event/participations/_actions_show.html.haml
+++ b/app/views/event/participations/_actions_show.html.haml
@@ -7,7 +7,7 @@
   = button_action_edit
 
 - if can?(:create_invoice, entry.person)
-  = invoice_button([entry.person])
+  = invoice_button(people: [entry.person])
 
 - if can?(:print, entry)
   = action_button(t('global.button.print'),

--- a/app/views/invoice_lists/_actions_index.html.haml
+++ b/app/views/invoice_lists/_actions_index.html.haml
@@ -1,0 +1,4 @@
+- #  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+- #  hitobito_cvp and licensed under the Affero General Public License version 3
+- #  or later. See the COPYING file at the top-level directory or at
+- #  https://github.com/hitobito/hitobito_cvp.

--- a/app/views/invoice_lists/_form.html.haml
+++ b/app/views/invoice_lists/_form.html.haml
@@ -7,17 +7,21 @@
              cancel_url: cancel_url,
              data: { group: group_path(parent) }) do |f|
 
+  = f.hidden_field :receiver_id
+  = f.hidden_field :receiver_type
   = f.hidden_field :recipient_ids
-  = f.labeled_input_field :title, help: t('.recipient_info', count: entry.recipients.size)
 
-  = f.labeled_input_field :description
-  = f.labeled_input_field :payment_information
-  = f.labeled_input_field :payment_purpose
+  = f.fields_for :invoice, entry.invoice do |fi|
+    = fi.labeled_input_field :title, help: t('.recipient_info', count: entry.recipient_ids_count)
 
-  = field_set_tag do
-    = render "invoice_articles", f: f
+    = fi.labeled_input_field :description
+    = fi.labeled_input_field :payment_information
+    = fi.labeled_input_field :payment_purpose
 
-  = field_set_tag do
-    = f.labeled_inline_fields_for :invoice_items, 'invoice_items'
+    = field_set_tag do
+      = render "invoice_articles", f: fi
 
-  = render "calculated", invoice: entry.decorate
+    = field_set_tag do
+      = fi.labeled_inline_fields_for :invoice_items, 'invoice_items'
+
+    = render "calculated", invoice: fi.object.decorate

--- a/app/views/invoice_lists/_form.html.haml
+++ b/app/views/invoice_lists/_form.html.haml
@@ -7,9 +7,12 @@
              cancel_url: cancel_url,
              data: { group: group_path(parent) }) do |f|
 
-  = f.hidden_field :receiver_id
-  = f.hidden_field :receiver_type
-  = f.hidden_field :recipient_ids
+  - if entry.receiver
+    = f.hidden_field :receiver_id
+    = f.hidden_field :receiver_type
+
+  - if entry.recipient_ids
+    = f.hidden_field :recipient_ids
 
   = f.fields_for :invoice, entry.invoice do |fi|
     = fi.labeled_input_field :title, help: t('.recipient_info', count: entry.recipient_ids_count)

--- a/app/views/invoice_lists/_list.html.haml
+++ b/app/views/invoice_lists/_list.html.haml
@@ -1,7 +1,7 @@
 = crud_table do |t|
   - t.col(t.sort_header(:title)) do |item|
     = content_tag(:strong) do
-      = link_to(item.title, group_invoices_path(item.group, invoice_list_id: item.id))
+      = link_to(item.title, group_invoice_list_invoices_path(item.group, item))
   - t.col(t.sort_header(:receiver)) do |item|
     = link_to(item.receiver_label, [item.group, item.receiver]) if item.receiver
 

--- a/app/views/invoice_lists/_list.html.haml
+++ b/app/views/invoice_lists/_list.html.haml
@@ -1,3 +1,7 @@
+- if @year
+  .pull-right
+    = render 'shared/page_per_year', paging_params: { returning: true }
+
 = crud_table do |t|
   - t.col(t.sort_header(:title)) do |item|
     = content_tag(:strong) do

--- a/app/views/invoice_lists/_list.html.haml
+++ b/app/views/invoice_lists/_list.html.haml
@@ -3,6 +3,6 @@
     = content_tag(:strong) do
       = link_to(item.title, group_invoices_path(item.group, invoice_list_id: item.id))
   - t.col(t.sort_header(:receiver)) do |item|
-    = link_to(item.receiver_label, [item.group, item.receiver])
+    = link_to(item.receiver_label, [item.group, item.receiver]) if item.receiver
 
   - t.sortable_attrs(:recipients_total, :amount_total, :recipients_paid, :amount_paid)

--- a/app/views/invoice_lists/_list.html.haml
+++ b/app/views/invoice_lists/_list.html.haml
@@ -9,4 +9,4 @@
   - t.col(t.sort_header(:receiver)) do |item|
     = link_to(item.receiver_label, [item.group, item.receiver]) if item.receiver
 
-  - t.sortable_attrs(:recipients_total, :amount_total, :recipients_paid, :amount_paid)
+  - t.sortable_attrs(:recipients_total, :recipients_paid, :amount_total, :amount_paid)

--- a/app/views/invoice_lists/_list.html.haml
+++ b/app/views/invoice_lists/_list.html.haml
@@ -1,0 +1,8 @@
+= crud_table do |t|
+  - t.col(t.sort_header(:title)) do |item|
+    = content_tag(:strong) do
+      = link_to(item.title, group_invoices_path(item.group, invoice_list_id: item.id))
+  - t.col(t.sort_header(:receiver)) do |item|
+    = link_to(item.receiver_label, [item.group, item.receiver])
+
+  - t.sortable_attrs(:recipients_total, :amount_total, :recipients_paid, :amount_paid)

--- a/app/views/invoice_lists/new.js.haml
+++ b/app/views/invoice_lists/new.js.haml
@@ -3,4 +3,4 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-$('#calculated').html('#{escape_javascript(render('calculated', invoice: entry.decorate))}')
+$('#calculated').html('#{escape_javascript(render('calculated', invoice: entry.invoice.decorate))}')

--- a/app/views/invoices/_actions_index.html.haml
+++ b/app/views/invoices/_actions_index.html.haml
@@ -4,12 +4,14 @@
 -#  https://github.com/hitobito/hitobito.
 
 
-= invoice_sending_dropdown(:group_invoice_list_path)
-
 - if entries.present?
-  = action_button ti('link.delete'), group_invoice_list_path, :'trash-alt', method: :delete, data: { checkable: true }
+  = invoice_sending_dropdown
+  = action_button ti('link.delete'), group_invoice_list_path(group, invoice_list_id: invoice_list&.id), :'trash-alt', method: :delete, data: { checkable: true }
   = invoices_export_dropdown
   = invoices_print_dropdown
-  = action_button(t('invoices.add_payments'), new_group_payment_process_path(parent), :plus)
 
-= action_button(t('invoices.add'), new_group_invoice_path(parent), :plus)
+  - unless @invoice_list
+    = action_button(t('invoices.add_payments'), new_group_payment_process_path(parent), :plus)
+
+- unless @invoice_list
+  = action_button(t('invoices.add'), new_group_invoice_path(parent), :plus)

--- a/app/views/invoices/_actions_show.html.haml
+++ b/app/views/invoices/_actions_show.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-= invoice_sending_dropdown(:group_invoice_list_path) unless entry.payed?
+= invoice_sending_dropdown unless entry.payed?
 = button_action_edit
 = invoices_export_dropdown
 = invoices_print_dropdown

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -14,7 +14,7 @@
     = f.labeled_input_field :recipient_address, rows: 4
 
   = f.labeled_input_field :payment_information, rows: 2
-  - if parent.invoice_config.with_reference?
+  - if parent.invoice_config.with_reference? || entry.qr?
     = f.labeled_input_field :payment_purpose, rows: 2
 
   = field_set_tag do

--- a/app/views/invoices/_nav_left.html.haml
+++ b/app/views/invoices/_nav_left.html.haml
@@ -10,6 +10,7 @@
       = link_to icon('link'), parent, class: 'inline'
     %ul
       = nav Invoice.model_name.human(count: 2), group_invoices_path(parent), %w(invoices)
+      = nav InvoiceList.model_name.human(count: 2), group_invoice_lists_path(parent), %w(invoice_lists)
       = nav InvoiceArticle.model_name.human(count: 2), group_invoice_articles_path(parent), %w(invoice_articles)
       = nav t('navigation.admin'), group_invoice_config_path(parent), %w(invoice_config)
   - else

--- a/app/views/invoices/_nav_left.html.haml
+++ b/app/views/invoices/_nav_left.html.haml
@@ -4,14 +4,15 @@
 -#  https://github.com/hitobito/hitobito.
 
 - current_user.finance_groups.each do |group|
-  - if group == parent
+  - parent_group = parent.is_a?(InvoiceList) ? parent.group : group
+  - if group == parent_group
     .divider
-      = parent
-      = link_to icon('link'), parent, class: 'inline'
+      = group
+      = link_to icon('link'), group, class: 'inline'
     %ul
-      = nav Invoice.model_name.human(count: 2), group_invoices_path(parent), %w(invoices)
-      = nav InvoiceList.model_name.human(count: 2), group_invoice_lists_path(parent), %w(invoice_lists)
-      = nav InvoiceArticle.model_name.human(count: 2), group_invoice_articles_path(parent), %w(invoice_articles)
-      = nav t('navigation.admin'), group_invoice_config_path(parent), %w(invoice_config)
+      = nav Invoice.model_name.human(count: 2), group_invoices_path(group), %w(invoices)
+      = nav InvoiceList.model_name.human(count: 2), group_invoice_lists_path(group), %w(invoice_lists)
+      = nav InvoiceArticle.model_name.human(count: 2), group_invoice_articles_path(group), %w(invoice_articles)
+      = nav t('navigation.admin'), group_invoice_config_path(group), %w(invoice_config)
   - else
     = nav(group, group_invoices_path(group))

--- a/app/views/invoices/_table.html.haml
+++ b/app/views/invoices/_table.html.haml
@@ -5,7 +5,7 @@
   - t.col(check_box_tag(:all, 0, false, { data: :multiselect })) do |i|
     - check_box_tag('ids[]', i.id, false, data: { multiselect: true })
   - t.col(t.sort_header(:title)) do |invoice|
-    %strong= link_to invoice.title, group_invoice_path(parent, invoice)
+    %strong= link_to invoice.title, group_invoice_path(invoice.group_id, invoice)
   - t.sortable_attrs(:sequence_number, :state, :recipient, :issued_at, :sent_at, :due_at)
   - t.col(t.sort_header(:total), class: 'right') { |i| i.decorate.total }
 

--- a/app/views/mailing_lists/_actions_show.html.haml
+++ b/app/views/mailing_lists/_actions_show.html.haml
@@ -7,4 +7,4 @@
 = button_action_destroy if can?(:destroy, entry)
 = button_toggle_subscription
 - if can?(:create_invoices_from_list, entry.group)
-  = invoice_button(Draper.undecorate(entry))
+  = invoice_button(mailing_list: Draper.undecorate(entry))

--- a/app/views/mailing_lists/_actions_show.html.haml
+++ b/app/views/mailing_lists/_actions_show.html.haml
@@ -6,3 +6,5 @@
 = button_action_edit if can?(:edit, entry)
 = button_action_destroy if can?(:destroy, entry)
 = button_toggle_subscription
+- if can?(:create_invoices_from_list, entry.group)
+  = invoice_button(Draper.undecorate(entry))

--- a/app/views/people/_actions_index.html.haml
+++ b/app/views/people/_actions_index.html.haml
@@ -6,7 +6,7 @@
   = action_button(t('.add_person'), new_group_role_path(@group), :plus)
 
 - if can?(:create_invoices_from_list, @group)
-  = invoice_button(people: @people)
+  = invoice_button(filter: list_filter_args.merge(group_id: @group.id))
 
 - if can?(:new, @group.roles.new)
   = action_button(t('.import_list'), new_group_csv_imports_path, :upload)

--- a/app/views/people/_actions_index.html.haml
+++ b/app/views/people/_actions_index.html.haml
@@ -6,7 +6,7 @@
   = action_button(t('.add_person'), new_group_role_path(@group), :plus)
 
 - if can?(:create_invoices_from_list, @group)
-  = invoice_button(@people)
+  = invoice_button(people: @people)
 
 - if can?(:new, @group.roles.new)
   = action_button(t('.import_list'), new_group_csv_imports_path, :upload)

--- a/app/views/people/_actions_show.html.haml
+++ b/app/views/people/_actions_show.html.haml
@@ -10,7 +10,7 @@
   = button_action_destroy(nil, { class: "btn-danger", data: { confirm: t('person.confirm_delete',
                                                               person: entry.person) } })
 - if can?(:create_invoice, entry)
-  = invoice_button([entry])
+  = invoice_button(people: [entry])
 
 = dropdown_people_export(can?(:show_full, entry), false, true, false)
 

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -789,7 +789,7 @@ de:
 
       invoice_list:
         title: Titel
-        receiver: Quelle
+        receiver: Empfänger
         recipients_total: Empfänger Insgesamt
         recipients_paid: Empfänger Bezahlt
         amount_total: Betrag insgesamt

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -205,6 +205,9 @@ de:
       invoice_item:
         one: Rechnungsposten
         other: Rechnungsposten
+      invoice_list:
+        one: Sammelrechnung
+        other: Sammelrechnungen
       label_format:
         one: Etikettenformat
         other: Etikettenformate
@@ -782,6 +785,15 @@ de:
         cost: Betrag
         cost_center: Kostenstelle
         account: Konto
+
+
+      invoice_list:
+        title: Titel
+        receiver: Quelle
+        recipients_total: Empfänger Insgesamt
+        recipients_paid: Empfänger Bezahlt
+        amount_total: Betrag insgesamt
+        amount_paid: Betrag bezahlt
 
       # used for nested attributes
       invoice_items:

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -683,6 +683,7 @@ de:
     create:
       one: "Rechnung <i>%{title}</i> wurde erstellt."
       other: "Rechnung <i>%{title}</i> wurde für %{count} Empfänger erstellt."
+    create_batch: "Rechnung <i>%{title}</i> wird für %{count} Empfänger im Hintergrund erstellt."
     update:
       zero: 'Es muss mindestens eine Rechnung ausgewählt werden.'
       model_error: "Rechnung %{number} ist ungültig - %{error}."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,16 +55,18 @@ Hitobito::Application.routes.draw do
 
       end
 
-      resource :invoice_list, except: [:edit]
-      resource :invoice_config, only: [:edit, :show, :update]
-      resources :invoice_lists
-
       resources :invoices do
         resources :payments, only: :create
       end
       resources :invoice_articles
+      resource :invoice_config, only: [:edit, :show, :update]
 
+      resource :invoice_list, except: [:edit, :show]
+      resources :invoice_lists, only: [:index] do
+        resources :invoices, only: [:index]
+      end
       resource :payment_process, only: [:new, :show, :create]
+
       resources :notes, only: [:index, :create, :destroy]
 
       resources :people, except: [:new, :create] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Hitobito::Application.routes.draw do
 
       resource :invoice_list, except: [:edit]
       resource :invoice_config, only: [:edit, :show, :update]
+      resources :invoice_lists
 
       resources :invoices do
         resources :payments, only: :create

--- a/db/migrate/20201109154535_add_invoice_lists.rb
+++ b/db/migrate/20201109154535_add_invoice_lists.rb
@@ -17,6 +17,7 @@ class AddInvoiceLists < ActiveRecord::Migration[6.0]
       t.integer :recipients_total, default: 0, null: false
       t.integer :recipients_paid, default: 0, null: false
       t.integer :recipients_processed, default: 0, null: false
+      t.text :invalid_recipient_ids
       t.timestamps
     end
 

--- a/db/migrate/20201109154535_add_invoice_lists.rb
+++ b/db/migrate/20201109154535_add_invoice_lists.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cvp.
+
+class AddInvoiceLists < ActiveRecord::Migration[6.0]
+  def change
+    create_table :invoice_lists do |t|
+      t.belongs_to :receiver, polymorphic: true
+      t.belongs_to :group
+      t.belongs_to :creator
+      t.string :title, null: false
+      t.decimal :amount_total, precision: 15, scale: 2, default: 0, null: false
+      t.decimal :amount_payed, precision: 15, scale: 2, default: 0, null: false
+      t.integer :recipients_total, default: 0, null: false
+      t.integer :recipients_payed, default: 0, null: false
+      t.timestamps
+    end
+
+    change_table :invoices do |t|
+      t.belongs_to :invoice_list, null: true
+    end
+  end
+end

--- a/db/migrate/20201109154535_add_invoice_lists.rb
+++ b/db/migrate/20201109154535_add_invoice_lists.rb
@@ -13,9 +13,9 @@ class AddInvoiceLists < ActiveRecord::Migration[6.0]
       t.belongs_to :creator
       t.string :title, null: false
       t.decimal :amount_total, precision: 15, scale: 2, default: 0, null: false
-      t.decimal :amount_payed, precision: 15, scale: 2, default: 0, null: false
+      t.decimal :amount_paid, precision: 15, scale: 2, default: 0, null: false
       t.integer :recipients_total, default: 0, null: false
-      t.integer :recipients_payed, default: 0, null: false
+      t.integer :recipients_paid, default: 0, null: false
       t.timestamps
     end
 

--- a/db/migrate/20201109154535_add_invoice_lists.rb
+++ b/db/migrate/20201109154535_add_invoice_lists.rb
@@ -16,6 +16,7 @@ class AddInvoiceLists < ActiveRecord::Migration[6.0]
       t.decimal :amount_paid, precision: 15, scale: 2, default: 0, null: false
       t.integer :recipients_total, default: 0, null: false
       t.integer :recipients_paid, default: 0, null: false
+      t.integer :recipients_processed, default: 0, null: false
       t.timestamps
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -318,6 +318,7 @@ ActiveRecord::Schema.define(version: 2020_12_22_123403) do
     t.decimal "amount_paid", precision: 15, scale: 2, default: "0.0", null: false
     t.integer "recipients_total", default: 0, null: false
     t.integer "recipients_paid", default: 0, null: false
+    t.integer "recipients_processed", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["creator_id"], name: "index_invoice_lists_on_creator_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -319,6 +319,7 @@ ActiveRecord::Schema.define(version: 2020_12_22_123403) do
     t.integer "recipients_total", default: 0, null: false
     t.integer "recipients_paid", default: 0, null: false
     t.integer "recipients_processed", default: 0, null: false
+    t.text "invalid_recipient_ids"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["creator_id"], name: "index_invoice_lists_on_creator_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -308,6 +308,23 @@ ActiveRecord::Schema.define(version: 2020_12_22_123403) do
     t.index ["invoice_id"], name: "index_invoice_items_on_invoice_id"
   end
 
+  create_table "invoice_lists", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "receiver_type"
+    t.bigint "receiver_id"
+    t.bigint "group_id"
+    t.bigint "creator_id"
+    t.string "title", null: false
+    t.decimal "amount_total", precision: 15, scale: 2, default: "0.0", null: false
+    t.decimal "amount_payed", precision: 15, scale: 2, default: "0.0", null: false
+    t.integer "recipients_total", default: 0, null: false
+    t.integer "recipients_payed", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["creator_id"], name: "index_invoice_lists_on_creator_id"
+    t.index ["group_id"], name: "index_invoice_lists_on_group_id"
+    t.index ["receiver_type", "receiver_id"], name: "index_invoice_lists_on_receiver_type_and_receiver_id"
+  end
+
   create_table "invoices", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", null: false
     t.string "sequence_number", null: false
@@ -338,8 +355,10 @@ ActiveRecord::Schema.define(version: 2020_12_22_123403) do
     t.string "vat_number"
     t.string "currency", default: "CHF", null: false
     t.string "reference", null: false
+    t.bigint "invoice_list_id"
     t.index ["esr_number"], name: "index_invoices_on_esr_number"
     t.index ["group_id"], name: "index_invoices_on_group_id"
+    t.index ["invoice_list_id"], name: "index_invoices_on_invoice_list_id"
     t.index ["recipient_id"], name: "index_invoices_on_recipient_id"
     t.index ["sequence_number"], name: "index_invoices_on_sequence_number"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -315,9 +315,9 @@ ActiveRecord::Schema.define(version: 2020_12_22_123403) do
     t.bigint "creator_id"
     t.string "title", null: false
     t.decimal "amount_total", precision: 15, scale: 2, default: "0.0", null: false
-    t.decimal "amount_payed", precision: 15, scale: 2, default: "0.0", null: false
+    t.decimal "amount_paid", precision: 15, scale: 2, default: "0.0", null: false
     t.integer "recipients_total", default: 0, null: false
-    t.integer "recipients_payed", default: 0, null: false
+    t.integer "recipients_paid", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["creator_id"], name: "index_invoice_lists_on_creator_id"

--- a/spec/abilities/invoice_ability_spec.rb
+++ b/spec/abilities/invoice_ability_spec.rb
@@ -90,4 +90,28 @@ describe InvoiceAbility do
       end
     end
   end
+
+  context 'InvoiceList' do
+
+    def invoice_list(group, abo_group)
+      InvoiceList.new(group: groups(group), receiver: groups(abo_group).mailing_lists.build)
+    end
+
+    def ability(role)
+      Ability.new(roles(role).person)
+    end
+
+    it 'top_leader may work only with abos in his layer' do
+      expect(ability(:top_leader)).to be_able_to(:create, invoice_list(:top_layer, :top_layer))
+      expect(ability(:top_leader)).to be_able_to(:create, invoice_list(:top_layer, :top_group))
+      expect(ability(:top_leader)).not_to be_able_to(:create, invoice_list(:top_layer, :bottom_layer_one))
+    end
+
+    it 'bottom_member may work only with abos in his layer' do
+      expect(ability(:bottom_member)).to be_able_to(:create, invoice_list(:bottom_layer_one, :bottom_layer_one))
+      expect(ability(:bottom_member)).not_to be_able_to(:create, invoice_list(:bottom_layer_one, :top_group))
+      expect(ability(:bottom_member)).not_to be_able_to(:create, invoice_list(:bottom_layer_one, :top_layer))
+    end
+  end
+
 end

--- a/spec/controllers/invoice_lists_controller_spec.rb
+++ b/spec/controllers/invoice_lists_controller_spec.rb
@@ -111,6 +111,16 @@ describe InvoiceListsController do
       expect(invoice.issued_at).to be_present
     end
 
+    it 'PUT#update redirects to invoice_list_invoices path if invoice_list is set' do
+      list = InvoiceList.create!(title: :title, group: group)
+      invoice = Invoice.create!(group: group, title: 'test', recipient: person,
+                                invoice_list: list,
+                                invoice_items_attributes:
+                                  { '1' => { name: 'item1', unit_cost: 1, count: 1}})
+      post :update, params: { group_id: group.id, invoice_list_id: list.id, ids: invoice.id }
+      expect(response).to redirect_to group_invoice_list_invoices_path(group, list, returning: true)
+    end
+
     it 'PUT#update can move multiple invoices at once' do
       invoice = Invoice.create!(group: group, title: 'test', recipient: person,
                                 invoice_items_attributes:

--- a/spec/controllers/invoice_lists_controller_spec.rb
+++ b/spec/controllers/invoice_lists_controller_spec.rb
@@ -39,6 +39,27 @@ describe InvoiceListsController do
     end
   end
 
+  context 'index' do
+    render_views
+    let(:group) { groups(:top_layer) }
+    let(:node) { Capybara::Node::Simple.new(response.body) }
+    let(:column) { node.find('#main table tbody tr td:eq(3)') }
+
+    before { sign_in(people(:top_leader)) }
+
+    it 'renders processed and total Empfänger count' do
+      InvoiceList.create!(group: group, title: 'title', recipients_processed: 10, recipients_total: 20)
+      get :index, params: { group_id: group.id }
+      expect(column).to have_text("10 / 20")
+    end
+
+    it 'renders final Empfänger count' do
+      InvoiceList.create!(group: group, title: 'title', recipients_processed: 20, recipients_total: 20)
+      get :index, params: { group_id: group.id }
+      expect(column).to have_text("20")
+    end
+  end
+
   context 'parameter handling' do
     before { sign_in(person) }
 

--- a/spec/controllers/invoice_lists_controller_spec.rb
+++ b/spec/controllers/invoice_lists_controller_spec.rb
@@ -48,7 +48,7 @@ describe InvoiceListsController do
     end
 
     it 'GET#new assigns assigns invoice_list from receiver' do
-      get :new, params: { group_id: group.id, invoice_list: { receiver_id: list.id, receiver_type: mailing_list.class  } }
+      get :new, params: { group_id: group.id, invoice_list: { receiver_id: list.id, receiver_type: list.class  } }
       expect(response).to render_template('crud/new')
       expect(assigns(:invoice_list).receiver).to eq list
     end

--- a/spec/controllers/invoice_lists_controller_spec.rb
+++ b/spec/controllers/invoice_lists_controller_spec.rb
@@ -45,6 +45,28 @@ describe InvoiceListsController do
       expect(assigns(:invoice_list)).to have(2).recipients
     end
 
+    it "values from filter param" do
+      leader = Fabricate(Group::BottomLayer::Leader.sti_name, group: group).person
+      role_types = [Group::BottomLayer::Leader]
+
+      get :new, {
+        params: {
+          group_id: group.id,
+          invoice_list: { recipient_ids: person.id },
+          filter: {
+            group_id: group.id,
+            range: 'deep',
+            filters: {
+              role: { role_type_ids: role_types.collect(&:id).join("-") }
+            }
+          }
+        }
+      }
+      expect(response).to be_successful
+      expect(assigns(:invoice_list)).to have(1).recipients
+      expect(assigns(:invoice_list).recipients).to eq([leader])
+    end
+
     it "may update when person has finance permission on layer group" do
       put :update, params: { group_id: group.id, invoice_list: { recipient_ids: '' } }
       expect(response).to redirect_to group_invoices_path(group, returning: true)

--- a/spec/controllers/invoice_lists_controller_spec.rb
+++ b/spec/controllers/invoice_lists_controller_spec.rb
@@ -88,6 +88,25 @@ describe InvoiceListsController do
       expect(assigns(:invoice_list)).to have(1).recipients
       expect(assigns(:invoice_list).recipients).to eq([leader])
     end
+
+    it "handles  blank filter params" do
+      leader = Fabricate(Group::BottomLayer::Leader.sti_name, group: group).person
+      role_types = [Group::BottomLayer::Leader]
+
+      get :new, {
+        params: {
+          group_id: group.id,
+          invoice_list: { recipient_ids: person.id },
+          filter: {
+            group_id: group.id,
+            range: '',
+            filters: ''
+          }
+        }
+      }
+      expect(response).to be_successful
+      expect(assigns(:invoice_list)).to have(2).recipients
+    end
   end
 
   context 'sheet title' do

--- a/spec/controllers/invoice_lists_controller_spec.rb
+++ b/spec/controllers/invoice_lists_controller_spec.rb
@@ -22,7 +22,7 @@ describe InvoiceListsController do
 
     it "may update when person has finance permission on layer group" do
       put :update, params: { group_id: group.id, invoice_list: { recipient_ids: [] } }
-      expect(response).to redirect_to group_invoices_path(group)
+      expect(response).to redirect_to group_invoices_path(group, returning: true)
     end
 
     it "may not index when person has finance permission on layer group" do
@@ -66,7 +66,7 @@ describe InvoiceListsController do
         post :create, params: { group_id: group.id, invoice_list: { recipient_ids: person.id, invoice: invoice_attrs } }
       end.to change { group.invoices.count }.by(1)
 
-      expect(response).to redirect_to group_invoices_path(group)
+      expect(response).to redirect_to group_invoices_path(group, returning: true)
       expect(flash[:notice]).to include 'Rechnung <i>Title</i> wurde erstellt.'
     end
 
@@ -89,7 +89,7 @@ describe InvoiceListsController do
 
     it 'PUT#update informs if not invoice has been selected' do
       post :update, params: { group_id: group.id }
-      expect(response).to redirect_to group_invoices_path(group)
+      expect(response).to redirect_to group_invoices_path(group, returning: true)
       expect(flash[:alert]).to include 'Es muss mindestens eine Rechnung ausgewählt werden.'
     end
 
@@ -104,7 +104,7 @@ describe InvoiceListsController do
           end.to change { invoice.reload.updated_at }
         end.not_to change { Delayed::Job.count }
       end
-      expect(response).to redirect_to group_invoices_path(group)
+      expect(response).to redirect_to group_invoices_path(group, returning: true)
       expect(flash[:notice][0]).to match /Rechnung \d+-\d+ wurde gestellt./
       expect(invoice.reload.state).to eq 'issued'
       expect(invoice.due_at).to be_present
@@ -124,7 +124,7 @@ describe InvoiceListsController do
           post :update, params: { group_id: group.id, ids: [invoice.id, other.id].join(',') }
         end.to change { other.reload.updated_at }
       end
-      expect(response).to redirect_to group_invoices_path(group)
+      expect(response).to redirect_to group_invoices_path(group, returning: true)
       expect(flash[:notice]).to include '2 Rechnungen wurden gestellt.'
     end
 
@@ -137,14 +137,14 @@ describe InvoiceListsController do
         post :update, params: { group_id: group.id, ids: [invoice.id].join(','), mail: 'true' }
       end.to change { Delayed::Job.count }.by(1)
 
-      expect(response).to redirect_to group_invoices_path(group)
+      expect(response).to redirect_to group_invoices_path(group, returning: true)
       expect(flash[:notice][0]).to match(/Rechnung \d+-\d+ wurde gestellt./)
       expect(flash[:notice][1]).to match(/Rechnung \d+-\d+ wird im Hintergrund per E-Mail verschickt./)
     end
 
     it 'DELETE#destroy informs if no invoice has been selected' do
       delete :destroy, params: { group_id: group.id }
-      expect(response).to redirect_to group_invoices_path(group)
+      expect(response).to redirect_to group_invoices_path(group, returning: true)
       expect(flash[:alert]).to include 'Zuerst muss eine Rechnung ausgewählt werden.'
     end
 
@@ -153,7 +153,7 @@ describe InvoiceListsController do
       expect do
         travel(1.day) { delete :destroy, params: { group_id: group.id, ids: invoice.id } }
       end.to change { invoice.reload.updated_at }
-      expect(response).to redirect_to group_invoices_path(group)
+      expect(response).to redirect_to group_invoices_path(group, returning: true)
       expect(flash[:notice]).to include 'Rechnung wurde storniert.'
       expect(invoice.reload.state).to eq 'cancelled'
     end
@@ -166,7 +166,7 @@ describe InvoiceListsController do
           delete :destroy, params: { group_id: group.id, ids: [invoice.id, other.id].join(',') }
         end
       end.to change { other.reload.updated_at }
-      expect(response).to redirect_to group_invoices_path(group)
+      expect(response).to redirect_to group_invoices_path(group, returning: true)
       expect(flash[:notice]).to include '2 Rechnungen wurden storniert.'
       expect(other.reload.state).to eq 'cancelled'
     end

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -25,6 +25,19 @@ describe PaymentsController do
     expect(response).to redirect_to(group_invoice_path(group, invoice))
   end
 
+  it 'POST#creates valid arguments create payment and updates invoice_list' do
+    list = InvoiceList.create(title: :title, group: invoice.group)
+    invoice.update(state: :sent, invoice_list: list)
+    expect do
+      post :create, params: { group_id: group.id, invoice_id: invoice.id, payment: { amount: invoice.total } }
+    end.to change { invoice.payments.count }.by(1)
+
+    expect(flash[:notice]).to be_present
+    expect(response).to redirect_to(group_invoice_path(group, invoice))
+    expect(list.reload.recipients_paid).to eq 1
+    expect(list.amount_paid).to eq invoice.total
+  end
+
   it 'POST#creates invalid arguments redirect back' do
     invoice.update(state: :sent)
     expect do

--- a/spec/domain/invoice/batch_create_spec.rb
+++ b/spec/domain/invoice/batch_create_spec.rb
@@ -9,6 +9,8 @@
 require 'spec_helper'
 
 describe Invoice::BatchCreate do
+  include ActiveJob::TestHelper
+
   let(:mailing_list) { mailing_lists(:leaders) }
   let(:group)        { groups(:top_layer) }
   let(:person)       { people(:top_leader) }
@@ -27,7 +29,7 @@ describe Invoice::BatchCreate do
     list.invoice = invoice
 
     expect do
-      Invoice::BatchCreate.new(list).call
+      Invoice::BatchCreate.call(list)
     end.to change { [group.invoices.count, group.invoice_items.count] }.by([1, 2])
     expect(list.reload).to have(1).invoices
     expect(list.receiver).to eq mailing_list
@@ -35,6 +37,32 @@ describe Invoice::BatchCreate do
     expect(list.recipients_paid).to eq 0
     expect(list.amount_total).to eq 2.5
     expect(list.amount_paid).to eq 0
+  end
+
+  it '#call offloads to job when recipients exceed limit' do
+    Fabricate(Group::TopGroup::Leader.sti_name, group: groups(:top_group))
+    Subscription.create!(mailing_list: mailing_list,
+                         subscriber: group,
+                         role_types: [Group::TopGroup::Leader])
+
+    list = InvoiceList.new(receiver: mailing_list, group: group, title: :title)
+
+    invoice = Invoice.new(title: 'invoice', group: group)
+    invoice.invoice_items.build(name: 'pens', unit_cost: 1.5)
+    invoice.invoice_items.build(name: 'pins', unit_cost: 0.5, count: 2)
+    list.invoice = invoice
+
+    expect do
+      Invoice::BatchCreate.call(list, 1)
+      Delayed::Job.last.payload_object.perform
+    end.to change { [group.invoices.count, group.invoice_items.count] }.by([2, 4])
+    expect(list.reload).to have(2).invoices
+    expect(list.receiver).to eq mailing_list
+    expect(list.recipients_total).to eq 2
+    expect(list.recipients_paid).to eq 0
+    expect(list.amount_total).to eq 5
+    expect(list.amount_paid).to eq 0
+    expect(list.recipients_processed).to eq 2
   end
 
   it '#call does not create any list model for recipient_ids' do
@@ -47,12 +75,12 @@ describe Invoice::BatchCreate do
     list.invoice = invoice
 
     expect do
-      Invoice::BatchCreate.new(list).call
+      Invoice::BatchCreate.call(list)
     end.to change { [group.invoices.count, group.invoice_items.count] }.by([2, 4])
     expect(list).not_to be_persisted
   end
 
-  it '#call does rollback if any save fails' do
+  xit '#call does rollback if any save fails' do
     list = InvoiceList.new(group: group)
     list.recipient_ids = [person.id, other_person.id].join(',')
 

--- a/spec/domain/invoice/batch_create_spec.rb
+++ b/spec/domain/invoice/batch_create_spec.rb
@@ -1,0 +1,71 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cvp.
+
+
+require 'spec_helper'
+
+describe Invoice::BatchCreate do
+  let(:mailing_list) { mailing_lists(:leaders) }
+  let(:group)        { groups(:top_layer) }
+  let(:person)       { people(:top_leader) }
+  let(:other_person) { people(:bottom_member) }
+
+  it '#call creates invoices for abo' do
+    Subscription.create!(mailing_list: mailing_list,
+                         subscriber: group,
+                         role_types: [Group::TopGroup::Leader])
+
+    list = InvoiceList.new(receiver: mailing_list, group: group, title: :title)
+
+    invoice = Invoice.new(title: 'invoice', group: group)
+    invoice.invoice_items.build(name: 'pens', unit_cost: 1.5)
+    invoice.invoice_items.build(name: 'pins', unit_cost: 0.5, count: 2)
+    list.invoice = invoice
+
+    expect do
+      Invoice::BatchCreate.new(list).call
+    end.to change { [group.invoices.count, group.invoice_items.count] }.by([1, 2])
+    expect(list.reload).to have(1).invoices
+    expect(list.receiver).to eq mailing_list
+    expect(list.recipients_total).to eq 1
+    expect(list.recipients_paid).to eq 0
+    expect(list.amount_total).to eq 2.5
+    expect(list.amount_paid).to eq 0
+  end
+
+  it '#call does not create any list model for recipient_ids' do
+    list = InvoiceList.new(group: group)
+    list.recipient_ids = [person.id, other_person.id].join(',')
+
+    invoice = Invoice.new(title: 'invoice', group: group)
+    invoice.invoice_items.build(name: 'pens', unit_cost: 1.5)
+    invoice.invoice_items.build(name: 'pins', unit_cost: 0.5, count: 2)
+    list.invoice = invoice
+
+    expect do
+      Invoice::BatchCreate.new(list).call
+    end.to change { [group.invoices.count, group.invoice_items.count] }.by([2, 4])
+    expect(list).not_to be_persisted
+  end
+
+  it '#call does rollback if any save fails' do
+    list = InvoiceList.new(group: group)
+    list.recipient_ids = [person.id, other_person.id].join(',')
+
+    invoice = Invoice.new(title: 'invoice', group: group)
+    invoice.invoice_items.build(name: 'pens', unit_cost: 1.5)
+    list.invoice = invoice
+
+    allow_any_instance_of(Invoice).to receive(:save).and_wrap_original do |m|
+      @saved = @saved ? false : m.call
+    end
+
+    expect do
+      Invoice::BatchCreate.new(list).call
+    end.not_to change { [group.invoices.count, group.invoice_items.count] }
+  end
+end

--- a/spec/domain/invoice/filter_spec.rb
+++ b/spec/domain/invoice/filter_spec.rb
@@ -21,4 +21,10 @@ describe Invoice::Filter do
     filtered = Invoice::Filter.new(year: today.last_year.year).apply(Invoice)
     expect(filtered.count).to eq 1
   end
+
+  it 'filters by invoice_list_id' do
+    invoice.update(invoice_list_id: 1)
+    filtered = Invoice::Filter.new(invoice_list_id: 1).apply(Invoice)
+    expect(filtered.count).to eq 1
+  end
 end

--- a/spec/domain/invoice/payment_processor_spec.rb
+++ b/spec/domain/invoice/payment_processor_spec.rb
@@ -31,6 +31,20 @@ describe Invoice::PaymentProcessor do
     expect(invoice.reload).to be_payed
   end
 
+  it 'creates payment and marks invoice as payed and updates invoice_list' do
+    list = InvoiceList.create!(title: :title, group: invoice.group)
+    invoice.update_columns(esr_number: '00 00000 00000 10000 00000 00905',
+                           invoice_list_id: list.id,
+                           total: 710.82)
+    expect do
+      expect(parser.process).to eq 1
+    end.to change { Payment.count }.by(1)
+    expect(invoice.reload).to be_payed
+    expect(list.reload.amount_paid.to_s).to eq '710.82'
+    expect(list.reload.recipients_paid).to eq 1
+  end
+
+
   it 'invalid payments only produce set alert' do
     expect(parser.alert).to be_present
     expect(parser.notice).to be_blank

--- a/spec/domain/invoice/payment_processor_spec.rb
+++ b/spec/domain/invoice/payment_processor_spec.rb
@@ -33,7 +33,7 @@ describe Invoice::PaymentProcessor do
 
   it 'creates payment and marks invoice as payed and updates invoice_list' do
     list = InvoiceList.create!(title: :title, group: invoice.group)
-    invoice.update_columns(esr_number: '00 00000 00000 10000 00000 00905',
+    invoice.update_columns(reference: '000000000000100000000000905',
                            invoice_list_id: list.id,
                            total: 710.82)
     expect do

--- a/spec/domain/invoice/qrcode_spec.rb
+++ b/spec/domain/invoice/qrcode_spec.rb
@@ -98,14 +98,14 @@ describe Invoice::Qrcode do
   describe :additional_infos do
     subject { invoice.qrcode.additional_infos }
     it 'reads payment_purpose' do
-      invoice.payment_information = "Some\ndata"
+      invoice.payment_purpose = "Some\ndata"
       expect(subject[:purpose]).to eq 'Some data'
       expect(subject[:trailer]).to eq 'EPD'
       expect(subject[:infos]).to be_nil
     end
 
     it 'truncates payment_purpose to 120 chars' do
-      invoice.payment_information = "A" * 121
+      invoice.payment_purpose = "A" * 121
       expect(subject[:purpose].size).to eq 120
     end
   end

--- a/spec/domain/invoice/qrcode_spec.rb
+++ b/spec/domain/invoice/qrcode_spec.rb
@@ -95,6 +95,21 @@ describe Invoice::Qrcode do
     end
   end
 
+  describe :additional_infos do
+    subject { invoice.qrcode.additional_infos }
+    it 'reads payment_purpose' do
+      invoice.payment_information = "Some\ndata"
+      expect(subject[:purpose]).to eq 'Some data'
+      expect(subject[:trailer]).to eq 'EPD'
+      expect(subject[:infos]).to be_nil
+    end
+
+    it 'truncates payment_purpose to 120 chars' do
+      invoice.payment_information = "A" * 121
+      expect(subject[:purpose].size).to eq 120
+    end
+  end
+
   describe :debitor do
     subject { invoice.qrcode.debitor }
     it 'is extracted from recipient_address' do

--- a/spec/models/invoice_config_spec.rb
+++ b/spec/models/invoice_config_spec.rb
@@ -16,10 +16,22 @@ describe InvoiceConfig do
   describe 'payment_slip dependent validations' do
     subject { Fabricate(Group::BottomLayer.sti_name, id: 1).reload.invoice_config }
 
+    it 'qr' do
+      subject.payment_slip = 'qr'
+      expect(subject).not_to be_valid
+      expect(subject.errors.keys).to eq [:payee, :iban]
+    end
+
+    it 'no_ps' do
+      subject.payment_slip = 'no_ps'
+      expect(subject).not_to be_valid
+      expect(subject.errors.keys).to eq [:payee]
+    end
+
     it 'ch_es' do
       subject.payment_slip = 'ch_es'
       expect(subject).not_to be_valid
-      expect(subject.errors.keys).to eq [:payee, :iban]
+      expect(subject.errors.keys).to eq [:payee]
     end
 
     it 'ch_esr' do
@@ -31,7 +43,7 @@ describe InvoiceConfig do
     it 'ch_bes' do
       subject.payment_slip = 'ch_bes'
       expect(subject).not_to be_valid
-      expect(subject.errors.keys).to eq [:payee, :beneficiary, :iban]
+      expect(subject.errors.keys).to eq [:payee, :beneficiary]
     end
 
     it 'ch_besr' do
@@ -40,17 +52,6 @@ describe InvoiceConfig do
       expect(subject.errors.keys).to eq [:payee, :beneficiary, :participant_number, :participant_number_internal]
     end
 
-    it 'no_ps' do
-      subject.payment_slip = 'no_ps'
-      expect(subject).not_to be_valid
-      expect(subject.errors.keys).to eq [:payee, :iban]
-    end
-
-    it 'qr' do
-      subject.payment_slip = 'qr'
-      expect(subject).not_to be_valid
-      expect(subject.errors.keys).to eq [:payee, :iban]
-    end
   end
 
   it 'validates correct payee format'

--- a/spec/models/invoice_list_spec.rb
+++ b/spec/models/invoice_list_spec.rb
@@ -28,63 +28,6 @@ describe InvoiceList do
     expect(subject.first_recipient).to eq person
   end
 
-  it '#multi_create creates invoices for abo' do
-    subject.receiver = list
-    Subscription.create!(mailing_list: list,
-                         subscriber: group,
-                         role_types: [Group::TopGroup::Leader])
-    subject.group = group
-
-    invoice = Invoice.new(title: 'invoice', group: group)
-    invoice.invoice_items.build(name: 'pens', unit_cost: 1.5)
-    invoice.invoice_items.build(name: 'pins', unit_cost: 0.5, count: 2)
-    subject.invoice = invoice
-
-    expect do
-      subject.multi_create
-    end.to change { [group.invoices.count, group.invoice_items.count] }.by([1, 2])
-    expect(subject.reload).to have(1).invoices
-    expect(subject.receiver).to eq list
-  end
-
-  it '#multi_create creates invoices for multiple recipients' do
-    subject.recipient_ids = [person.id, other_person.id].join(',')
-    subject.group = group
-
-    invoice = Invoice.new(title: 'invoice', group: group)
-    invoice.invoice_items.build(name: 'pens', unit_cost: 1.5)
-    invoice.invoice_items.build(name: 'pins', unit_cost: 0.5, count: 2)
-    subject.invoice = invoice
-
-    expect do
-      subject.multi_create
-    end.to change { [group.invoices.count, group.invoice_items.count] }.by([2, 4])
-    expect(subject.reload).to have(2).invoices
-
-    expect(subject.receiver_type).to be_nil
-    expect(subject.recipients_total).to eq 2
-    expect(subject.recipients_paid).to eq 0
-    expect(subject.amount_total).to eq 5
-    expect(subject.amount_paid).to eq 0
-  end
-
-  it '#multi_create does rollback if any save fails' do
-    subject.recipient_ids = [person.id, other_person.id].join(',')
-    subject.group = group
-
-    invoice = Invoice.new(title: 'invoice', group: group)
-    invoice.invoice_items.build(name: 'pens', unit_cost: 1.5)
-    subject.invoice = invoice
-
-    allow_any_instance_of(Invoice).to receive(:save).and_wrap_original do |m|
-      @saved = @saved ? false : m.call
-    end
-
-    expect do
-      subject.multi_create
-    end.not_to change { [group.invoices.count, group.invoice_items.count] }
-  end
-
   it '#update_paid updates payment informations' do
     subject.update(group: group, title: :title)
     invoice = subject.invoices.create!(title: :title, recipient_id: person.id, total: 10, group: group)
@@ -94,5 +37,4 @@ describe InvoiceList do
     expect(subject.amount_paid).to eq 10
     expect(subject.recipients_paid).to eq 1
   end
-
 end

--- a/spec/models/invoice_list_spec.rb
+++ b/spec/models/invoice_list_spec.rb
@@ -1,0 +1,88 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cvp.
+
+require 'spec_helper'
+
+describe InvoiceList do
+  let(:list)         { mailing_lists(:leaders) }
+  let(:group)        { groups(:top_layer) }
+  let(:person)       { people(:top_leader) }
+  let(:other_person) { people(:bottom_member) }
+
+  it 'accepts recipient_ids as comma-separates values' do
+    subject.attributes = { recipient_ids: "#{person.id},#{other_person.id}" }
+    expect(subject.recipient_ids_count).to eq 2
+    expect(subject.first_recipient).to eq person
+  end
+
+  it 'accepts receiver as id and type' do
+    Subscription.create!(mailing_list: list,
+                         subscriber: group,
+                         role_types: [Group::TopGroup::Leader])
+    subject.attributes = { receiver_type: 'MailingList', receiver_id: list.id }
+    expect(subject.recipient_ids_count).to eq 1
+    expect(subject.first_recipient).to eq person
+  end
+
+  it '#multi_create creates invoices for abo' do
+    subject.receiver = list
+    Subscription.create!(mailing_list: list,
+                         subscriber: group,
+                         role_types: [Group::TopGroup::Leader])
+    subject.group = group
+
+    invoice = Invoice.new(title: 'invoice', group: group)
+    invoice.invoice_items.build(name: 'pens', unit_cost: 1.5)
+    invoice.invoice_items.build(name: 'pins', unit_cost: 0.5, count: 2)
+    subject.invoice = invoice
+
+    expect do
+      subject.multi_create
+    end.to change { [group.invoices.count, group.invoice_items.count] }.by([1, 2])
+    expect(subject.reload).to have(1).invoices
+    expect(subject.receiver).to eq list
+  end
+
+  it '#multi_create creates invoices for multiple recipients' do
+    subject.recipient_ids = [person.id, other_person.id].join(',')
+    subject.group = group
+
+    invoice = Invoice.new(title: 'invoice', group: group)
+    invoice.invoice_items.build(name: 'pens', unit_cost: 1.5)
+    invoice.invoice_items.build(name: 'pins', unit_cost: 0.5, count: 2)
+    subject.invoice = invoice
+
+    expect do
+      subject.multi_create
+    end.to change { [group.invoices.count, group.invoice_items.count] }.by([2, 4])
+    expect(subject.reload).to have(2).invoices
+
+    expect(subject.receiver_type).to be_nil
+    expect(subject.recipients_total).to eq 2
+    expect(subject.recipients_paid).to eq 0
+    expect(subject.amount_total).to eq 5
+    expect(subject.amount_paid).to eq 0
+  end
+
+  it '#multi_create does rollsback if any save fails' do
+    subject.recipient_ids = [person.id, other_person.id].join(',')
+    subject.group = group
+
+    invoice = Invoice.new(title: 'invoice', group: group)
+    invoice.invoice_items.build(name: 'pens', unit_cost: 1.5)
+    subject.invoice = invoice
+
+    allow_any_instance_of(Invoice).to receive(:save).and_wrap_original do |m|
+      @saved = @saved ? false : m.call
+    end
+
+    expect do
+      subject.multi_create
+    end.not_to change { [group.invoices.count, group.invoice_items.count] }
+  end
+end
+

--- a/spec/models/invoice_list_spec.rb
+++ b/spec/models/invoice_list_spec.rb
@@ -28,6 +28,14 @@ describe InvoiceList do
     expect(subject.first_recipient).to eq person
   end
 
+  it 'only accepts mailing list as receiver' do
+    subject.attributes = { title: :test, receiver: list }
+    expect(subject).to be_valid
+
+    subject.attributes = { title: :test, receiver: group }
+    expect(subject).not_to be_valid
+  end
+
   it '#update_paid updates payment informations' do
     subject.update(group: group, title: :title)
     invoice = subject.invoices.create!(title: :title, recipient_id: person.id, total: 10, group: group)

--- a/spec/models/invoice_list_spec.rb
+++ b/spec/models/invoice_list_spec.rb
@@ -68,7 +68,7 @@ describe InvoiceList do
     expect(subject.amount_paid).to eq 0
   end
 
-  it '#multi_create does rollsback if any save fails' do
+  it '#multi_create does rollback if any save fails' do
     subject.recipient_ids = [person.id, other_person.id].join(',')
     subject.group = group
 
@@ -84,5 +84,15 @@ describe InvoiceList do
       subject.multi_create
     end.not_to change { [group.invoices.count, group.invoice_items.count] }
   end
-end
 
+  it '#update_paid updates payment informations' do
+    subject.update(group: group, title: :title)
+    invoice = subject.invoices.create!(title: :title, recipient_id: person.id, total: 10, group: group)
+    subject.invoices.create!(title: :title, recipient_id: other_person.id, total: 20, group: group)
+    invoice.payments.create!(amount: 10)
+    subject.update_paid
+    expect(subject.amount_paid).to eq 10
+    expect(subject.recipients_paid).to eq 1
+  end
+
+end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -101,37 +101,6 @@ describe Invoice do
     expect(invoice.total).to eq(1.5)
   end
 
-  it '#recipients loads people from recipient_ids' do
-    invoice = Invoice.new(title: 'invoice', group: group)
-    invoice.recipient_ids = "2,b,#{person.id},c,"
-    expect(invoice.recipients).to eq [person]
-  end
-
-  it '#multi_create creates invoices for multiple recipients' do
-    invoice = Invoice.new(title: 'invoice', group: group)
-    invoice.recipient_ids = [person.id, other_person.id].join(',')
-    invoice.invoice_items.build(name: 'pens', unit_cost: 1.5)
-    invoice.invoice_items.build(name: 'pins', unit_cost: 0.5, count: 2)
-
-    expect do
-      invoice.multi_create
-    end.to change { [group.invoices.count, group.invoice_items.count] }.by([2, 4])
-  end
-
-  it '#multi_create does rollsback if any save fails' do
-    invoice = Invoice.new(title: 'invoice', group: group)
-    invoice.recipient_ids = [person.id, other_person.id].join(',')
-    invoice.invoice_items.build(name: 'pens', unit_cost: 1.5)
-
-    allow_any_instance_of(Invoice).to receive(:save).and_wrap_original do |m|
-      @saved = @saved ? false : m.call
-    end
-
-    expect do
-      invoice.multi_create
-    end.not_to change { [group.invoices.count, group.invoice_items.count] }
-  end
-
   it '#to_s returns total amount' do
     invoice = invoices(:invoice)
     expect(invoice.to_s).to eq "Invoice(#{invoice.sequence_number}): 5.35"

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -135,11 +135,13 @@ describe Invoice do
     end
 
     it 'sets esr without blanks for qr invoice with qr iban' do
-      expect(create_invoice(payment_slip: :qr, iban: qr_iban).reference).to eq esr_without_blanks
+      group.invoice_config.update(payment_slip: :qr, iban: qr_iban)
+      expect(create_invoice.reference).to eq esr_without_blanks
     end
 
     it 'sets cors for qr invoice without qr iban' do
-      expect(create_invoice(payment_slip: :qr, iban: iban).reference).to eq 'RF29834963567Z1'
+      group.invoice_config.update(payment_slip: :qr, iban: iban)
+      expect(create_invoice.reference).to eq 'RF29834963567Z1'
     end
   end
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -25,12 +25,14 @@ describe Payment do
       invoice.payments.create!(amount: invoice.total)
     end.to change { invoice.state }
     expect(invoice.state).to eq 'payed'
+    expect(invoice.amount_open).to eq 0.0
   end
 
   it 'creating a smaller payment does not change invoice state' do
     expect do
       invoice.payments.create!(amount: invoice.total - 1)
     end.not_to change { invoice.state }
+    expect(invoice.amount_open).to eq 1.0
   end
 
   it 'allows multiple payments for same invoice without reference' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = 'random'
 
-  config.backtrace_exclusion_patterns = [/lib\/rspec/]
+  config.backtrace_exclusion_patterns = [/lib\/rspec/, /asdf/]
   config.example_status_persistence_file_path = Rails.root.join('tmp', 'examples.txt').to_s
 
   config.include(MailerMacros)

--- a/spec/views/invoice_lists/_form.html.haml_spec.rb
+++ b/spec/views/invoice_lists/_form.html.haml_spec.rb
@@ -1,19 +1,20 @@
 require 'spec_helper'
 
 describe 'invoice_lists/_form.html.haml' do
-  let(:group)   { groups(:bottom_layer_one) }
-  let(:person)  { people(:bottom_member) }
-  let(:invoice) { group.invoices.build }
-  let(:dom)     { Capybara::Node::Simple.new(render) }
+  let(:group)        {  groups(:bottom_layer_one) }
+  let(:person)       {  people(:bottom_member) }
+  let(:invoice)      {  group.invoices.build }
+  let(:invoice_list) {  InvoiceList.new(group: group, recipient_ids: '1,2', invoice: invoice) }
+  let(:dom)          {  Capybara::Node::Simple.new(render) }
 
   before do
     allow(view).to receive_messages({
       current_user: person,
       parent: group,
       cancel_url: '',
-      model_class: Invoice,
-      entry: invoice,
-      path_args: [group, invoice]
+      model_class: InvoiceList,
+      entry: invoice_list,
+      path_args: [group, invoice_list]
     })
 
     allow(controller).to receive_messages(current_user: person)


### PR DESCRIPTION
Erlaubt für Empfänger eines Abos eine Sammelrechnung zu erstellen. Dazu wird vom Abo aus eine neue Sammelrechnung 
erstellt. Je nach Anzahl Empfänger werden die Einzelrechnungen über eine Job erstellt. 

Sammelrechnungen sind als eigener Menüpunkt unter Rechnungen aufgeführt und zeigen einen Zusammenzug der Einzelrechnungen (Empfänger, Betrag Total, Betrag Bezahlt an).  Von einer Sammelrechnung kann zu den dazugehörigen Einzelrechnungen navigiert werden  (`optional_nesting`) 


refs hitobito/hitobito_cvp#54