### PR TITLE
Annotate wieder aktiveren

### DIFF
--- a/app/models/additional_email.rb
+++ b/app/models/additional_email.rb
@@ -9,12 +9,16 @@
 # Table name: additional_emails
 #
 #  id               :integer          not null, primary key
-#  contactable_id   :integer          not null
 #  contactable_type :string(255)      not null
 #  email            :string(255)      not null
 #  label            :string(255)
-#  public           :boolean          default(TRUE), not null
 #  mailings         :boolean          default(FALSE), not null
+#  public           :boolean          default(TRUE), not null
+#  contactable_id   :integer          not null
+#
+# Indexes
+#
+#  index_additional_emails_on_contactable_id_and_contactable_type  (contactable_id,contactable_type)
 #
 
 class AdditionalEmail < ActiveRecord::Base

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -10,14 +10,18 @@
 # Table name: addresses
 #
 #  id               :bigint           not null, primary key
-#  street_short     :string(128)      not null
-#  street_short_old :string(128)      not null
+#  numbers          :text(16777215)
+#  state            :string(128)      not null
 #  street_long      :string(128)      not null
 #  street_long_old  :string(128)      not null
+#  street_short     :string(128)      not null
+#  street_short_old :string(128)      not null
 #  town             :string(128)      not null
 #  zip_code         :integer          not null
-#  state            :string(128)      not null
-#  numbers          :text(16777215)
+#
+# Indexes
+#
+#  index_addresses_on_zip_code_and_street_short  (zip_code,street_short)
 #
 
 class Address < ActiveRecord::Base

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,38 +11,44 @@
 # Table name: events
 #
 #  id                          :integer          not null, primary key
-#  type                        :string(255)
+#  applicant_count             :integer          default(0)
+#  application_closing_at      :date
+#  application_conditions      :text(16777215)
+#  application_opening_at      :date
+#  applications_cancelable     :boolean          default(FALSE), not null
+#  cost                        :string(255)
+#  description                 :text(16777215)
+#  display_booking_info        :boolean          default(TRUE), not null
+#  external_applications       :boolean          default(FALSE)
+#  hidden_contact_attrs        :text(16777215)
+#  location                    :text(16777215)
+#  maximum_participants        :integer
+#  motto                       :string(255)
 #  name                        :string(255)      not null
 #  number                      :string(255)
-#  motto                       :string(255)
-#  cost                        :string(255)
-#  maximum_participants        :integer
-#  contact_id                  :integer
-#  description                 :text(65535)
-#  location                    :text(65535)
-#  application_opening_at      :date
-#  application_closing_at      :date
-#  application_conditions      :text(65535)
-#  kind_id                     :integer
-#  state                       :string(60)
-#  priorization                :boolean          default(FALSE), not null
-#  requires_approval           :boolean          default(FALSE), not null
-#  created_at                  :datetime
-#  updated_at                  :datetime
 #  participant_count           :integer          default(0)
-#  application_contact_id      :integer
-#  external_applications       :boolean          default(FALSE)
-#  applicant_count             :integer          default(0)
-#  teamer_count                :integer          default(0)
+#  participations_visible      :boolean          default(FALSE), not null
+#  priorization                :boolean          default(FALSE), not null
+#  required_contact_attrs      :text(16777215)
+#  requires_approval           :boolean          default(FALSE), not null
 #  signature                   :boolean
 #  signature_confirmation      :boolean
 #  signature_confirmation_text :string(255)
+#  state                       :string(60)
+#  teamer_count                :integer          default(0)
+#  type                        :string(255)
+#  waiting_list                :boolean          default(TRUE), not null
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  application_contact_id      :integer
+#  contact_id                  :integer
 #  creator_id                  :integer
+#  kind_id                     :integer
 #  updater_id                  :integer
-#  applications_cancelable     :boolean          default(FALSE), not null
-#  required_contact_attrs      :text(65535)
-#  hidden_contact_attrs        :text(65535)
-#  display_booking_info        :boolean          default(TRUE), not null
+#
+# Indexes
+#
+#  index_events_on_kind_id  (kind_id)
 #
 
 # An event is any single or multi-day event that has participants and a

--- a/app/models/event/answer.rb
+++ b/app/models/event/answer.rb
@@ -9,9 +9,13 @@
 # Table name: event_answers
 #
 #  id               :integer          not null, primary key
+#  answer           :string(255)
 #  participation_id :integer          not null
 #  question_id      :integer          not null
-#  answer           :string(255)
+#
+# Indexes
+#
+#  index_event_answers_on_participation_id_and_question_id  (participation_id,question_id) UNIQUE
 #
 
 class Event::Answer < ActiveRecord::Base

--- a/app/models/event/application.rb
+++ b/app/models/event/application.rb
@@ -9,13 +9,13 @@
 # Table name: event_applications
 #
 #  id                   :integer          not null, primary key
-#  priority_1_id        :integer          not null
-#  priority_2_id        :integer
-#  priority_3_id        :integer
 #  approved             :boolean          default(FALSE), not null
 #  rejected             :boolean          default(FALSE), not null
 #  waiting_list         :boolean          default(FALSE), not null
-#  waiting_list_comment :text(65535)
+#  waiting_list_comment :text(16777215)
+#  priority_1_id        :integer          not null
+#  priority_2_id        :integer
+#  priority_3_id        :integer
 #
 
 class Event::Application < ActiveRecord::Base

--- a/app/models/event/attachment.rb
+++ b/app/models/event/attachment.rb
@@ -9,8 +9,12 @@
 # Table name: event_attachments
 #
 #  id       :integer          not null, primary key
-#  event_id :integer          not null
 #  file     :string(255)      not null
+#  event_id :integer          not null
+#
+# Indexes
+#
+#  index_event_attachments_on_event_id  (event_id)
 #
 
 class Event::Attachment < ActiveRecord::Base

--- a/app/models/event/course.rb
+++ b/app/models/event/course.rb
@@ -9,38 +9,44 @@
 # Table name: events
 #
 #  id                          :integer          not null, primary key
-#  type                        :string(255)
+#  applicant_count             :integer          default(0)
+#  application_closing_at      :date
+#  application_conditions      :text(16777215)
+#  application_opening_at      :date
+#  applications_cancelable     :boolean          default(FALSE), not null
+#  cost                        :string(255)
+#  description                 :text(16777215)
+#  display_booking_info        :boolean          default(TRUE), not null
+#  external_applications       :boolean          default(FALSE)
+#  hidden_contact_attrs        :text(16777215)
+#  location                    :text(16777215)
+#  maximum_participants        :integer
+#  motto                       :string(255)
 #  name                        :string(255)      not null
 #  number                      :string(255)
-#  motto                       :string(255)
-#  cost                        :string(255)
-#  maximum_participants        :integer
-#  contact_id                  :integer
-#  description                 :text(65535)
-#  location                    :text(65535)
-#  application_opening_at      :date
-#  application_closing_at      :date
-#  application_conditions      :text(65535)
-#  kind_id                     :integer
-#  state                       :string(60)
-#  priorization                :boolean          default(FALSE), not null
-#  requires_approval           :boolean          default(FALSE), not null
-#  created_at                  :datetime
-#  updated_at                  :datetime
 #  participant_count           :integer          default(0)
-#  application_contact_id      :integer
-#  external_applications       :boolean          default(FALSE)
-#  applicant_count             :integer          default(0)
-#  teamer_count                :integer          default(0)
+#  participations_visible      :boolean          default(FALSE), not null
+#  priorization                :boolean          default(FALSE), not null
+#  required_contact_attrs      :text(16777215)
+#  requires_approval           :boolean          default(FALSE), not null
 #  signature                   :boolean
 #  signature_confirmation      :boolean
 #  signature_confirmation_text :string(255)
+#  state                       :string(60)
+#  teamer_count                :integer          default(0)
+#  type                        :string(255)
+#  waiting_list                :boolean          default(TRUE), not null
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  application_contact_id      :integer
+#  contact_id                  :integer
 #  creator_id                  :integer
+#  kind_id                     :integer
 #  updater_id                  :integer
-#  applications_cancelable     :boolean          default(FALSE), not null
-#  required_contact_attrs      :text(65535)
-#  hidden_contact_attrs        :text(65535)
-#  display_booking_info        :boolean          default(TRUE), not null
+#
+# Indexes
+#
+#  index_events_on_kind_id  (kind_id)
 #
 
 # A course is a specialised Event that has by default applications,

--- a/app/models/event/course/role/participant.rb
+++ b/app/models/event/course/role/participant.rb
@@ -9,9 +9,14 @@
 # Table name: event_roles
 #
 #  id               :integer          not null, primary key
+#  label            :string(255)
 #  type             :string(255)      not null
 #  participation_id :integer          not null
-#  label            :string(255)
+#
+# Indexes
+#
+#  index_event_roles_on_participation_id  (participation_id)
+#  index_event_roles_on_type              (type)
 #
 
 # Kursteilnehmer

--- a/app/models/event/date.rb
+++ b/app/models/event/date.rb
@@ -9,11 +9,16 @@
 # Table name: event_dates
 #
 #  id        :integer          not null, primary key
-#  event_id  :integer          not null
-#  label     :string(255)
-#  start_at  :datetime
 #  finish_at :datetime
+#  label     :string(255)
 #  location  :string(255)
+#  start_at  :datetime
+#  event_id  :integer          not null
+#
+# Indexes
+#
+#  index_event_dates_on_event_id               (event_id)
+#  index_event_dates_on_event_id_and_start_at  (event_id,start_at)
 #
 
 class Event::Date < ActiveRecord::Base

--- a/app/models/event/kind_qualification_kind.rb
+++ b/app/models/event/kind_qualification_kind.rb
@@ -9,11 +9,16 @@
 # Table name: event_kind_qualification_kinds
 #
 #  id                    :integer          not null, primary key
+#  category              :string(255)      not null
+#  grouping              :integer
+#  role                  :string(255)      not null
 #  event_kind_id         :integer          not null
 #  qualification_kind_id :integer          not null
-#  category              :string(255)      not null
-#  role                  :string(255)      not null
-#  grouping              :integer
+#
+# Indexes
+#
+#  index_event_kind_qualification_kinds_on_category  (category)
+#  index_event_kind_qualification_kinds_on_role      (role)
 #
 
 class Event::KindQualificationKind < ActiveRecord::Base

--- a/app/models/event/participation.rb
+++ b/app/models/event/participation.rb
@@ -9,14 +9,21 @@
 # Table name: event_participations
 #
 #  id                     :integer          not null, primary key
-#  event_id               :integer          not null
-#  person_id              :integer          not null
-#  additional_information :text(65535)
+#  active                 :boolean          default(FALSE), not null
+#  additional_information :text(16777215)
+#  qualified              :boolean
 #  created_at             :datetime
 #  updated_at             :datetime
-#  active                 :boolean          default(FALSE), not null
 #  application_id         :integer
-#  qualified              :boolean
+#  event_id               :integer          not null
+#  person_id              :integer          not null
+#
+# Indexes
+#
+#  index_event_participations_on_application_id          (application_id)
+#  index_event_participations_on_event_id                (event_id)
+#  index_event_participations_on_event_id_and_person_id  (event_id,person_id) UNIQUE
+#  index_event_participations_on_person_id               (person_id)
 #
 
 class Event::Participation < ActiveRecord::Base

--- a/app/models/event/question.rb
+++ b/app/models/event/question.rb
@@ -11,12 +11,14 @@
 # Table name: event_questions
 #
 #  id               :integer          not null, primary key
-#  event_id         :integer
-#  question         :string(255)
-#  choices          :string(255)
+#  admin            :boolean          default(FALSE), not null
 #  multiple_choices :boolean          default(FALSE), not null
 #  required         :boolean          default(FALSE), not null
-#  admin            :boolean          default(FALSE), not null
+#  event_id         :integer
+#
+# Indexes
+#
+#  index_event_questions_on_event_id  (event_id)
 #
 
 class Event::Question < ActiveRecord::Base

--- a/app/models/event/role.rb
+++ b/app/models/event/role.rb
@@ -9,9 +9,14 @@
 # Table name: event_roles
 #
 #  id               :integer          not null, primary key
+#  label            :string(255)
 #  type             :string(255)      not null
 #  participation_id :integer          not null
-#  label            :string(255)
+#
+# Indexes
+#
+#  index_event_roles_on_participation_id  (participation_id)
+#  index_event_roles_on_type              (type)
 #
 
 class Event::Role < ActiveRecord::Base

--- a/app/models/event/role/assistant_leader.rb
+++ b/app/models/event/role/assistant_leader.rb
@@ -9,9 +9,14 @@
 # Table name: event_roles
 #
 #  id               :integer          not null, primary key
+#  label            :string(255)
 #  type             :string(255)      not null
 #  participation_id :integer          not null
-#  label            :string(255)
+#
+# Indexes
+#
+#  index_event_roles_on_participation_id  (participation_id)
+#  index_event_roles_on_type              (type)
 #
 
 # Hilfsleiter

--- a/app/models/event/role/cook.rb
+++ b/app/models/event/role/cook.rb
@@ -9,9 +9,14 @@
 # Table name: event_roles
 #
 #  id               :integer          not null, primary key
+#  label            :string(255)
 #  type             :string(255)      not null
 #  participation_id :integer          not null
-#  label            :string(255)
+#
+# Indexes
+#
+#  index_event_roles_on_participation_id  (participation_id)
+#  index_event_roles_on_type              (type)
 #
 
 # Kueche

--- a/app/models/event/role/helper.rb
+++ b/app/models/event/role/helper.rb
@@ -9,9 +9,14 @@
 # Table name: event_roles
 #
 #  id               :integer          not null, primary key
+#  label            :string(255)
 #  type             :string(255)      not null
 #  participation_id :integer          not null
-#  label            :string(255)
+#
+# Indexes
+#
+#  index_event_roles_on_participation_id  (participation_id)
+#  index_event_roles_on_type              (type)
 #
 
 # Kueche

--- a/app/models/event/role/leader.rb
+++ b/app/models/event/role/leader.rb
@@ -9,9 +9,14 @@
 # Table name: event_roles
 #
 #  id               :integer          not null, primary key
+#  label            :string(255)
 #  type             :string(255)      not null
 #  participation_id :integer          not null
-#  label            :string(255)
+#
+# Indexes
+#
+#  index_event_roles_on_participation_id  (participation_id)
+#  index_event_roles_on_type              (type)
 #
 
 # Hauptsleiter

--- a/app/models/event/role/participant.rb
+++ b/app/models/event/role/participant.rb
@@ -9,9 +9,14 @@
 # Table name: event_roles
 #
 #  id               :integer          not null, primary key
+#  label            :string(255)
 #  type             :string(255)      not null
 #  participation_id :integer          not null
-#  label            :string(255)
+#
+# Indexes
+#
+#  index_event_roles_on_participation_id  (participation_id)
+#  index_event_roles_on_type              (type)
 #
 
 # Teilnehmer

--- a/app/models/event/role/speaker.rb
+++ b/app/models/event/role/speaker.rb
@@ -9,9 +9,14 @@
 # Table name: event_roles
 #
 #  id               :integer          not null, primary key
+#  label            :string(255)
 #  type             :string(255)      not null
 #  participation_id :integer          not null
-#  label            :string(255)
+#
+# Indexes
+#
+#  index_event_roles_on_participation_id  (participation_id)
+#  index_event_roles_on_type              (type)
 #
 
 # Referent

--- a/app/models/event/role/treasurer.rb
+++ b/app/models/event/role/treasurer.rb
@@ -9,9 +9,14 @@
 # Table name: event_roles
 #
 #  id               :integer          not null, primary key
+#  label            :string(255)
 #  type             :string(255)      not null
 #  participation_id :integer          not null
-#  label            :string(255)
+#
+# Indexes
+#
+#  index_event_roles_on_participation_id  (participation_id)
+#  index_event_roles_on_type              (type)
 #
 
 # Kassier

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -9,27 +9,35 @@
 # Table name: groups
 #
 #  id                          :integer          not null, primary key
-#  parent_id                   :integer
-#  lft                         :integer
-#  rgt                         :integer
-#  name                        :string(255)      not null
-#  short_name                  :string(31)
-#  type                        :string(255)      not null
-#  email                       :string(255)
-#  address                     :string(1024)
-#  zip_code                    :integer
-#  town                        :string(255)
+#  address                     :text(16777215)
 #  country                     :string(255)
-#  contact_id                  :integer
+#  deleted_at                  :datetime
+#  description                 :text(16777215)
+#  email                       :string(255)
+#  lft                         :integer
+#  logo                        :string(255)
+#  name                        :string(255)      not null
+#  require_person_add_requests :boolean          default(FALSE), not null
+#  rgt                         :integer
+#  short_name                  :string(31)
+#  town                        :string(255)
+#  type                        :string(255)      not null
+#  zip_code                    :integer
 #  created_at                  :datetime
 #  updated_at                  :datetime
-#  deleted_at                  :datetime
-#  layer_group_id              :integer
+#  contact_id                  :integer
 #  creator_id                  :integer
-#  updater_id                  :integer
 #  deleter_id                  :integer
-#  require_person_add_requests :boolean          default(FALSE), not null
-#  description                 :text(65535)
+#  layer_group_id              :integer
+#  parent_id                   :integer
+#  updater_id                  :integer
+#
+# Indexes
+#
+#  index_groups_on_layer_group_id  (layer_group_id)
+#  index_groups_on_lft_and_rgt     (lft,rgt)
+#  index_groups_on_parent_id       (parent_id)
+#  index_groups_on_type            (type)
 #
 
 class Group < ActiveRecord::Base

--- a/app/models/help_text.rb
+++ b/app/models/help_text.rb
@@ -4,10 +4,14 @@
 # Table name: help_texts
 #
 #  id         :integer          not null, primary key
-#  controller :string(255)      not null
-#  model      :string(255)
-#  kind       :string(255)      not null
-#  name       :string(255)      not null
+#  controller :string(100)      not null
+#  kind       :string(100)      not null
+#  model      :string(100)
+#  name       :string(100)      not null
+#
+# Indexes
+#
+#  index_help_texts_fields  (controller,model,kind,name) UNIQUE
 #
 
 #  Copyright (c) 2019, Pfadibewegung Schweiz. This file is part of

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,33 +7,44 @@
 # Table name: invoices
 #
 #  id                          :integer          not null, primary key
-#  title                       :string(255)      not null
+#  account_number              :string(255)
+#  address                     :text(16777215)
+#  beneficiary                 :text(16777215)
+#  currency                    :string(255)      default("CHF"), not null
+#  description                 :text(16777215)
+#  due_at                      :date
+#  esr_number                  :string(255)      not null
+#  iban                        :string(255)
+#  issued_at                   :date
+#  participant_number          :string(255)
+#  participant_number_internal :string(255)
+#  payee                       :text(16777215)
+#  payment_information         :text(16777215)
+#  payment_purpose             :text(16777215)
+#  payment_slip                :string(255)      default("ch_es"), not null
+#  recipient_address           :text(16777215)
+#  recipient_email             :string(255)
+#  reference                   :string(255)      not null
+#  sent_at                     :date
 #  sequence_number             :string(255)      not null
 #  state                       :string(255)      default("draft"), not null
-#  esr_number                  :string(255)      not null
-#  description                 :text(65535)
-#  recipient_email             :string(255)
-#  recipient_address           :text(65535)
-#  sent_at                     :date
-#  due_at                      :date
-#  group_id                    :integer          not null
-#  recipient_id                :integer
+#  title                       :string(255)      not null
 #  total                       :decimal(12, 2)
+#  vat_number                  :string(255)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
-#  account_number              :string(255)
-#  address                     :text(65535)
-#  issued_at                   :date
-#  iban                        :string(255)
-#  payment_purpose             :text(65535)
-#  payment_information         :text(65535)
-#  payment_slip                :string(255)      default("ch_es"), not null
-#  beneficiary                 :text(65535)
-#  payee                       :text(65535)
-#  participant_number          :string(255)
 #  creator_id                  :integer
-#  participant_number_internal :string(255)
-#  vat_number                  :string(255)
+#  group_id                    :integer          not null
+#  invoice_list_id             :bigint
+#  recipient_id                :integer
+#
+# Indexes
+#
+#  index_invoices_on_esr_number       (esr_number)
+#  index_invoices_on_group_id         (group_id)
+#  index_invoices_on_invoice_list_id  (invoice_list_id)
+#  index_invoices_on_recipient_id     (recipient_id)
+#  index_invoices_on_sequence_number  (sequence_number)
 #
 
 class Invoice < ActiveRecord::Base

--- a/app/models/invoice_article.rb
+++ b/app/models/invoice_article.rb
@@ -9,17 +9,21 @@
 # Table name: invoice_articles
 #
 #  id          :integer          not null, primary key
-#  number      :string(255)
-#  name        :string(255)      not null
-#  description :text(65535)
+#  account     :string(255)
 #  category    :string(255)
+#  cost_center :string(255)
+#  description :text(16777215)
+#  name        :string(255)      not null
+#  number      :string(255)
 #  unit_cost   :decimal(12, 2)
 #  vat_rate    :decimal(5, 2)
-#  cost_center :string(255)
-#  account     :string(255)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  group_id    :integer          not null
+#
+# Indexes
+#
+#  index_invoice_articles_on_number_and_group_id  (number,group_id) UNIQUE
 #
 
 class InvoiceArticle < ActiveRecord::Base

--- a/app/models/invoice_config.rb
+++ b/app/models/invoice_config.rb
@@ -9,20 +9,25 @@
 # Table name: invoice_configs
 #
 #  id                          :integer          not null, primary key
-#  sequence_number             :integer          default(1), not null
-#  due_days                    :integer          default(30), not null
-#  group_id                    :integer          not null
-#  address                     :text(65535)
-#  payment_information         :text(65535)
 #  account_number              :string(255)
-#  iban                        :string(255)
-#  payment_slip                :string(255)      default("ch_es"), not null
-#  beneficiary                 :text(65535)
-#  payee                       :text(65535)
-#  participant_number          :string(255)
+#  address                     :text(16777215)
+#  beneficiary                 :text(16777215)
+#  currency                    :string(255)      default("CHF"), not null
+#  due_days                    :integer          default(30), not null
 #  email                       :string(255)
+#  iban                        :string(255)
+#  participant_number          :string(255)
 #  participant_number_internal :string(255)
+#  payee                       :text(16777215)
+#  payment_information         :text(16777215)
+#  payment_slip                :string(255)      default("ch_es"), not null
+#  sequence_number             :integer          default(1), not null
 #  vat_number                  :string(255)
+#  group_id                    :integer          not null
+#
+# Indexes
+#
+#  index_invoice_configs_on_group_id  (group_id)
 #
 
 class InvoiceConfig < ActiveRecord::Base

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -9,14 +9,18 @@
 # Table name: invoice_items
 #
 #  id          :integer          not null, primary key
-#  invoice_id  :integer          not null
-#  name        :string(255)      not null
-#  description :text(65535)
-#  vat_rate    :decimal(5, 2)
-#  unit_cost   :decimal(12, 2)   not null
-#  count       :integer          default(1), not null
-#  cost_center :string(255)
 #  account     :string(255)
+#  cost_center :string(255)
+#  count       :integer          default(1), not null
+#  description :text(16777215)
+#  name        :string(255)      not null
+#  unit_cost   :decimal(12, 2)   not null
+#  vat_rate    :decimal(5, 2)
+#  invoice_id  :integer          not null
+#
+# Indexes
+#
+#  index_invoice_items_on_invoice_id  (invoice_id)
 #
 
 class InvoiceItem < ActiveRecord::Base

--- a/app/models/invoice_list.rb
+++ b/app/models/invoice_list.rb
@@ -1,5 +1,32 @@
 # encoding: utf-8
 
+# == Schema Information
+#
+# Table name: invoice_lists
+#
+#  id                    :bigint           not null, primary key
+#  amount_paid           :decimal(15, 2)   default(0.0), not null
+#  amount_total          :decimal(15, 2)   default(0.0), not null
+#  invalid_recipient_ids :text(65535)
+#  receiver_type         :string(255)
+#  recipients_paid       :integer          default(0), not null
+#  recipients_processed  :integer          default(0), not null
+#  recipients_total      :integer          default(0), not null
+#  title                 :string(255)      not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  creator_id            :bigint
+#  group_id              :bigint
+#  receiver_id           :bigint
+#
+# Indexes
+#
+#  index_invoice_lists_on_creator_id                     (creator_id)
+#  index_invoice_lists_on_group_id                       (group_id)
+#  index_invoice_lists_on_receiver_type_and_receiver_id  (receiver_type,receiver_id)
+#
+
+
 #  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
 #  hitobito_cvp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -9,9 +9,13 @@
 # Table name: locations
 #
 #  id       :integer          not null, primary key
-#  name     :string(255)      not null
 #  canton   :string(2)        not null
+#  name     :string(255)      not null
 #  zip_code :string(255)      not null
+#
+# Indexes
+#
+#  index_locations_on_zip_code_and_canton_and_name  (zip_code,canton,name) UNIQUE
 #
 
 class Location < ActiveRecord::Base

--- a/app/models/mail_log.rb
+++ b/app/models/mail_log.rb
@@ -11,13 +11,18 @@
 #
 #  id                :integer          not null, primary key
 #  mail_from         :string(255)
-#  mail_subject      :string(255)
 #  mail_hash         :string(255)
-#  status            :integer          default(0)
+#  mail_subject      :string(255)
 #  mailing_list_name :string(255)
-#  mailing_list_id   :integer
+#  status            :integer          default("retreived")
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  mailing_list_id   :integer
+#
+# Indexes
+#
+#  index_mail_logs_on_mail_hash        (mail_hash)
+#  index_mail_logs_on_mailing_list_id  (mailing_list_id)
 #
 
 class MailLog < ActiveRecord::Base

--- a/app/models/mailing_list.rb
+++ b/app/models/mailing_list.rb
@@ -8,23 +8,29 @@
 #
 # Table name: mailing_lists
 #
-#  id                       :integer          not null, primary key
-#  name                     :string(255)      not null
-#  group_id                 :integer          not null
-#  description              :text(65535)
-#  publisher                :string(255)
-#  mail_name                :string(255)
-#  additional_sender        :string(255)
-#  subscribable             :boolean          default(FALSE), not null
-#  subscribers_may_post     :boolean          default(FALSE), not null
-#  anyone_may_post          :boolean          default(FALSE), not null
-#  preferred_labels         :string(255)
-#  delivery_report          :boolean          default(FALSE), not null
-#  main_email               :boolean          default(FALSE)
-#  mailchimp_api_key        :string(255)
-#  mailchimp_list_id        :string(255)
-#  mailchimp_syncing        :boolean          default(FALSE)
-#  mailchimp_last_synced_at :datetime
+#  id                                  :integer          not null, primary key
+#  additional_sender                   :string(255)
+#  anyone_may_post                     :boolean          default(FALSE), not null
+#  delivery_report                     :boolean          default(FALSE), not null
+#  description                         :text(16777215)
+#  mail_name                           :string(255)
+#  mailchimp_api_key                   :string(255)
+#  mailchimp_include_additional_emails :boolean          default(FALSE)
+#  mailchimp_last_synced_at            :datetime
+#  mailchimp_result                    :text(16777215)
+#  mailchimp_syncing                   :boolean          default(FALSE)
+#  main_email                          :boolean          default(FALSE)
+#  name                                :string(255)      not null
+#  preferred_labels                    :string(255)
+#  publisher                           :string(255)
+#  subscribable                        :boolean          default(FALSE), not null
+#  subscribers_may_post                :boolean          default(FALSE), not null
+#  group_id                            :integer          not null
+#  mailchimp_list_id                   :string(255)
+#
+# Indexes
+#
+#  index_mailing_lists_on_group_id  (group_id)
 #
 
 class MailingList < ActiveRecord::Base

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -9,12 +9,16 @@
 # Table name: notes
 #
 #  id           :integer          not null, primary key
-#  subject_id   :integer          not null
-#  author_id    :integer          not null
-#  text         :text(65535)
+#  subject_type :string(255)
+#  text         :text(16777215)
 #  created_at   :datetime
 #  updated_at   :datetime
-#  subject_type :string(255)
+#  author_id    :integer          not null
+#  subject_id   :integer          not null
+#
+# Indexes
+#
+#  index_notes_on_subject_id  (subject_id)
 #
 
 class Note < ActiveRecord::Base

--- a/app/models/oauth/access_grant.rb
+++ b/app/models/oauth/access_grant.rb
@@ -2,15 +2,26 @@
 #
 # Table name: oauth_access_grants
 #
-#  id                :integer          not null, primary key
-#  resource_owner_id :integer          not null
-#  application_id    :integer          not null
-#  token             :string(255)      not null
-#  expires_in        :integer          not null
-#  redirect_uri      :text(65535)      not null
-#  created_at        :datetime         not null
-#  revoked_at        :datetime
-#  scopes            :string(255)
+#  id                    :integer          not null, primary key
+#  code_challenge        :string(255)
+#  code_challenge_method :string(255)
+#  expires_in            :integer          not null
+#  redirect_uri          :text(16777215)   not null
+#  revoked_at            :datetime
+#  scopes                :string(255)
+#  token                 :string(255)      not null
+#  created_at            :datetime         not null
+#  application_id        :integer          not null
+#  resource_owner_id     :integer          not null
+#
+# Indexes
+#
+#  fk_rails_b4b53e07b8                 (application_id)
+#  index_oauth_access_grants_on_token  (token) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (application_id => oauth_applications.id)
 #
 
 module Oauth

--- a/app/models/oauth/access_token.rb
+++ b/app/models/oauth/access_token.rb
@@ -3,15 +3,26 @@
 # Table name: oauth_access_tokens
 #
 #  id                     :integer          not null, primary key
-#  resource_owner_id      :integer
-#  application_id         :integer
-#  token                  :string(255)      not null
-#  refresh_token          :string(255)
 #  expires_in             :integer
-#  revoked_at             :datetime
-#  created_at             :datetime         not null
-#  scopes                 :string(255)
 #  previous_refresh_token :string(255)      default(""), not null
+#  refresh_token          :string(255)
+#  revoked_at             :datetime
+#  scopes                 :string(255)
+#  token                  :string(255)      not null
+#  created_at             :datetime         not null
+#  application_id         :integer
+#  resource_owner_id      :integer
+#
+# Indexes
+#
+#  fk_rails_732cb83ab7                             (application_id)
+#  index_oauth_access_tokens_on_refresh_token      (refresh_token) UNIQUE
+#  index_oauth_access_tokens_on_resource_owner_id  (resource_owner_id)
+#  index_oauth_access_tokens_on_token              (token) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (application_id => oauth_applications.id)
 #
 
 module Oauth

--- a/app/models/oauth/application.rb
+++ b/app/models/oauth/application.rb
@@ -3,14 +3,18 @@
 # Table name: oauth_applications
 #
 #  id           :integer          not null, primary key
-#  name         :string(255)      not null
-#  uid          :string(255)      not null
-#  secret       :string(255)      not null
-#  redirect_uri :text(65535)      not null
-#  scopes       :string(255)      default(""), not null
 #  confidential :boolean          default(TRUE), not null
+#  name         :string(255)      not null
+#  redirect_uri :text(16777215)   not null
+#  scopes       :string(255)      default(""), not null
+#  secret       :string(255)      not null
+#  uid          :string(255)      not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_oauth_applications_on_uid  (uid) UNIQUE
 #
 
 module Oauth

--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -10,15 +10,20 @@
 # Table name: versions
 #
 #  id             :integer          not null, primary key
-#  item_type      :string(255)      not null
-#  item_id        :integer          not null
 #  event          :string(255)      not null
-#  whodunnit      :string(255)
-#  object         :text(65535)
-#  object_changes :text(65535)
+#  item_type      :string(255)      not null
 #  main_type      :string(255)
-#  main_id        :integer
+#  object         :text(16777215)
+#  object_changes :text(16777215)
+#  whodunnit      :string(255)
 #  created_at     :datetime
+#  item_id        :integer          not null
+#  main_id        :integer
+#
+# Indexes
+#
+#  index_versions_on_item_type_and_item_id  (item_type,item_id)
+#  index_versions_on_main_id_and_main_type  (main_id,main_type)
 #
 
 module PaperTrail

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -5,10 +5,14 @@
 # Table name: payments
 #
 #  id          :integer          not null, primary key
-#  invoice_id  :integer          not null
 #  amount      :decimal(12, 2)   not null
 #  received_at :date             not null
 #  reference   :string(255)
+#  invoice_id  :integer          not null
+#
+# Indexes
+#
+#  index_payments_on_invoice_id  (invoice_id)
 #
 
 #  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of

--- a/app/models/payment_reminder.rb
+++ b/app/models/payment_reminder.rb
@@ -9,13 +9,17 @@
 # Table name: payment_reminders
 #
 #  id         :integer          not null, primary key
-#  invoice_id :integer          not null
 #  due_at     :date             not null
+#  level      :integer
+#  text       :string(255)
+#  title      :string(255)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  title      :string(255)
-#  text       :string(255)
-#  level      :integer
+#  invoice_id :integer          not null
+#
+# Indexes
+#
+#  index_payment_reminders_on_invoice_id  (invoice_id)
 #
 
 class PaymentReminder < ActiveRecord::Base

--- a/app/models/payment_reminder_config.rb
+++ b/app/models/payment_reminder_config.rb
@@ -3,11 +3,15 @@
 # Table name: payment_reminder_configs
 #
 #  id                :integer          not null, primary key
-#  invoice_config_id :integer          not null
-#  title             :string(255)      not null
-#  text              :string(255)      not null
 #  due_days          :integer          not null
 #  level             :integer          not null
+#  text              :string(255)      not null
+#  title             :string(255)      not null
+#  invoice_config_id :integer          not null
+#
+# Indexes
+#
+#  index_payment_reminder_configs_on_invoice_config_id  (invoice_config_id)
 #
 
 class PaymentReminderConfig < ActiveRecord::Base

--- a/app/models/people_filter.rb
+++ b/app/models/people_filter.rb
@@ -9,13 +9,17 @@
 # Table name: people_filters
 #
 #  id           :integer          not null, primary key
-#  name         :string(255)      not null
-#  group_id     :integer
+#  filter_chain :text(16777215)
 #  group_type   :string(255)
-#  filter_chain :text(65535)
+#  name         :string(255)      not null
 #  range        :string(255)      default("deep")
 #  created_at   :datetime
 #  updated_at   :datetime
+#  group_id     :integer
+#
+# Indexes
+#
+#  index_people_filters_on_group_id_and_group_type  (group_id,group_type)
 #
 
 class PeopleFilter < ActiveRecord::Base

--- a/app/models/people_relation.rb
+++ b/app/models/people_relation.rb
@@ -9,9 +9,14 @@
 # Table name: people_relations
 #
 #  id      :integer          not null, primary key
+#  kind    :string(255)      not null
 #  head_id :integer          not null
 #  tail_id :integer          not null
-#  kind    :string(255)      not null
+#
+# Indexes
+#
+#  index_people_relations_on_head_id  (head_id)
+#  index_people_relations_on_tail_id  (tail_id)
 #
 
 # Relates two people together. Every relation has an opposite that is created,

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,43 +1,63 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
 # Table name: people
 #
 #  id                        :integer          not null, primary key
-#  first_name                :string(255)
-#  last_name                 :string(255)
-#  company_name              :string(255)
-#  nickname                  :string(255)
-#  company                   :boolean          default(FALSE), not null
-#  email                     :string(255)
-#  address                   :string(1024)
-#  zip_code                  :string(255)
-#  town                      :string(255)
-#  country                   :string(255)
-#  gender                    :string(1)
+#  additional_information    :text(16777215)
+#  additional_languages      :string(255)
+#  address                   :text(16777215)
+#  advertising               :string(255)
+#  authentication_token      :string(255)
 #  birthday                  :date
-#  additional_information    :text(65535)
+#  company                   :boolean          default(FALSE), not null
+#  company_name              :string(255)
 #  contact_data_visible      :boolean          default(FALSE), not null
+#  correspondence_language   :string(255)
+#  country                   :string(255)
+#  current_sign_in_at        :datetime
+#  current_sign_in_ip        :string(255)
+#  email                     :string(255)
+#  encrypted_password        :string(255)
+#  event_feed_token          :string(255)
+#  failed_attempts           :integer          default(0)
+#  first_name                :string(255)
+#  gender                    :string(1)
+#  household_key             :string(255)
+#  last_name                 :string(255)
+#  last_sign_in_at           :datetime
+#  last_sign_in_ip           :string(255)
+#  locked_at                 :datetime
+#  nationality               :string(255)
+#  nickname                  :string(255)
+#  picture                   :string(255)
+#  remember_created_at       :datetime
+#  reset_password_sent_at    :datetime
+#  reset_password_token      :string(255)
+#  show_global_label_formats :boolean          default(TRUE), not null
+#  sign_in_count             :integer          default(0)
+#  title                     :string(255)
+#  town                      :string(255)
+#  unlock_token              :string(255)
+#  zip_code                  :string(255)
 #  created_at                :datetime
 #  updated_at                :datetime
-#  encrypted_password        :string(255)
-#  reset_password_token      :string(255)
-#  reset_password_sent_at    :datetime
-#  remember_created_at       :datetime
-#  sign_in_count             :integer          default(0)
-#  current_sign_in_at        :datetime
-#  last_sign_in_at           :datetime
-#  current_sign_in_ip        :string(255)
-#  last_sign_in_ip           :string(255)
-#  picture                   :string(255)
-#  last_label_format_id      :integer
 #  creator_id                :integer
-#  updater_id                :integer
+#  last_label_format_id      :integer
 #  primary_group_id          :integer
-#  failed_attempts           :integer          default(0)
-#  locked_at                 :datetime
-#  authentication_token      :string(255)
-#  show_global_label_formats :boolean          default(TRUE), not null
-#  household_key             :string(255)
+#  updater_id                :integer
+#
+# Indexes
+#
+#  index_people_on_authentication_token  (authentication_token)
+#  index_people_on_email                 (email) UNIQUE
+#  index_people_on_event_feed_token      (event_feed_token) UNIQUE
+#  index_people_on_first_name            (first_name)
+#  index_people_on_household_key         (household_key)
+#  index_people_on_last_name             (last_name)
+#  index_people_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_people_on_unlock_token          (unlock_token) UNIQUE
 #
 
 class Person < ActiveRecord::Base

--- a/app/models/person/add_request.rb
+++ b/app/models/person/add_request.rb
@@ -9,12 +9,17 @@
 # Table name: person_add_requests
 #
 #  id           :integer          not null, primary key
+#  role_type    :string(255)
+#  type         :string(255)      not null
+#  created_at   :datetime         not null
+#  body_id      :integer          not null
 #  person_id    :integer          not null
 #  requester_id :integer          not null
-#  type         :string(255)      not null
-#  body_id      :integer          not null
-#  role_type    :string(255)
-#  created_at   :datetime         not null
+#
+# Indexes
+#
+#  index_person_add_requests_on_person_id         (person_id)
+#  index_person_add_requests_on_type_and_body_id  (type,body_id)
 #
 
 class Person::AddRequest < ActiveRecord::Base

--- a/app/models/person/add_request/event.rb
+++ b/app/models/person/add_request/event.rb
@@ -9,12 +9,17 @@
 # Table name: person_add_requests
 #
 #  id           :integer          not null, primary key
+#  role_type    :string(255)
+#  type         :string(255)      not null
+#  created_at   :datetime         not null
+#  body_id      :integer          not null
 #  person_id    :integer          not null
 #  requester_id :integer          not null
-#  type         :string(255)      not null
-#  body_id      :integer          not null
-#  role_type    :string(255)
-#  created_at   :datetime         not null
+#
+# Indexes
+#
+#  index_person_add_requests_on_person_id         (person_id)
+#  index_person_add_requests_on_type_and_body_id  (type,body_id)
 #
 
 class Person::AddRequest::Event < Person::AddRequest

--- a/app/models/person/add_request/group.rb
+++ b/app/models/person/add_request/group.rb
@@ -9,12 +9,17 @@
 # Table name: person_add_requests
 #
 #  id           :integer          not null, primary key
+#  role_type    :string(255)
+#  type         :string(255)      not null
+#  created_at   :datetime         not null
+#  body_id      :integer          not null
 #  person_id    :integer          not null
 #  requester_id :integer          not null
-#  type         :string(255)      not null
-#  body_id      :integer          not null
-#  role_type    :string(255)
-#  created_at   :datetime         not null
+#
+# Indexes
+#
+#  index_person_add_requests_on_person_id         (person_id)
+#  index_person_add_requests_on_type_and_body_id  (type,body_id)
 #
 
 class Person::AddRequest::Group < Person::AddRequest

--- a/app/models/person/add_request/ignored_approver.rb
+++ b/app/models/person/add_request/ignored_approver.rb
@@ -13,6 +13,10 @@
 #  group_id  :integer          not null
 #  person_id :integer          not null
 #
+# Indexes
+#
+#  person_add_request_ignored_approvers_index  (group_id,person_id) UNIQUE
+#
 class Person::AddRequest::IgnoredApprover < ActiveRecord::Base
 
   belongs_to :group, class_name: '::Group'

--- a/app/models/person/add_request/mailing_list.rb
+++ b/app/models/person/add_request/mailing_list.rb
@@ -9,12 +9,17 @@
 # Table name: person_add_requests
 #
 #  id           :integer          not null, primary key
+#  role_type    :string(255)
+#  type         :string(255)      not null
+#  created_at   :datetime         not null
+#  body_id      :integer          not null
 #  person_id    :integer          not null
 #  requester_id :integer          not null
-#  type         :string(255)      not null
-#  body_id      :integer          not null
-#  role_type    :string(255)
-#  created_at   :datetime         not null
+#
+# Indexes
+#
+#  index_person_add_requests_on_person_id         (person_id)
+#  index_person_add_requests_on_type_and_body_id  (type,body_id)
 #
 
 class Person::AddRequest::MailingList < Person::AddRequest

--- a/app/models/person_duplicate.rb
+++ b/app/models/person_duplicate.rb
@@ -2,10 +2,16 @@
 #
 # Table name: person_duplicates
 #
-#  id                   :integer          not null, primary key
-#  person_1_id          :integer          not null
-#  person_2_id          :integer          not null
-#  ignore               :boolean          default(FALSE), not null
+#  id          :bigint           not null, primary key
+#  ignore      :boolean          default(FALSE), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  person_1_id :integer          not null
+#  person_2_id :integer          not null
+#
+# Indexes
+#
+#  index_person_duplicates_on_person_1_id_and_person_2_id  (person_1_id,person_2_id) UNIQUE
 #
 
 class PersonDuplicate < ActiveRecord::Base

--- a/app/models/phone_number.rb
+++ b/app/models/phone_number.rb
@@ -9,11 +9,15 @@
 # Table name: phone_numbers
 #
 #  id               :integer          not null, primary key
-#  contactable_id   :integer          not null
 #  contactable_type :string(255)      not null
-#  number           :string(255)      not null
 #  label            :string(255)
+#  number           :string(255)      not null
 #  public           :boolean          default(TRUE), not null
+#  contactable_id   :integer          not null
+#
+# Indexes
+#
+#  index_phone_numbers_on_contactable_id_and_contactable_type  (contactable_id,contactable_type)
 #
 
 class PhoneNumber < ActiveRecord::Base

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -9,11 +9,16 @@
 # Table name: qualifications
 #
 #  id                    :integer          not null, primary key
-#  person_id             :integer          not null
-#  qualification_kind_id :integer          not null
-#  start_at              :date             not null
 #  finish_at             :date
 #  origin                :string(255)
+#  start_at              :date             not null
+#  person_id             :integer          not null
+#  qualification_kind_id :integer          not null
+#
+# Indexes
+#
+#  index_qualifications_on_person_id              (person_id)
+#  index_qualifications_on_qualification_kind_id  (qualification_kind_id)
 #
 
 class Qualification < ActiveRecord::Base

--- a/app/models/related_role_type.rb
+++ b/app/models/related_role_type.rb
@@ -9,9 +9,14 @@
 # Table name: related_role_types
 #
 #  id            :integer          not null, primary key
-#  relation_id   :integer
-#  role_type     :string(255)      not null
 #  relation_type :string(255)
+#  role_type     :string(255)      not null
+#  relation_id   :integer
+#
+# Indexes
+#
+#  index_related_role_types_on_relation_id_and_relation_type  (relation_id,relation_type)
+#  index_related_role_types_on_role_type                      (role_type)
 #
 
 class RelatedRoleType < ActiveRecord::Base

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -9,13 +9,18 @@
 # Table name: roles
 #
 #  id         :integer          not null, primary key
-#  person_id  :integer          not null
-#  group_id   :integer          not null
-#  type       :string(255)      not null
+#  deleted_at :datetime
 #  label      :string(255)
+#  type       :string(255)      not null
 #  created_at :datetime
 #  updated_at :datetime
-#  deleted_at :datetime
+#  group_id   :integer          not null
+#  person_id  :integer          not null
+#
+# Indexes
+#
+#  index_roles_on_person_id_and_group_id  (person_id,group_id)
+#  index_roles_on_type                    (type)
 #
 
 class Role < ActiveRecord::Base

--- a/app/models/service_token.rb
+++ b/app/models/service_token.rb
@@ -6,18 +6,21 @@
 #
 # Table name: service_tokens
 #
-#  id             :integer          not null, primary key
-#  layer_group_id :integer          not null
-#  name           :string(255)      not null
-#  description    :text(65535)
-#  token          :string(255)      not null
-#  last_access    :datetime
-#  people         :boolean          default(FALSE)
-#  people_below   :boolean          default(FALSE)
-#  groups         :boolean          default(FALSE)
-#  events         :boolean          default(FALSE)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id                   :integer          not null, primary key
+#  description          :text(16777215)
+#  event_participations :boolean          default(FALSE), not null
+#  events               :boolean          default(FALSE)
+#  groups               :boolean          default(FALSE)
+#  invoices             :boolean          default(FALSE), not null
+#  last_access          :datetime
+#  mailing_lists        :boolean          default(FALSE), not null
+#  name                 :string(255)      not null
+#  people               :boolean          default(FALSE)
+#  people_below         :boolean          default(FALSE)
+#  token                :string(255)      not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  layer_group_id       :integer          not null
 #
 
 class ServiceToken < ActiveRecord::Base

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,5 +1,22 @@
 # encoding: utf-8
 
+# == Schema Information
+#
+# Table name: sessions
+#
+#  id         :integer          not null, primary key
+#  data       :text(16777215)
+#  created_at :datetime
+#  updated_at :datetime
+#  session_id :string(255)      not null
+#
+# Indexes
+#
+#  index_sessions_on_session_id  (session_id)
+#  index_sessions_on_updated_at  (updated_at)
+#
+
+
 #  Copyright (c) 2012-2020, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at

--- a/app/models/social_account.rb
+++ b/app/models/social_account.rb
@@ -9,11 +9,15 @@
 # Table name: social_accounts
 #
 #  id               :integer          not null, primary key
-#  contactable_id   :integer          not null
 #  contactable_type :string(255)      not null
-#  name             :string(255)      not null
 #  label            :string(255)
+#  name             :string(255)      not null
 #  public           :boolean          default(TRUE), not null
+#  contactable_id   :integer          not null
+#
+# Indexes
+#
+#  index_social_accounts_on_contactable_id_and_contactable_type  (contactable_id,contactable_type)
 #
 
 class SocialAccount < ActiveRecord::Base

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -9,10 +9,15 @@
 # Table name: subscriptions
 #
 #  id              :integer          not null, primary key
+#  excluded        :boolean          default(FALSE), not null
+#  subscriber_type :string(255)      not null
 #  mailing_list_id :integer          not null
 #  subscriber_id   :integer          not null
-#  subscriber_type :string(255)      not null
-#  excluded        :boolean          default(FALSE), not null
+#
+# Indexes
+#
+#  index_subscriptions_on_mailing_list_id                    (mailing_list_id)
+#  index_subscriptions_on_subscriber_id_and_subscriber_type  (subscriber_id,subscriber_type)
 #
 
 class Subscription < ActiveRecord::Base

--- a/app/models/table_display.rb
+++ b/app/models/table_display.rb
@@ -7,9 +7,13 @@
 # Table name: table_displays
 #
 #  id        :integer          not null, primary key
+#  selected  :text(16777215)
 #  type      :string(255)      not null
 #  person_id :integer          not null
-#  selected  :text(65535)
+#
+# Indexes
+#
+#  index_table_displays_on_person_id_and_type  (person_id,type) UNIQUE
 #
 
 class TableDisplay < ActiveRecord::Base

--- a/app/models/table_display/participations.rb
+++ b/app/models/table_display/participations.rb
@@ -3,9 +3,13 @@
 # Table name: table_displays
 #
 #  id        :integer          not null, primary key
+#  selected  :text(16777215)
 #  type      :string(255)      not null
 #  person_id :integer          not null
-#  selected  :text(65535)
+#
+# Indexes
+#
+#  index_table_displays_on_person_id_and_type  (person_id,type) UNIQUE
 #
 
 class TableDisplay::Participations < TableDisplay

--- a/app/models/table_display/people.rb
+++ b/app/models/table_display/people.rb
@@ -3,9 +3,13 @@
 # Table name: table_displays
 #
 #  id        :integer          not null, primary key
+#  selected  :text(16777215)
 #  type      :string(255)      not null
 #  person_id :integer          not null
-#  selected  :text(65535)
+#
+# Indexes
+#
+#  index_table_displays_on_person_id_and_type  (person_id,type) UNIQUE
 #
 
 class TableDisplay::People < TableDisplay

--- a/app/serializers/additional_email_serializer.rb
+++ b/app/serializers/additional_email_serializer.rb
@@ -5,12 +5,16 @@
 # Table name: additional_emails
 #
 #  id               :integer          not null, primary key
-#  contactable_id   :integer          not null
 #  contactable_type :string(255)      not null
 #  email            :string(255)      not null
 #  label            :string(255)
-#  public           :boolean          default(TRUE), not null
 #  mailings         :boolean          default(FALSE), not null
+#  public           :boolean          default(TRUE), not null
+#  contactable_id   :integer          not null
+#
+# Indexes
+#
+#  index_additional_emails_on_contactable_id_and_contactable_type  (contactable_id,contactable_type)
 #
 
 #  Copyright (c) 2014, CEVI Regionalverband ZH-SH-GL. This file is part of

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -8,38 +8,44 @@
 # Table name: events
 #
 #  id                          :integer          not null, primary key
-#  type                        :string(255)
+#  applicant_count             :integer          default(0)
+#  application_closing_at      :date
+#  application_conditions      :text(16777215)
+#  application_opening_at      :date
+#  applications_cancelable     :boolean          default(FALSE), not null
+#  cost                        :string(255)
+#  description                 :text(16777215)
+#  display_booking_info        :boolean          default(TRUE), not null
+#  external_applications       :boolean          default(FALSE)
+#  hidden_contact_attrs        :text(16777215)
+#  location                    :text(16777215)
+#  maximum_participants        :integer
+#  motto                       :string(255)
 #  name                        :string(255)      not null
 #  number                      :string(255)
-#  motto                       :string(255)
-#  cost                        :string(255)
-#  maximum_participants        :integer
-#  contact_id                  :integer
-#  description                 :text(65535)
-#  location                    :text(65535)
-#  application_opening_at      :date
-#  application_closing_at      :date
-#  application_conditions      :text(65535)
-#  kind_id                     :integer
-#  state                       :string(60)
-#  priorization                :boolean          default(FALSE), not null
-#  requires_approval           :boolean          default(FALSE), not null
-#  created_at                  :datetime
-#  updated_at                  :datetime
 #  participant_count           :integer          default(0)
-#  application_contact_id      :integer
-#  external_applications       :boolean          default(FALSE)
-#  applicant_count             :integer          default(0)
-#  teamer_count                :integer          default(0)
+#  participations_visible      :boolean          default(FALSE), not null
+#  priorization                :boolean          default(FALSE), not null
+#  required_contact_attrs      :text(16777215)
+#  requires_approval           :boolean          default(FALSE), not null
 #  signature                   :boolean
 #  signature_confirmation      :boolean
 #  signature_confirmation_text :string(255)
+#  state                       :string(60)
+#  teamer_count                :integer          default(0)
+#  type                        :string(255)
+#  waiting_list                :boolean          default(TRUE), not null
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  application_contact_id      :integer
+#  contact_id                  :integer
 #  creator_id                  :integer
+#  kind_id                     :integer
 #  updater_id                  :integer
-#  applications_cancelable     :boolean          default(FALSE), not null
-#  required_contact_attrs      :text(65535)
-#  hidden_contact_attrs        :text(65535)
-#  display_booking_info        :boolean          default(TRUE), not null
+#
+# Indexes
+#
+#  index_events_on_kind_id  (kind_id)
 #
 
 class EventSerializer < ApplicationSerializer

--- a/app/serializers/group_serializer.rb
+++ b/app/serializers/group_serializer.rb
@@ -5,27 +5,35 @@
 # Table name: groups
 #
 #  id                          :integer          not null, primary key
-#  parent_id                   :integer
-#  lft                         :integer
-#  rgt                         :integer
-#  name                        :string(255)      not null
-#  short_name                  :string(31)
-#  type                        :string(255)      not null
-#  email                       :string(255)
-#  address                     :string(1024)
-#  zip_code                    :integer
-#  town                        :string(255)
+#  address                     :text(16777215)
 #  country                     :string(255)
-#  contact_id                  :integer
+#  deleted_at                  :datetime
+#  description                 :text(16777215)
+#  email                       :string(255)
+#  lft                         :integer
+#  logo                        :string(255)
+#  name                        :string(255)      not null
+#  require_person_add_requests :boolean          default(FALSE), not null
+#  rgt                         :integer
+#  short_name                  :string(31)
+#  town                        :string(255)
+#  type                        :string(255)      not null
+#  zip_code                    :integer
 #  created_at                  :datetime
 #  updated_at                  :datetime
-#  deleted_at                  :datetime
-#  layer_group_id              :integer
+#  contact_id                  :integer
 #  creator_id                  :integer
-#  updater_id                  :integer
 #  deleter_id                  :integer
-#  require_person_add_requests :boolean          default(FALSE), not null
-#  description                 :text(65535)
+#  layer_group_id              :integer
+#  parent_id                   :integer
+#  updater_id                  :integer
+#
+# Indexes
+#
+#  index_groups_on_layer_group_id  (layer_group_id)
+#  index_groups_on_lft_and_rgt     (lft,rgt)
+#  index_groups_on_parent_id       (parent_id)
+#  index_groups_on_type            (type)
 #
 
 #  Copyright (c) 2014, CEVI Regionalverband ZH-SH-GL. This file is part of

--- a/app/serializers/invoice_item_serializer.rb
+++ b/app/serializers/invoice_item_serializer.rb
@@ -10,14 +10,18 @@
 # Table name: invoice_items
 #
 #  id          :integer          not null, primary key
-#  invoice_id  :integer          not null
-#  name        :string(255)      not null
-#  description :text(65535)
-#  vat_rate    :decimal(5, 2)
-#  unit_cost   :decimal(12, 2)   not null
-#  count       :integer          default(1), not null
-#  cost_center :string(255)
 #  account     :string(255)
+#  cost_center :string(255)
+#  count       :integer          default(1), not null
+#  description :text(16777215)
+#  name        :string(255)      not null
+#  unit_cost   :decimal(12, 2)   not null
+#  vat_rate    :decimal(5, 2)
+#  invoice_id  :integer          not null
+#
+# Indexes
+#
+#  index_invoice_items_on_invoice_id  (invoice_id)
 #
 
 class InvoiceItemSerializer < ApplicationSerializer

--- a/app/serializers/invoice_serializer.rb
+++ b/app/serializers/invoice_serializer.rb
@@ -9,33 +9,44 @@
 # Table name: invoices
 #
 #  id                          :integer          not null, primary key
-#  title                       :string(255)      not null
+#  account_number              :string(255)
+#  address                     :text(16777215)
+#  beneficiary                 :text(16777215)
+#  currency                    :string(255)      default("CHF"), not null
+#  description                 :text(16777215)
+#  due_at                      :date
+#  esr_number                  :string(255)      not null
+#  iban                        :string(255)
+#  issued_at                   :date
+#  participant_number          :string(255)
+#  participant_number_internal :string(255)
+#  payee                       :text(16777215)
+#  payment_information         :text(16777215)
+#  payment_purpose             :text(16777215)
+#  payment_slip                :string(255)      default("ch_es"), not null
+#  recipient_address           :text(16777215)
+#  recipient_email             :string(255)
+#  reference                   :string(255)      not null
+#  sent_at                     :date
 #  sequence_number             :string(255)      not null
 #  state                       :string(255)      default("draft"), not null
-#  esr_number                  :string(255)      not null
-#  description                 :text(65535)
-#  recipient_email             :string(255)
-#  recipient_address           :text(65535)
-#  sent_at                     :date
-#  due_at                      :date
-#  group_id                    :integer          not null
-#  recipient_id                :integer
+#  title                       :string(255)      not null
 #  total                       :decimal(12, 2)
+#  vat_number                  :string(255)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
-#  account_number              :string(255)
-#  address                     :text(65535)
-#  issued_at                   :date
-#  iban                        :string(255)
-#  payment_purpose             :text(65535)
-#  payment_information         :text(65535)
-#  payment_slip                :string(255)      default("ch_es"), not null
-#  beneficiary                 :text(65535)
-#  payee                       :text(65535)
-#  participant_number          :string(255)
 #  creator_id                  :integer
-#  participant_number_internal :string(255)
-#  vat_number                  :string(255)
+#  group_id                    :integer          not null
+#  invoice_list_id             :bigint
+#  recipient_id                :integer
+#
+# Indexes
+#
+#  index_invoices_on_esr_number       (esr_number)
+#  index_invoices_on_group_id         (group_id)
+#  index_invoices_on_invoice_list_id  (invoice_list_id)
+#  index_invoices_on_recipient_id     (recipient_id)
+#  index_invoices_on_sequence_number  (sequence_number)
 #
 
 class InvoiceSerializer < ApplicationSerializer

--- a/app/serializers/mailing_list_serializer.rb
+++ b/app/serializers/mailing_list_serializer.rb
@@ -1,5 +1,35 @@
 # encoding: utf-8
 
+# == Schema Information
+#
+# Table name: mailing_lists
+#
+#  id                                  :integer          not null, primary key
+#  additional_sender                   :string(255)
+#  anyone_may_post                     :boolean          default(FALSE), not null
+#  delivery_report                     :boolean          default(FALSE), not null
+#  description                         :text(16777215)
+#  mail_name                           :string(255)
+#  mailchimp_api_key                   :string(255)
+#  mailchimp_include_additional_emails :boolean          default(FALSE)
+#  mailchimp_last_synced_at            :datetime
+#  mailchimp_result                    :text(16777215)
+#  mailchimp_syncing                   :boolean          default(FALSE)
+#  main_email                          :boolean          default(FALSE)
+#  name                                :string(255)      not null
+#  preferred_labels                    :string(255)
+#  publisher                           :string(255)
+#  subscribable                        :boolean          default(FALSE), not null
+#  subscribers_may_post                :boolean          default(FALSE), not null
+#  group_id                            :integer          not null
+#  mailchimp_list_id                   :string(255)
+#
+# Indexes
+#
+#  index_mailing_lists_on_group_id  (group_id)
+#
+
+
 #  Copyright (c) 2020, Pfadibewegung Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at

--- a/app/serializers/payment_reminder_serializer.rb
+++ b/app/serializers/payment_reminder_serializer.rb
@@ -9,13 +9,17 @@
 # Table name: payment_reminders
 #
 #  id         :integer          not null, primary key
-#  invoice_id :integer          not null
 #  due_at     :date             not null
+#  level      :integer
+#  text       :string(255)
+#  title      :string(255)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  title      :string(255)
-#  text       :string(255)
-#  level      :integer
+#  invoice_id :integer          not null
+#
+# Indexes
+#
+#  index_payment_reminders_on_invoice_id  (invoice_id)
 #
 
 class PaymentReminderSerializer < ApplicationSerializer

--- a/app/serializers/payment_serializer.rb
+++ b/app/serializers/payment_serializer.rb
@@ -5,10 +5,14 @@
 # Table name: payments
 #
 #  id          :integer          not null, primary key
-#  invoice_id  :integer          not null
 #  amount      :decimal(12, 2)   not null
 #  received_at :date             not null
 #  reference   :string(255)
+#  invoice_id  :integer          not null
+#
+# Indexes
+#
+#  index_payments_on_invoice_id  (invoice_id)
 #
 
 #  Copyright (c) 2012-2019, Jungwacht Blauring Schweiz. This file is part of

--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -5,41 +5,59 @@
 # Table name: people
 #
 #  id                        :integer          not null, primary key
-#  first_name                :string(255)
-#  last_name                 :string(255)
-#  company_name              :string(255)
-#  nickname                  :string(255)
-#  company                   :boolean          default(FALSE), not null
-#  email                     :string(255)
-#  address                   :string(1024)
-#  zip_code                  :string(255)
-#  town                      :string(255)
-#  country                   :string(255)
-#  gender                    :string(1)
+#  additional_information    :text(16777215)
+#  additional_languages      :string(255)
+#  address                   :text(16777215)
+#  advertising               :string(255)
+#  authentication_token      :string(255)
 #  birthday                  :date
-#  additional_information    :text(65535)
+#  company                   :boolean          default(FALSE), not null
+#  company_name              :string(255)
 #  contact_data_visible      :boolean          default(FALSE), not null
+#  correspondence_language   :string(255)
+#  country                   :string(255)
+#  current_sign_in_at        :datetime
+#  current_sign_in_ip        :string(255)
+#  email                     :string(255)
+#  encrypted_password        :string(255)
+#  event_feed_token          :string(255)
+#  failed_attempts           :integer          default(0)
+#  first_name                :string(255)
+#  gender                    :string(1)
+#  household_key             :string(255)
+#  last_name                 :string(255)
+#  last_sign_in_at           :datetime
+#  last_sign_in_ip           :string(255)
+#  locked_at                 :datetime
+#  nationality               :string(255)
+#  nickname                  :string(255)
+#  picture                   :string(255)
+#  remember_created_at       :datetime
+#  reset_password_sent_at    :datetime
+#  reset_password_token      :string(255)
+#  show_global_label_formats :boolean          default(TRUE), not null
+#  sign_in_count             :integer          default(0)
+#  title                     :string(255)
+#  town                      :string(255)
+#  unlock_token              :string(255)
+#  zip_code                  :string(255)
 #  created_at                :datetime
 #  updated_at                :datetime
-#  encrypted_password        :string(255)
-#  reset_password_token      :string(255)
-#  reset_password_sent_at    :datetime
-#  remember_created_at       :datetime
-#  sign_in_count             :integer          default(0)
-#  current_sign_in_at        :datetime
-#  last_sign_in_at           :datetime
-#  current_sign_in_ip        :string(255)
-#  last_sign_in_ip           :string(255)
-#  picture                   :string(255)
-#  last_label_format_id      :integer
 #  creator_id                :integer
-#  updater_id                :integer
+#  last_label_format_id      :integer
 #  primary_group_id          :integer
-#  failed_attempts           :integer          default(0)
-#  locked_at                 :datetime
-#  authentication_token      :string(255)
-#  show_global_label_formats :boolean          default(TRUE), not null
-#  household_key             :string(255)
+#  updater_id                :integer
+#
+# Indexes
+#
+#  index_people_on_authentication_token  (authentication_token)
+#  index_people_on_email                 (email) UNIQUE
+#  index_people_on_event_feed_token      (event_feed_token) UNIQUE
+#  index_people_on_first_name            (first_name)
+#  index_people_on_household_key         (household_key)
+#  index_people_on_last_name             (last_name)
+#  index_people_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_people_on_unlock_token          (unlock_token) UNIQUE
 #
 
 #  Copyright (c) 2014, CEVI Regionalverband ZH-SH-GL. This file is part of

--- a/app/serializers/phone_number_serializer.rb
+++ b/app/serializers/phone_number_serializer.rb
@@ -5,11 +5,15 @@
 # Table name: phone_numbers
 #
 #  id               :integer          not null, primary key
-#  contactable_id   :integer          not null
 #  contactable_type :string(255)      not null
-#  number           :string(255)      not null
 #  label            :string(255)
+#  number           :string(255)      not null
 #  public           :boolean          default(TRUE), not null
+#  contactable_id   :integer          not null
+#
+# Indexes
+#
+#  index_phone_numbers_on_contactable_id_and_contactable_type  (contactable_id,contactable_type)
 #
 
 #  Copyright (c) 2014, CEVI Regionalverband ZH-SH-GL. This file is part of

--- a/app/serializers/role_serializer.rb
+++ b/app/serializers/role_serializer.rb
@@ -5,13 +5,18 @@
 # Table name: roles
 #
 #  id         :integer          not null, primary key
-#  person_id  :integer          not null
-#  group_id   :integer          not null
-#  type       :string(255)      not null
+#  deleted_at :datetime
 #  label      :string(255)
+#  type       :string(255)      not null
 #  created_at :datetime
 #  updated_at :datetime
-#  deleted_at :datetime
+#  group_id   :integer          not null
+#  person_id  :integer          not null
+#
+# Indexes
+#
+#  index_roles_on_person_id_and_group_id  (person_id,group_id)
+#  index_roles_on_type                    (type)
 #
 
 #  Copyright (c) 2014, CEVI Regionalverband ZH-SH-GL. This file is part of

--- a/app/serializers/social_account_serializer.rb
+++ b/app/serializers/social_account_serializer.rb
@@ -5,11 +5,15 @@
 # Table name: social_accounts
 #
 #  id               :integer          not null, primary key
-#  contactable_id   :integer          not null
 #  contactable_type :string(255)      not null
-#  name             :string(255)      not null
 #  label            :string(255)
+#  name             :string(255)      not null
 #  public           :boolean          default(TRUE), not null
+#  contactable_id   :integer          not null
+#
+# Indexes
+#
+#  index_social_accounts_on_contactable_id_and_contactable_type  (contactable_id,contactable_type)
 #
 
 #  Copyright (c) 2014, CEVI Regionalverband ZH-SH-GL. This file is part of

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,54 @@
+if Rails.env.test?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/lib/tasks/model.rake
+++ b/lib/tasks/model.rake
@@ -8,7 +8,7 @@
 
 desc 'Add column annotations to active records'
 task :annotate do
-  sh 'annotate -p before -e tests'
+  sh 'RAILS_ENV=test annotate -p before -e tests'
 end
 
 namespace :erd do

--- a/spec/fabricators/additional_email_fabricator.rb
+++ b/spec/fabricators/additional_email_fabricator.rb
@@ -9,12 +9,16 @@
 # Table name: additional_emails
 #
 #  id               :integer          not null, primary key
-#  contactable_id   :integer          not null
 #  contactable_type :string(255)      not null
 #  email            :string(255)      not null
 #  label            :string(255)
-#  public           :boolean          default(TRUE), not null
 #  mailings         :boolean          default(FALSE), not null
+#  public           :boolean          default(TRUE), not null
+#  contactable_id   :integer          not null
+#
+# Indexes
+#
+#  index_additional_emails_on_contactable_id_and_contactable_type  (contactable_id,contactable_type)
 #
 
 Fabricator(:additional_email) do

--- a/spec/fabricators/event/application_fabricator.rb
+++ b/spec/fabricators/event/application_fabricator.rb
@@ -9,13 +9,13 @@
 # Table name: event_applications
 #
 #  id                   :integer          not null, primary key
-#  priority_1_id        :integer          not null
-#  priority_2_id        :integer
-#  priority_3_id        :integer
 #  approved             :boolean          default(FALSE), not null
 #  rejected             :boolean          default(FALSE), not null
 #  waiting_list         :boolean          default(FALSE), not null
-#  waiting_list_comment :text(65535)
+#  waiting_list_comment :text(16777215)
+#  priority_1_id        :integer          not null
+#  priority_2_id        :integer
+#  priority_3_id        :integer
 #
 
 Fabricator(:event_application, class_name: 'Event::Application') do

--- a/spec/fabricators/event/date_fabricator.rb
+++ b/spec/fabricators/event/date_fabricator.rb
@@ -9,11 +9,16 @@
 # Table name: event_dates
 #
 #  id        :integer          not null, primary key
-#  event_id  :integer          not null
-#  label     :string(255)
-#  start_at  :datetime
 #  finish_at :datetime
+#  label     :string(255)
 #  location  :string(255)
+#  start_at  :datetime
+#  event_id  :integer          not null
+#
+# Indexes
+#
+#  index_event_dates_on_event_id               (event_id)
+#  index_event_dates_on_event_id_and_start_at  (event_id,start_at)
 #
 
 Fabricator(:event_date, class_name: 'Event::Date') do

--- a/spec/fabricators/event/participation_fabricator.rb
+++ b/spec/fabricators/event/participation_fabricator.rb
@@ -4,14 +4,21 @@
 # Table name: event_participations
 #
 #  id                     :integer          not null, primary key
-#  event_id               :integer          not null
-#  person_id              :integer          not null
-#  additional_information :text(65535)
+#  active                 :boolean          default(FALSE), not null
+#  additional_information :text(16777215)
+#  qualified              :boolean
 #  created_at             :datetime
 #  updated_at             :datetime
-#  active                 :boolean          default(FALSE), not null
 #  application_id         :integer
-#  qualified              :boolean
+#  event_id               :integer          not null
+#  person_id              :integer          not null
+#
+# Indexes
+#
+#  index_event_participations_on_application_id          (application_id)
+#  index_event_participations_on_event_id                (event_id)
+#  index_event_participations_on_event_id_and_person_id  (event_id,person_id) UNIQUE
+#  index_event_participations_on_person_id               (person_id)
 #
 
 #  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of

--- a/spec/fabricators/event/question_fabricator.rb
+++ b/spec/fabricators/event/question_fabricator.rb
@@ -9,12 +9,14 @@
 # Table name: event_questions
 #
 #  id               :integer          not null, primary key
-#  event_id         :integer
-#  question         :string(255)
-#  choices          :string(255)
+#  admin            :boolean          default(FALSE), not null
 #  multiple_choices :boolean          default(FALSE), not null
 #  required         :boolean          default(FALSE), not null
-#  admin            :boolean          default(FALSE), not null
+#  event_id         :integer
+#
+# Indexes
+#
+#  index_event_questions_on_event_id  (event_id)
 #
 
 Fabricator(:event_question, class_name: 'Event::Question') do

--- a/spec/fabricators/event/role_fabricator.rb
+++ b/spec/fabricators/event/role_fabricator.rb
@@ -9,9 +9,14 @@
 # Table name: event_roles
 #
 #  id               :integer          not null, primary key
+#  label            :string(255)
 #  type             :string(255)      not null
 #  participation_id :integer          not null
-#  label            :string(255)
+#
+# Indexes
+#
+#  index_event_roles_on_participation_id  (participation_id)
+#  index_event_roles_on_type              (type)
 #
 
 Fabricator(:event_role, class_name: 'Event::Role') do

--- a/spec/fabricators/event_fabricator.rb
+++ b/spec/fabricators/event_fabricator.rb
@@ -9,38 +9,44 @@
 # Table name: events
 #
 #  id                          :integer          not null, primary key
-#  type                        :string(255)
+#  applicant_count             :integer          default(0)
+#  application_closing_at      :date
+#  application_conditions      :text(16777215)
+#  application_opening_at      :date
+#  applications_cancelable     :boolean          default(FALSE), not null
+#  cost                        :string(255)
+#  description                 :text(16777215)
+#  display_booking_info        :boolean          default(TRUE), not null
+#  external_applications       :boolean          default(FALSE)
+#  hidden_contact_attrs        :text(16777215)
+#  location                    :text(16777215)
+#  maximum_participants        :integer
+#  motto                       :string(255)
 #  name                        :string(255)      not null
 #  number                      :string(255)
-#  motto                       :string(255)
-#  cost                        :string(255)
-#  maximum_participants        :integer
-#  contact_id                  :integer
-#  description                 :text(65535)
-#  location                    :text(65535)
-#  application_opening_at      :date
-#  application_closing_at      :date
-#  application_conditions      :text(65535)
-#  kind_id                     :integer
-#  state                       :string(60)
-#  priorization                :boolean          default(FALSE), not null
-#  requires_approval           :boolean          default(FALSE), not null
-#  created_at                  :datetime
-#  updated_at                  :datetime
 #  participant_count           :integer          default(0)
-#  application_contact_id      :integer
-#  external_applications       :boolean          default(FALSE)
-#  applicant_count             :integer          default(0)
-#  teamer_count                :integer          default(0)
+#  participations_visible      :boolean          default(FALSE), not null
+#  priorization                :boolean          default(FALSE), not null
+#  required_contact_attrs      :text(16777215)
+#  requires_approval           :boolean          default(FALSE), not null
 #  signature                   :boolean
 #  signature_confirmation      :boolean
 #  signature_confirmation_text :string(255)
+#  state                       :string(60)
+#  teamer_count                :integer          default(0)
+#  type                        :string(255)
+#  waiting_list                :boolean          default(TRUE), not null
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  application_contact_id      :integer
+#  contact_id                  :integer
 #  creator_id                  :integer
+#  kind_id                     :integer
 #  updater_id                  :integer
-#  applications_cancelable     :boolean          default(FALSE), not null
-#  required_contact_attrs      :text(65535)
-#  hidden_contact_attrs        :text(65535)
-#  display_booking_info        :boolean          default(TRUE), not null
+#
+# Indexes
+#
+#  index_events_on_kind_id  (kind_id)
 #
 
 Fabricator(:event) do

--- a/spec/fabricators/group_fabricator.rb
+++ b/spec/fabricators/group_fabricator.rb
@@ -4,27 +4,35 @@
 # Table name: groups
 #
 #  id                          :integer          not null, primary key
-#  parent_id                   :integer
-#  lft                         :integer
-#  rgt                         :integer
-#  name                        :string(255)      not null
-#  short_name                  :string(31)
-#  type                        :string(255)      not null
-#  email                       :string(255)
-#  address                     :string(1024)
-#  zip_code                    :integer
-#  town                        :string(255)
+#  address                     :text(16777215)
 #  country                     :string(255)
-#  contact_id                  :integer
+#  deleted_at                  :datetime
+#  description                 :text(16777215)
+#  email                       :string(255)
+#  lft                         :integer
+#  logo                        :string(255)
+#  name                        :string(255)      not null
+#  require_person_add_requests :boolean          default(FALSE), not null
+#  rgt                         :integer
+#  short_name                  :string(31)
+#  town                        :string(255)
+#  type                        :string(255)      not null
+#  zip_code                    :integer
 #  created_at                  :datetime
 #  updated_at                  :datetime
-#  deleted_at                  :datetime
-#  layer_group_id              :integer
+#  contact_id                  :integer
 #  creator_id                  :integer
-#  updater_id                  :integer
 #  deleter_id                  :integer
-#  require_person_add_requests :boolean          default(FALSE), not null
-#  description                 :text(65535)
+#  layer_group_id              :integer
+#  parent_id                   :integer
+#  updater_id                  :integer
+#
+# Indexes
+#
+#  index_groups_on_layer_group_id  (layer_group_id)
+#  index_groups_on_lft_and_rgt     (lft,rgt)
+#  index_groups_on_parent_id       (parent_id)
+#  index_groups_on_type            (type)
 #
 
 #  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of

--- a/spec/fabricators/invoice_fabricator.rb
+++ b/spec/fabricators/invoice_fabricator.rb
@@ -4,33 +4,44 @@
 # Table name: invoices
 #
 #  id                          :integer          not null, primary key
-#  title                       :string(255)      not null
+#  account_number              :string(255)
+#  address                     :text(16777215)
+#  beneficiary                 :text(16777215)
+#  currency                    :string(255)      default("CHF"), not null
+#  description                 :text(16777215)
+#  due_at                      :date
+#  esr_number                  :string(255)      not null
+#  iban                        :string(255)
+#  issued_at                   :date
+#  participant_number          :string(255)
+#  participant_number_internal :string(255)
+#  payee                       :text(16777215)
+#  payment_information         :text(16777215)
+#  payment_purpose             :text(16777215)
+#  payment_slip                :string(255)      default("ch_es"), not null
+#  recipient_address           :text(16777215)
+#  recipient_email             :string(255)
+#  reference                   :string(255)      not null
+#  sent_at                     :date
 #  sequence_number             :string(255)      not null
 #  state                       :string(255)      default("draft"), not null
-#  esr_number                  :string(255)      not null
-#  description                 :text(65535)
-#  recipient_email             :string(255)
-#  recipient_address           :text(65535)
-#  sent_at                     :date
-#  due_at                      :date
-#  group_id                    :integer          not null
-#  recipient_id                :integer
+#  title                       :string(255)      not null
 #  total                       :decimal(12, 2)
+#  vat_number                  :string(255)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
-#  account_number              :string(255)
-#  address                     :text(65535)
-#  issued_at                   :date
-#  iban                        :string(255)
-#  payment_purpose             :text(65535)
-#  payment_information         :text(65535)
-#  payment_slip                :string(255)      default("ch_es"), not null
-#  beneficiary                 :text(65535)
-#  payee                       :text(65535)
-#  participant_number          :string(255)
 #  creator_id                  :integer
-#  participant_number_internal :string(255)
-#  vat_number                  :string(255)
+#  group_id                    :integer          not null
+#  invoice_list_id             :bigint
+#  recipient_id                :integer
+#
+# Indexes
+#
+#  index_invoices_on_esr_number       (esr_number)
+#  index_invoices_on_group_id         (group_id)
+#  index_invoices_on_invoice_list_id  (invoice_list_id)
+#  index_invoices_on_recipient_id     (recipient_id)
+#  index_invoices_on_sequence_number  (sequence_number)
 #
 
 #  Copyright (c) 2017, Jungwacht Blauring Schweiz. This file is part of

--- a/spec/fabricators/mailing_list_fabricator.rb
+++ b/spec/fabricators/mailing_list_fabricator.rb
@@ -8,23 +8,29 @@
 #
 # Table name: mailing_lists
 #
-#  id                       :integer          not null, primary key
-#  name                     :string(255)      not null
-#  group_id                 :integer          not null
-#  description              :text(65535)
-#  publisher                :string(255)
-#  mail_name                :string(255)
-#  additional_sender        :string(255)
-#  subscribable             :boolean          default(FALSE), not null
-#  subscribers_may_post     :boolean          default(FALSE), not null
-#  anyone_may_post          :boolean          default(FALSE), not null
-#  preferred_labels         :string(255)
-#  delivery_report          :boolean          default(FALSE), not null
-#  main_email               :boolean          default(FALSE)
-#  mailchimp_api_key        :string(255)
-#  mailchimp_list_id        :string(255)
-#  mailchimp_syncing        :boolean          default(FALSE)
-#  mailchimp_last_synced_at :datetime
+#  id                                  :integer          not null, primary key
+#  additional_sender                   :string(255)
+#  anyone_may_post                     :boolean          default(FALSE), not null
+#  delivery_report                     :boolean          default(FALSE), not null
+#  description                         :text(16777215)
+#  mail_name                           :string(255)
+#  mailchimp_api_key                   :string(255)
+#  mailchimp_include_additional_emails :boolean          default(FALSE)
+#  mailchimp_last_synced_at            :datetime
+#  mailchimp_result                    :text(16777215)
+#  mailchimp_syncing                   :boolean          default(FALSE)
+#  main_email                          :boolean          default(FALSE)
+#  name                                :string(255)      not null
+#  preferred_labels                    :string(255)
+#  publisher                           :string(255)
+#  subscribable                        :boolean          default(FALSE), not null
+#  subscribers_may_post                :boolean          default(FALSE), not null
+#  group_id                            :integer          not null
+#  mailchimp_list_id                   :string(255)
+#
+# Indexes
+#
+#  index_mailing_lists_on_group_id  (group_id)
 #
 
 Fabricator(:mailing_list) do

--- a/spec/fabricators/person_duplicate_fabricator.rb
+++ b/spec/fabricators/person_duplicate_fabricator.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: person_duplicates
+#
+#  id          :bigint           not null, primary key
+#  ignore      :boolean          default(FALSE), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  person_1_id :integer          not null
+#  person_2_id :integer          not null
+#
+# Indexes
+#
+#  index_person_duplicates_on_person_1_id_and_person_2_id  (person_1_id,person_2_id) UNIQUE
+#
+
+
 #  Copyright (c) 2020, CVP Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at

--- a/spec/fabricators/phone_number_fabricator.rb
+++ b/spec/fabricators/phone_number_fabricator.rb
@@ -9,11 +9,15 @@
 # Table name: phone_numbers
 #
 #  id               :integer          not null, primary key
-#  contactable_id   :integer          not null
 #  contactable_type :string(255)      not null
-#  number           :string(255)      not null
 #  label            :string(255)
+#  number           :string(255)      not null
 #  public           :boolean          default(TRUE), not null
+#  contactable_id   :integer          not null
+#
+# Indexes
+#
+#  index_phone_numbers_on_contactable_id_and_contactable_type  (contactable_id,contactable_type)
 #
 
 Fabricator(:phone_number) do

--- a/spec/fabricators/qualification_fabricator.rb
+++ b/spec/fabricators/qualification_fabricator.rb
@@ -9,11 +9,16 @@
 # Table name: qualifications
 #
 #  id                    :integer          not null, primary key
-#  person_id             :integer          not null
-#  qualification_kind_id :integer          not null
-#  start_at              :date             not null
 #  finish_at             :date
 #  origin                :string(255)
+#  start_at              :date             not null
+#  person_id             :integer          not null
+#  qualification_kind_id :integer          not null
+#
+# Indexes
+#
+#  index_qualifications_on_person_id              (person_id)
+#  index_qualifications_on_qualification_kind_id  (qualification_kind_id)
 #
 
 Fabricator(:qualification) do

--- a/spec/fabricators/role_fabricator.rb
+++ b/spec/fabricators/role_fabricator.rb
@@ -9,13 +9,18 @@
 # Table name: roles
 #
 #  id         :integer          not null, primary key
-#  person_id  :integer          not null
-#  group_id   :integer          not null
-#  type       :string(255)      not null
+#  deleted_at :datetime
 #  label      :string(255)
+#  type       :string(255)      not null
 #  created_at :datetime
 #  updated_at :datetime
-#  deleted_at :datetime
+#  group_id   :integer          not null
+#  person_id  :integer          not null
+#
+# Indexes
+#
+#  index_roles_on_person_id_and_group_id  (person_id,group_id)
+#  index_roles_on_type                    (type)
 #
 
 Fabricator(:role) do

--- a/spec/fabricators/service_token_fabricator.rb
+++ b/spec/fabricators/service_token_fabricator.rb
@@ -6,18 +6,21 @@
 #
 # Table name: service_tokens
 #
-#  id             :integer          not null, primary key
-#  layer_group_id :integer          not null
-#  name           :string(255)      not null
-#  description    :text(65535)
-#  token          :string(255)      not null
-#  last_access    :datetime
-#  people         :boolean          default(FALSE)
-#  people_below   :boolean          default(FALSE)
-#  groups         :boolean          default(FALSE)
-#  events         :boolean          default(FALSE)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id                   :integer          not null, primary key
+#  description          :text(16777215)
+#  event_participations :boolean          default(FALSE), not null
+#  events               :boolean          default(FALSE)
+#  groups               :boolean          default(FALSE)
+#  invoices             :boolean          default(FALSE), not null
+#  last_access          :datetime
+#  mailing_lists        :boolean          default(FALSE), not null
+#  name                 :string(255)      not null
+#  people               :boolean          default(FALSE)
+#  people_below         :boolean          default(FALSE)
+#  token                :string(255)      not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  layer_group_id       :integer          not null
 #
 
 Fabricator(:service_token) do

--- a/spec/fabricators/social_account_fabricator.rb
+++ b/spec/fabricators/social_account_fabricator.rb
@@ -9,11 +9,15 @@
 # Table name: social_accounts
 #
 #  id               :integer          not null, primary key
-#  contactable_id   :integer          not null
 #  contactable_type :string(255)      not null
-#  name             :string(255)      not null
 #  label            :string(255)
+#  name             :string(255)      not null
 #  public           :boolean          default(TRUE), not null
+#  contactable_id   :integer          not null
+#
+# Indexes
+#
+#  index_social_accounts_on_contactable_id_and_contactable_type  (contactable_id,contactable_type)
 #
 
 Fabricator(:social_account) do

--- a/spec/fabricators/subscription_fabricator.rb
+++ b/spec/fabricators/subscription_fabricator.rb
@@ -9,10 +9,15 @@
 # Table name: subscriptions
 #
 #  id              :integer          not null, primary key
+#  excluded        :boolean          default(FALSE), not null
+#  subscriber_type :string(255)      not null
 #  mailing_list_id :integer          not null
 #  subscriber_id   :integer          not null
-#  subscriber_type :string(255)      not null
-#  excluded        :boolean          default(FALSE), not null
+#
+# Indexes
+#
+#  index_subscriptions_on_mailing_list_id                    (mailing_list_id)
+#  index_subscriptions_on_subscriber_id_and_subscriber_type  (subscriber_id,subscriber_type)
 #
 
 Fabricator(:subscription) do

--- a/spec/fixtures/addresses.yml
+++ b/spec/fixtures/addresses.yml
@@ -10,14 +10,18 @@
 # Table name: addresses
 #
 #  id               :bigint           not null, primary key
-#  street_short     :string(128)      not null
-#  street_short_old :string(128)      not null
+#  numbers          :text(16777215)
+#  state            :string(128)      not null
 #  street_long      :string(128)      not null
 #  street_long_old  :string(128)      not null
+#  street_short     :string(128)      not null
+#  street_short_old :string(128)      not null
 #  town             :string(128)      not null
 #  zip_code         :integer          not null
-#  state            :string(128)      not null
-#  numbers          :text(16777215)
+#
+# Indexes
+#
+#  index_addresses_on_zip_code_and_street_short  (zip_code,street_short)
 #
 
 bs_bern:

--- a/spec/fixtures/event/dates.yml
+++ b/spec/fixtures/event/dates.yml
@@ -7,11 +7,16 @@
 # Table name: event_dates
 #
 #  id        :integer          not null, primary key
-#  event_id  :integer          not null
-#  label     :string(255)
-#  start_at  :datetime
 #  finish_at :datetime
+#  label     :string(255)
 #  location  :string(255)
+#  start_at  :datetime
+#  event_id  :integer          not null
+#
+# Indexes
+#
+#  index_event_dates_on_event_id               (event_id)
+#  index_event_dates_on_event_id_and_start_at  (event_id,start_at)
 #
 
 first:

--- a/spec/fixtures/event/kind_qualification_kinds.yml
+++ b/spec/fixtures/event/kind_qualification_kinds.yml
@@ -7,11 +7,16 @@
 # Table name: event_kind_qualification_kinds
 #
 #  id                    :integer          not null, primary key
+#  category              :string(255)      not null
+#  grouping              :integer
+#  role                  :string(255)      not null
 #  event_kind_id         :integer          not null
 #  qualification_kind_id :integer          not null
-#  category              :string(255)      not null
-#  role                  :string(255)      not null
-#  grouping              :integer
+#
+# Indexes
+#
+#  index_event_kind_qualification_kinds_on_category  (category)
+#  index_event_kind_qualification_kinds_on_role      (role)
 #
 
 slkgl_pre:

--- a/spec/fixtures/event/participations.yml
+++ b/spec/fixtures/event/participations.yml
@@ -7,14 +7,21 @@
 # Table name: event_participations
 #
 #  id                     :integer          not null, primary key
-#  event_id               :integer          not null
-#  person_id              :integer          not null
-#  additional_information :text(65535)
+#  active                 :boolean          default(FALSE), not null
+#  additional_information :text(16777215)
+#  qualified              :boolean
 #  created_at             :datetime
 #  updated_at             :datetime
-#  active                 :boolean          default(FALSE), not null
 #  application_id         :integer
-#  qualified              :boolean
+#  event_id               :integer          not null
+#  person_id              :integer          not null
+#
+# Indexes
+#
+#  index_event_participations_on_application_id          (application_id)
+#  index_event_participations_on_event_id                (event_id)
+#  index_event_participations_on_event_id_and_person_id  (event_id,person_id) UNIQUE
+#  index_event_participations_on_person_id               (person_id)
 #
 
 top:

--- a/spec/fixtures/event/questions.yml
+++ b/spec/fixtures/event/questions.yml
@@ -7,12 +7,14 @@
 # Table name: event_questions
 #
 #  id               :integer          not null, primary key
-#  event_id         :integer
-#  question         :string(255)
-#  choices          :string(255)
+#  admin            :boolean          default(FALSE), not null
 #  multiple_choices :boolean          default(FALSE), not null
 #  required         :boolean          default(FALSE), not null
-#  admin            :boolean          default(FALSE), not null
+#  event_id         :integer
+#
+# Indexes
+#
+#  index_event_questions_on_event_id  (event_id)
 #
 
 top_ov:

--- a/spec/fixtures/event/roles.yml
+++ b/spec/fixtures/event/roles.yml
@@ -7,9 +7,14 @@
 # Table name: event_roles
 #
 #  id               :integer          not null, primary key
+#  label            :string(255)
 #  type             :string(255)      not null
 #  participation_id :integer          not null
-#  label            :string(255)
+#
+# Indexes
+#
+#  index_event_roles_on_participation_id  (participation_id)
+#  index_event_roles_on_type              (type)
 #
 
 #

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -7,38 +7,44 @@
 # Table name: events
 #
 #  id                          :integer          not null, primary key
-#  type                        :string(255)
+#  applicant_count             :integer          default(0)
+#  application_closing_at      :date
+#  application_conditions      :text(16777215)
+#  application_opening_at      :date
+#  applications_cancelable     :boolean          default(FALSE), not null
+#  cost                        :string(255)
+#  description                 :text(16777215)
+#  display_booking_info        :boolean          default(TRUE), not null
+#  external_applications       :boolean          default(FALSE)
+#  hidden_contact_attrs        :text(16777215)
+#  location                    :text(16777215)
+#  maximum_participants        :integer
+#  motto                       :string(255)
 #  name                        :string(255)      not null
 #  number                      :string(255)
-#  motto                       :string(255)
-#  cost                        :string(255)
-#  maximum_participants        :integer
-#  contact_id                  :integer
-#  description                 :text(65535)
-#  location                    :text(65535)
-#  application_opening_at      :date
-#  application_closing_at      :date
-#  application_conditions      :text(65535)
-#  kind_id                     :integer
-#  state                       :string(60)
-#  priorization                :boolean          default(FALSE), not null
-#  requires_approval           :boolean          default(FALSE), not null
-#  created_at                  :datetime
-#  updated_at                  :datetime
 #  participant_count           :integer          default(0)
-#  application_contact_id      :integer
-#  external_applications       :boolean          default(FALSE)
-#  applicant_count             :integer          default(0)
-#  teamer_count                :integer          default(0)
+#  participations_visible      :boolean          default(FALSE), not null
+#  priorization                :boolean          default(FALSE), not null
+#  required_contact_attrs      :text(16777215)
+#  requires_approval           :boolean          default(FALSE), not null
 #  signature                   :boolean
 #  signature_confirmation      :boolean
 #  signature_confirmation_text :string(255)
+#  state                       :string(60)
+#  teamer_count                :integer          default(0)
+#  type                        :string(255)
+#  waiting_list                :boolean          default(TRUE), not null
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  application_contact_id      :integer
+#  contact_id                  :integer
 #  creator_id                  :integer
+#  kind_id                     :integer
 #  updater_id                  :integer
-#  applications_cancelable     :boolean          default(FALSE), not null
-#  required_contact_attrs      :text(65535)
-#  hidden_contact_attrs        :text(65535)
-#  display_booking_info        :boolean          default(TRUE), not null
+#
+# Indexes
+#
+#  index_events_on_kind_id  (kind_id)
 #
 
 top_event:

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -7,27 +7,35 @@
 # Table name: groups
 #
 #  id                          :integer          not null, primary key
-#  parent_id                   :integer
-#  lft                         :integer
-#  rgt                         :integer
-#  name                        :string(255)      not null
-#  short_name                  :string(31)
-#  type                        :string(255)      not null
-#  email                       :string(255)
-#  address                     :string(1024)
-#  zip_code                    :integer
-#  town                        :string(255)
+#  address                     :text(16777215)
 #  country                     :string(255)
-#  contact_id                  :integer
+#  deleted_at                  :datetime
+#  description                 :text(16777215)
+#  email                       :string(255)
+#  lft                         :integer
+#  logo                        :string(255)
+#  name                        :string(255)      not null
+#  require_person_add_requests :boolean          default(FALSE), not null
+#  rgt                         :integer
+#  short_name                  :string(31)
+#  town                        :string(255)
+#  type                        :string(255)      not null
+#  zip_code                    :integer
 #  created_at                  :datetime
 #  updated_at                  :datetime
-#  deleted_at                  :datetime
-#  layer_group_id              :integer
+#  contact_id                  :integer
 #  creator_id                  :integer
-#  updater_id                  :integer
 #  deleter_id                  :integer
-#  require_person_add_requests :boolean          default(FALSE), not null
-#  description                 :text(65535)
+#  layer_group_id              :integer
+#  parent_id                   :integer
+#  updater_id                  :integer
+#
+# Indexes
+#
+#  index_groups_on_layer_group_id  (layer_group_id)
+#  index_groups_on_lft_and_rgt     (lft,rgt)
+#  index_groups_on_parent_id       (parent_id)
+#  index_groups_on_type            (type)
 #
 
 top_layer:

--- a/spec/fixtures/help_texts.yml
+++ b/spec/fixtures/help_texts.yml
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: help_texts
+#
+#  id         :integer          not null, primary key
+#  controller :string(100)      not null
+#  kind       :string(100)      not null
+#  model      :string(100)
+#  name       :string(100)      not null
+#
+# Indexes
+#
+#  index_help_texts_fields  (controller,model,kind,name) UNIQUE
+#
+
 #  Copyright (c) 2020, CVP Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at

--- a/spec/fixtures/invoice_articles.yml
+++ b/spec/fixtures/invoice_articles.yml
@@ -3,17 +3,21 @@
 # Table name: invoice_articles
 #
 #  id          :integer          not null, primary key
-#  number      :string(255)
-#  name        :string(255)      not null
-#  description :text(65535)
+#  account     :string(255)
 #  category    :string(255)
+#  cost_center :string(255)
+#  description :text(16777215)
+#  name        :string(255)      not null
+#  number      :string(255)
 #  unit_cost   :decimal(12, 2)
 #  vat_rate    :decimal(5, 2)
-#  cost_center :string(255)
-#  account     :string(255)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  group_id    :integer          not null
+#
+# Indexes
+#
+#  index_invoice_articles_on_number_and_group_id  (number,group_id) UNIQUE
 #
 
 beitrag:

--- a/spec/fixtures/invoice_configs.yml
+++ b/spec/fixtures/invoice_configs.yml
@@ -3,20 +3,25 @@
 # Table name: invoice_configs
 #
 #  id                          :integer          not null, primary key
-#  sequence_number             :integer          default(1), not null
-#  due_days                    :integer          default(30), not null
-#  group_id                    :integer          not null
-#  address                     :text(65535)
-#  payment_information         :text(65535)
 #  account_number              :string(255)
-#  iban                        :string(255)
-#  payment_slip                :string(255)      default("ch_es"), not null
-#  beneficiary                 :text(65535)
-#  payee                       :text(65535)
-#  participant_number          :string(255)
+#  address                     :text(16777215)
+#  beneficiary                 :text(16777215)
+#  currency                    :string(255)      default("CHF"), not null
+#  due_days                    :integer          default(30), not null
 #  email                       :string(255)
+#  iban                        :string(255)
+#  participant_number          :string(255)
 #  participant_number_internal :string(255)
+#  payee                       :text(16777215)
+#  payment_information         :text(16777215)
+#  payment_slip                :string(255)      default("ch_es"), not null
+#  sequence_number             :integer          default(1), not null
 #  vat_number                  :string(255)
+#  group_id                    :integer          not null
+#
+# Indexes
+#
+#  index_invoice_configs_on_group_id  (group_id)
 #
 
 top_layer:

--- a/spec/fixtures/invoice_items.yml
+++ b/spec/fixtures/invoice_items.yml
@@ -3,12 +3,18 @@
 # Table name: invoice_items
 #
 #  id          :integer          not null, primary key
-#  invoice_id  :integer          not null
-#  name        :string(255)      not null
-#  description :text(65535)
-#  vat_rate    :decimal(5, 2)
-#  unit_cost   :decimal(12, 2)   not null
+#  account     :string(255)
+#  cost_center :string(255)
 #  count       :integer          default(1), not null
+#  description :text(16777215)
+#  name        :string(255)      not null
+#  unit_cost   :decimal(12, 2)   not null
+#  vat_rate    :decimal(5, 2)
+#  invoice_id  :integer          not null
+#
+# Indexes
+#
+#  index_invoice_items_on_invoice_id  (invoice_id)
 #
 
 pens:

--- a/spec/fixtures/invoices.yml
+++ b/spec/fixtures/invoices.yml
@@ -3,33 +3,44 @@
 # Table name: invoices
 #
 #  id                          :integer          not null, primary key
-#  title                       :string(255)      not null
+#  account_number              :string(255)
+#  address                     :text(16777215)
+#  beneficiary                 :text(16777215)
+#  currency                    :string(255)      default("CHF"), not null
+#  description                 :text(16777215)
+#  due_at                      :date
+#  esr_number                  :string(255)      not null
+#  iban                        :string(255)
+#  issued_at                   :date
+#  participant_number          :string(255)
+#  participant_number_internal :string(255)
+#  payee                       :text(16777215)
+#  payment_information         :text(16777215)
+#  payment_purpose             :text(16777215)
+#  payment_slip                :string(255)      default("ch_es"), not null
+#  recipient_address           :text(16777215)
+#  recipient_email             :string(255)
+#  reference                   :string(255)      not null
+#  sent_at                     :date
 #  sequence_number             :string(255)      not null
 #  state                       :string(255)      default("draft"), not null
-#  esr_number                  :string(255)      not null
-#  description                 :text(65535)
-#  recipient_email             :string(255)
-#  recipient_address           :text(65535)
-#  sent_at                     :date
-#  due_at                      :date
-#  group_id                    :integer          not null
-#  recipient_id                :integer
+#  title                       :string(255)      not null
 #  total                       :decimal(12, 2)
+#  vat_number                  :string(255)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
-#  account_number              :string(255)
-#  address                     :text(65535)
-#  issued_at                   :date
-#  iban                        :string(255)
-#  payment_purpose             :text(65535)
-#  payment_information         :text(65535)
-#  payment_slip                :string(255)      default("ch_es"), not null
-#  beneficiary                 :text(65535)
-#  payee                       :text(65535)
-#  participant_number          :string(255)
 #  creator_id                  :integer
-#  participant_number_internal :string(255)
-#  vat_number                  :string(255)
+#  group_id                    :integer          not null
+#  invoice_list_id             :bigint
+#  recipient_id                :integer
+#
+# Indexes
+#
+#  index_invoices_on_esr_number       (esr_number)
+#  index_invoices_on_group_id         (group_id)
+#  index_invoices_on_invoice_list_id  (invoice_list_id)
+#  index_invoices_on_recipient_id     (recipient_id)
+#  index_invoices_on_sequence_number  (sequence_number)
 #
 
 invoice:

--- a/spec/fixtures/mailing_lists.yml
+++ b/spec/fixtures/mailing_lists.yml
@@ -6,23 +6,29 @@
 #
 # Table name: mailing_lists
 #
-#  id                       :integer          not null, primary key
-#  name                     :string(255)      not null
-#  group_id                 :integer          not null
-#  description              :text(65535)
-#  publisher                :string(255)
-#  mail_name                :string(255)
-#  additional_sender        :string(255)
-#  subscribable             :boolean          default(FALSE), not null
-#  subscribers_may_post     :boolean          default(FALSE), not null
-#  anyone_may_post          :boolean          default(FALSE), not null
-#  preferred_labels         :string(255)
-#  delivery_report          :boolean          default(FALSE), not null
-#  main_email               :boolean          default(FALSE)
-#  mailchimp_api_key        :string(255)
-#  mailchimp_list_id        :string(255)
-#  mailchimp_syncing        :boolean          default(FALSE)
-#  mailchimp_last_synced_at :datetime
+#  id                                  :integer          not null, primary key
+#  additional_sender                   :string(255)
+#  anyone_may_post                     :boolean          default(FALSE), not null
+#  delivery_report                     :boolean          default(FALSE), not null
+#  description                         :text(16777215)
+#  mail_name                           :string(255)
+#  mailchimp_api_key                   :string(255)
+#  mailchimp_include_additional_emails :boolean          default(FALSE)
+#  mailchimp_last_synced_at            :datetime
+#  mailchimp_result                    :text(16777215)
+#  mailchimp_syncing                   :boolean          default(FALSE)
+#  main_email                          :boolean          default(FALSE)
+#  name                                :string(255)      not null
+#  preferred_labels                    :string(255)
+#  publisher                           :string(255)
+#  subscribable                        :boolean          default(FALSE), not null
+#  subscribers_may_post                :boolean          default(FALSE), not null
+#  group_id                            :integer          not null
+#  mailchimp_list_id                   :string(255)
+#
+# Indexes
+#
+#  index_mailing_lists_on_group_id  (group_id)
 #
 
 leaders:

--- a/spec/fixtures/payment_reminder_configs.yml
+++ b/spec/fixtures/payment_reminder_configs.yml
@@ -3,11 +3,15 @@
 # Table name: payment_reminder_configs
 #
 #  id                :integer          not null, primary key
-#  invoice_config_id :integer          not null
-#  title             :string(255)      not null
-#  text              :string(255)      not null
 #  due_days          :integer          not null
 #  level             :integer          not null
+#  text              :string(255)      not null
+#  title             :string(255)      not null
+#  invoice_config_id :integer          not null
+#
+# Indexes
+#
+#  index_payment_reminder_configs_on_invoice_config_id  (invoice_config_id)
 #
 
 bottom_layer_one_first:

--- a/spec/fixtures/people.yml
+++ b/spec/fixtures/people.yml
@@ -7,41 +7,59 @@
 # Table name: people
 #
 #  id                        :integer          not null, primary key
-#  first_name                :string(255)
-#  last_name                 :string(255)
-#  company_name              :string(255)
-#  nickname                  :string(255)
-#  company                   :boolean          default(FALSE), not null
-#  email                     :string(255)
-#  address                   :string(1024)
-#  zip_code                  :string(255)
-#  town                      :string(255)
-#  country                   :string(255)
-#  gender                    :string(1)
+#  additional_information    :text(16777215)
+#  additional_languages      :string(255)
+#  address                   :text(16777215)
+#  advertising               :string(255)
+#  authentication_token      :string(255)
 #  birthday                  :date
-#  additional_information    :text(65535)
+#  company                   :boolean          default(FALSE), not null
+#  company_name              :string(255)
 #  contact_data_visible      :boolean          default(FALSE), not null
+#  correspondence_language   :string(255)
+#  country                   :string(255)
+#  current_sign_in_at        :datetime
+#  current_sign_in_ip        :string(255)
+#  email                     :string(255)
+#  encrypted_password        :string(255)
+#  event_feed_token          :string(255)
+#  failed_attempts           :integer          default(0)
+#  first_name                :string(255)
+#  gender                    :string(1)
+#  household_key             :string(255)
+#  last_name                 :string(255)
+#  last_sign_in_at           :datetime
+#  last_sign_in_ip           :string(255)
+#  locked_at                 :datetime
+#  nationality               :string(255)
+#  nickname                  :string(255)
+#  picture                   :string(255)
+#  remember_created_at       :datetime
+#  reset_password_sent_at    :datetime
+#  reset_password_token      :string(255)
+#  show_global_label_formats :boolean          default(TRUE), not null
+#  sign_in_count             :integer          default(0)
+#  title                     :string(255)
+#  town                      :string(255)
+#  unlock_token              :string(255)
+#  zip_code                  :string(255)
 #  created_at                :datetime
 #  updated_at                :datetime
-#  encrypted_password        :string(255)
-#  reset_password_token      :string(255)
-#  reset_password_sent_at    :datetime
-#  remember_created_at       :datetime
-#  sign_in_count             :integer          default(0)
-#  current_sign_in_at        :datetime
-#  last_sign_in_at           :datetime
-#  current_sign_in_ip        :string(255)
-#  last_sign_in_ip           :string(255)
-#  picture                   :string(255)
-#  last_label_format_id      :integer
 #  creator_id                :integer
-#  updater_id                :integer
+#  last_label_format_id      :integer
 #  primary_group_id          :integer
-#  failed_attempts           :integer          default(0)
-#  locked_at                 :datetime
-#  authentication_token      :string(255)
-#  show_global_label_formats :boolean          default(TRUE), not null
-#  household_key             :string(255)
+#  updater_id                :integer
+#
+# Indexes
+#
+#  index_people_on_authentication_token  (authentication_token)
+#  index_people_on_email                 (email) UNIQUE
+#  index_people_on_event_feed_token      (event_feed_token) UNIQUE
+#  index_people_on_first_name            (first_name)
+#  index_people_on_household_key         (household_key)
+#  index_people_on_last_name             (last_name)
+#  index_people_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_people_on_unlock_token          (unlock_token) UNIQUE
 #
 
 top_leader:

--- a/spec/fixtures/related_role_types.yml
+++ b/spec/fixtures/related_role_types.yml
@@ -7,9 +7,14 @@
 # Table name: related_role_types
 #
 #  id            :integer          not null, primary key
-#  relation_id   :integer
-#  role_type     :string(255)      not null
 #  relation_type :string(255)
+#  role_type     :string(255)      not null
+#  relation_id   :integer
+#
+# Indexes
+#
+#  index_related_role_types_on_relation_id_and_relation_type  (relation_id,relation_type)
+#  index_related_role_types_on_role_type                      (role_type)
 #
 
 leader_groups_bottom_layer:

--- a/spec/fixtures/roles.yml
+++ b/spec/fixtures/roles.yml
@@ -7,13 +7,18 @@
 # Table name: roles
 #
 #  id         :integer          not null, primary key
-#  person_id  :integer          not null
-#  group_id   :integer          not null
-#  type       :string(255)      not null
+#  deleted_at :datetime
 #  label      :string(255)
+#  type       :string(255)      not null
 #  created_at :datetime
 #  updated_at :datetime
-#  deleted_at :datetime
+#  group_id   :integer          not null
+#  person_id  :integer          not null
+#
+# Indexes
+#
+#  index_roles_on_person_id_and_group_id  (person_id,group_id)
+#  index_roles_on_type                    (type)
 #
 
 top_leader:

--- a/spec/fixtures/service_tokens.yml
+++ b/spec/fixtures/service_tokens.yml
@@ -6,18 +6,21 @@
 #
 # Table name: service_tokens
 #
-#  id             :integer          not null, primary key
-#  layer_group_id :integer          not null
-#  name           :string(255)      not null
-#  description    :text(65535)
-#  token          :string(255)      not null
-#  last_access    :datetime
-#  people         :boolean          default(FALSE)
-#  people_below   :boolean          default(FALSE)
-#  groups         :boolean          default(FALSE)
-#  events         :boolean          default(FALSE)
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id                   :integer          not null, primary key
+#  description          :text(16777215)
+#  event_participations :boolean          default(FALSE), not null
+#  events               :boolean          default(FALSE)
+#  groups               :boolean          default(FALSE)
+#  invoices             :boolean          default(FALSE), not null
+#  last_access          :datetime
+#  mailing_lists        :boolean          default(FALSE), not null
+#  name                 :string(255)      not null
+#  people               :boolean          default(FALSE)
+#  people_below         :boolean          default(FALSE)
+#  token                :string(255)      not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  layer_group_id       :integer          not null
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/spec/fixtures/subscriptions.yml
+++ b/spec/fixtures/subscriptions.yml
@@ -7,10 +7,15 @@
 # Table name: subscriptions
 #
 #  id              :integer          not null, primary key
+#  excluded        :boolean          default(FALSE), not null
+#  subscriber_type :string(255)      not null
 #  mailing_list_id :integer          not null
 #  subscriber_id   :integer          not null
-#  subscriber_type :string(255)      not null
-#  excluded        :boolean          default(FALSE), not null
+#
+# Indexes
+#
+#  index_subscriptions_on_mailing_list_id                    (mailing_list_id)
+#  index_subscriptions_on_subscriber_id_and_subscriber_type  (subscriber_id,subscriber_type)
 #
 
 leaders_group:

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -8,38 +8,44 @@
 # Table name: events
 #
 #  id                          :integer          not null, primary key
-#  type                        :string(255)
+#  applicant_count             :integer          default(0)
+#  application_closing_at      :date
+#  application_conditions      :text(16777215)
+#  application_opening_at      :date
+#  applications_cancelable     :boolean          default(FALSE), not null
+#  cost                        :string(255)
+#  description                 :text(16777215)
+#  display_booking_info        :boolean          default(TRUE), not null
+#  external_applications       :boolean          default(FALSE)
+#  hidden_contact_attrs        :text(16777215)
+#  location                    :text(16777215)
+#  maximum_participants        :integer
+#  motto                       :string(255)
 #  name                        :string(255)      not null
 #  number                      :string(255)
-#  motto                       :string(255)
-#  cost                        :string(255)
-#  maximum_participants        :integer
-#  contact_id                  :integer
-#  description                 :text(65535)
-#  location                    :text(65535)
-#  application_opening_at      :date
-#  application_closing_at      :date
-#  application_conditions      :text(65535)
-#  kind_id                     :integer
-#  state                       :string(60)
-#  priorization                :boolean          default(FALSE), not null
-#  requires_approval           :boolean          default(FALSE), not null
-#  created_at                  :datetime
-#  updated_at                  :datetime
 #  participant_count           :integer          default(0)
-#  application_contact_id      :integer
-#  external_applications       :boolean          default(FALSE)
-#  applicant_count             :integer          default(0)
-#  teamer_count                :integer          default(0)
+#  participations_visible      :boolean          default(FALSE), not null
+#  priorization                :boolean          default(FALSE), not null
+#  required_contact_attrs      :text(16777215)
+#  requires_approval           :boolean          default(FALSE), not null
 #  signature                   :boolean
 #  signature_confirmation      :boolean
 #  signature_confirmation_text :string(255)
+#  state                       :string(60)
+#  teamer_count                :integer          default(0)
+#  type                        :string(255)
+#  waiting_list                :boolean          default(TRUE), not null
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  application_contact_id      :integer
+#  contact_id                  :integer
 #  creator_id                  :integer
+#  kind_id                     :integer
 #  updater_id                  :integer
-#  applications_cancelable     :boolean          default(FALSE), not null
-#  required_contact_attrs      :text(65535)
-#  hidden_contact_attrs        :text(65535)
-#  display_booking_info        :boolean          default(TRUE), not null
+#
+# Indexes
+#
+#  index_events_on_kind_id  (kind_id)
 #
 
 require 'spec_helper'

--- a/spec/serializers/group_serializer_spec.rb
+++ b/spec/serializers/group_serializer_spec.rb
@@ -4,27 +4,35 @@
 # Table name: groups
 #
 #  id                          :integer          not null, primary key
-#  parent_id                   :integer
-#  lft                         :integer
-#  rgt                         :integer
-#  name                        :string(255)      not null
-#  short_name                  :string(31)
-#  type                        :string(255)      not null
-#  email                       :string(255)
-#  address                     :string(1024)
-#  zip_code                    :integer
-#  town                        :string(255)
+#  address                     :text(16777215)
 #  country                     :string(255)
-#  contact_id                  :integer
+#  deleted_at                  :datetime
+#  description                 :text(16777215)
+#  email                       :string(255)
+#  lft                         :integer
+#  logo                        :string(255)
+#  name                        :string(255)      not null
+#  require_person_add_requests :boolean          default(FALSE), not null
+#  rgt                         :integer
+#  short_name                  :string(31)
+#  town                        :string(255)
+#  type                        :string(255)      not null
+#  zip_code                    :integer
 #  created_at                  :datetime
 #  updated_at                  :datetime
-#  deleted_at                  :datetime
-#  layer_group_id              :integer
+#  contact_id                  :integer
 #  creator_id                  :integer
-#  updater_id                  :integer
 #  deleter_id                  :integer
-#  require_person_add_requests :boolean          default(FALSE), not null
-#  description                 :text(65535)
+#  layer_group_id              :integer
+#  parent_id                   :integer
+#  updater_id                  :integer
+#
+# Indexes
+#
+#  index_groups_on_layer_group_id  (layer_group_id)
+#  index_groups_on_lft_and_rgt     (lft,rgt)
+#  index_groups_on_parent_id       (parent_id)
+#  index_groups_on_type            (type)
 #
 
 #  Copyright (c) 2014, CEVI Regionalverband ZH-SH-GL. This file is part of

--- a/spec/serializers/invoice_serializer_spec.rb
+++ b/spec/serializers/invoice_serializer_spec.rb
@@ -9,33 +9,44 @@
 # Table name: invoices
 #
 #  id                          :integer          not null, primary key
-#  title                       :string(255)      not null
+#  account_number              :string(255)
+#  address                     :text(16777215)
+#  beneficiary                 :text(16777215)
+#  currency                    :string(255)      default("CHF"), not null
+#  description                 :text(16777215)
+#  due_at                      :date
+#  esr_number                  :string(255)      not null
+#  iban                        :string(255)
+#  issued_at                   :date
+#  participant_number          :string(255)
+#  participant_number_internal :string(255)
+#  payee                       :text(16777215)
+#  payment_information         :text(16777215)
+#  payment_purpose             :text(16777215)
+#  payment_slip                :string(255)      default("ch_es"), not null
+#  recipient_address           :text(16777215)
+#  recipient_email             :string(255)
+#  reference                   :string(255)      not null
+#  sent_at                     :date
 #  sequence_number             :string(255)      not null
 #  state                       :string(255)      default("draft"), not null
-#  esr_number                  :string(255)      not null
-#  description                 :text(65535)
-#  recipient_email             :string(255)
-#  recipient_address           :text(65535)
-#  sent_at                     :date
-#  due_at                      :date
-#  group_id                    :integer          not null
-#  recipient_id                :integer
+#  title                       :string(255)      not null
 #  total                       :decimal(12, 2)
+#  vat_number                  :string(255)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
-#  account_number              :string(255)
-#  address                     :text(65535)
-#  issued_at                   :date
-#  iban                        :string(255)
-#  payment_purpose             :text(65535)
-#  payment_information         :text(65535)
-#  payment_slip                :string(255)      default("ch_es"), not null
-#  beneficiary                 :text(65535)
-#  payee                       :text(65535)
-#  participant_number          :string(255)
 #  creator_id                  :integer
-#  participant_number_internal :string(255)
-#  vat_number                  :string(255)
+#  group_id                    :integer          not null
+#  invoice_list_id             :bigint
+#  recipient_id                :integer
+#
+# Indexes
+#
+#  index_invoices_on_esr_number       (esr_number)
+#  index_invoices_on_group_id         (group_id)
+#  index_invoices_on_invoice_list_id  (invoice_list_id)
+#  index_invoices_on_recipient_id     (recipient_id)
+#  index_invoices_on_sequence_number  (sequence_number)
 #
 
 require 'spec_helper'

--- a/spec/serializers/person_serializer_spec.rb
+++ b/spec/serializers/person_serializer_spec.rb
@@ -4,41 +4,59 @@
 # Table name: people
 #
 #  id                        :integer          not null, primary key
-#  first_name                :string(255)
-#  last_name                 :string(255)
-#  company_name              :string(255)
-#  nickname                  :string(255)
-#  company                   :boolean          default(FALSE), not null
-#  email                     :string(255)
-#  address                   :string(1024)
-#  zip_code                  :string(255)
-#  town                      :string(255)
-#  country                   :string(255)
-#  gender                    :string(1)
+#  additional_information    :text(16777215)
+#  additional_languages      :string(255)
+#  address                   :text(16777215)
+#  advertising               :string(255)
+#  authentication_token      :string(255)
 #  birthday                  :date
-#  additional_information    :text(65535)
+#  company                   :boolean          default(FALSE), not null
+#  company_name              :string(255)
 #  contact_data_visible      :boolean          default(FALSE), not null
+#  correspondence_language   :string(255)
+#  country                   :string(255)
+#  current_sign_in_at        :datetime
+#  current_sign_in_ip        :string(255)
+#  email                     :string(255)
+#  encrypted_password        :string(255)
+#  event_feed_token          :string(255)
+#  failed_attempts           :integer          default(0)
+#  first_name                :string(255)
+#  gender                    :string(1)
+#  household_key             :string(255)
+#  last_name                 :string(255)
+#  last_sign_in_at           :datetime
+#  last_sign_in_ip           :string(255)
+#  locked_at                 :datetime
+#  nationality               :string(255)
+#  nickname                  :string(255)
+#  picture                   :string(255)
+#  remember_created_at       :datetime
+#  reset_password_sent_at    :datetime
+#  reset_password_token      :string(255)
+#  show_global_label_formats :boolean          default(TRUE), not null
+#  sign_in_count             :integer          default(0)
+#  title                     :string(255)
+#  town                      :string(255)
+#  unlock_token              :string(255)
+#  zip_code                  :string(255)
 #  created_at                :datetime
 #  updated_at                :datetime
-#  encrypted_password        :string(255)
-#  reset_password_token      :string(255)
-#  reset_password_sent_at    :datetime
-#  remember_created_at       :datetime
-#  sign_in_count             :integer          default(0)
-#  current_sign_in_at        :datetime
-#  last_sign_in_at           :datetime
-#  current_sign_in_ip        :string(255)
-#  last_sign_in_ip           :string(255)
-#  picture                   :string(255)
-#  last_label_format_id      :integer
 #  creator_id                :integer
-#  updater_id                :integer
+#  last_label_format_id      :integer
 #  primary_group_id          :integer
-#  failed_attempts           :integer          default(0)
-#  locked_at                 :datetime
-#  authentication_token      :string(255)
-#  show_global_label_formats :boolean          default(TRUE), not null
-#  household_key             :string(255)
+#  updater_id                :integer
+#
+# Indexes
+#
+#  index_people_on_authentication_token  (authentication_token)
+#  index_people_on_email                 (email) UNIQUE
+#  index_people_on_event_feed_token      (event_feed_token) UNIQUE
+#  index_people_on_first_name            (first_name)
+#  index_people_on_household_key         (household_key)
+#  index_people_on_last_name             (last_name)
+#  index_people_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_people_on_unlock_token          (unlock_token) UNIQUE
 #
 
 #  Copyright (c) 2014, CEVI Regionalverband ZH-SH-GL. This file is part of


### PR DESCRIPTION
Habe die Konfiguration generiert und unseren Aufruf so angepasst, dass das annotate mit  `RAILS_ENV=test` aufgerufen wird. Somit sollte es ein expliziter schritt sein, d.h  `rake annotate` aufrufen wenn meine testdb nur das core schema geladen hat.

Zudem habe ich die bestehenden Models annotiert.