### PR TITLE
Message Models

### DIFF
--- a/app/models/mailing_list.rb
+++ b/app/models/mailing_list.rb
@@ -43,6 +43,7 @@ class MailingList < ActiveRecord::Base
            dependent: :destroy
 
   has_many :mail_logs, dependent: :nullify
+  has_many :messages, dependent: :nullify
 
   validates_by_schema
   validates :mail_name, uniqueness: { case_sensitive: false },

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,44 @@
+# == Schema Information
+#
+# Table name: messages
+#
+#  id              :bigint           not null, primary key
+#  failed_count    :integer          default(0)
+#  recipient_count :integer          default(0)
+#  sent_at         :datetime
+#  state           :string(255)      default("draft")
+#  subject         :string(1024)     not null
+#  success_count   :integer          default(0)
+#  type            :string(255)      not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  mailing_list_id :bigint
+#  sender_id       :bigint
+#
+# Indexes
+#
+#  index_messages_on_mailing_list_id  (mailing_list_id)
+#  index_messages_on_sender_id        (sender_id)
+#
+
+#  Copyright (c) 2012-2021, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+
+class Message < ActiveRecord::Base
+  validates_by_schema
+  has_many :message_recipients, dependent: :restrict_with_error
+  belongs_to :mailing_list
+
+  scope :list, -> { order(:created_at) }
+
+  def to_s
+    subject ? subject.truncate(20) : super
+  end
+
+  def preview?
+    is_a?(Message::Letter)
+  end
+end

--- a/app/models/message_recipient.rb
+++ b/app/models/message_recipient.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: message_recipients
+#
+#  id           :bigint           not null, primary key
+#  address      :string(255)
+#  email        :string(255)
+#  error        :text(65535)
+#  failed_at    :datetime
+#  phone_number :string(255)
+#  created_at   :datetime
+#  message_id   :bigint           not null
+#  person_id    :bigint           not null
+#
+# Indexes
+#
+#  index_message_recipients_on_message_id  (message_id)
+#  index_message_recipients_on_person_id   (person_id)
+#
+
+
+#  Copyright (c) 2012-2021, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class MessageRecipient < ActiveRecord::Base
+  validates_by_schema
+
+  belongs_to :message
+  belongs_to :person
+  has_one :mailing_list, through: :message, dependent: :restrict_with_error
+
+  scope :list, -> { order(:dispatched_at) }
+end

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -142,6 +142,9 @@ de:
       custom_content:
         one: Text
         other: Texte
+      dispatch:
+        one: Versand
+        other: Versände
       event:
         one: Anlass
         other: Anlässe
@@ -211,6 +214,9 @@ de:
       label_format:
         one: Etikettenformat
         other: Etikettenformate
+      message:
+        one: Nachricht
+        other: Nachrichten
       mail_log:
         one: Verlauf
         other: Verlauf
@@ -651,10 +657,14 @@ de:
           sender_rejected: Absender abgelehnt
           unkown_recipient: Fehler
 
+      message:
+        source: Empfänger
+        subject: Betreff
+        recipient_count: Anzahl Empfänger
+
       subscription:
         related_role_types: Rollen
         subscriber_id: '' # not used, error messages require different labels
-
       people_filter:
         name: Name
 

--- a/db/migrate/20210108072123_create_messaging_models.rb
+++ b/db/migrate/20210108072123_create_messaging_models.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+#
+#  Copyright (c) 2012-2021, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#
+#  https://github.com/hitobito/hitobito
+
+class CreateMessagingModels < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages do |t|
+      t.belongs_to :mailing_list
+      t.belongs_to :sender
+
+      t.string :type, null: false
+      t.string :subject, null: false, limit: 1024
+
+      t.string :state, default: :draft
+
+      t.integer :recipient_count, default: 0
+      t.integer :success_count, default: 0
+      t.integer :failed_count, default: 0
+
+      t.timestamp :sent_at
+
+      t.timestamps
+    end
+
+    create_table :message_recipients do |t|
+      t.belongs_to :message, null: false
+      t.belongs_to :person, null: false
+      t.string :phone_number
+      t.string :email
+      t.string :address
+      t.timestamp :created_at
+      t.timestamp :failed_at
+      t.text :error
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_07_151626) do
+ActiveRecord::Schema.define(version: 2021_01_08_072123) do
 
   create_table "action_text_rich_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -468,6 +468,35 @@ ActiveRecord::Schema.define(version: 2021_01_07_151626) do
     t.text "mailchimp_result"
     t.boolean "mailchimp_include_additional_emails", default: false
     t.index ["group_id"], name: "index_mailing_lists_on_group_id"
+  end
+
+  create_table "message_recipients", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "message_id", null: false
+    t.bigint "person_id", null: false
+    t.string "phone_number"
+    t.string "email"
+    t.string "address"
+    t.timestamp "created_at"
+    t.timestamp "failed_at"
+    t.text "error"
+    t.index ["message_id"], name: "index_message_recipients_on_message_id"
+    t.index ["person_id"], name: "index_message_recipients_on_person_id"
+  end
+
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "mailing_list_id"
+    t.bigint "sender_id"
+    t.string "type", null: false
+    t.string "subject", limit: 1024, null: false
+    t.string "state", default: "draft"
+    t.integer "recipient_count", default: 0
+    t.integer "success_count", default: 0
+    t.integer "failed_count", default: 0
+    t.timestamp "sent_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["mailing_list_id"], name: "index_messages_on_mailing_list_id"
+    t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
 
   create_table "notes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", force: :cascade do |t|

--- a/spec/fixtures/messages.yml
+++ b/spec/fixtures/messages.yml
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: messages
+#
+#  id              :bigint           not null, primary key
+#  failed_count    :integer          default(0)
+#  recipient_count :integer          default(0)
+#  sent_at         :datetime
+#  state           :string(255)      default("draft")
+#  subject         :string(1024)     not null
+#  success_count   :integer          default(0)
+#  type            :string(255)      not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  mailing_list_id :bigint
+#  sender_id       :bigint
+#
+# Indexes
+#
+#  index_messages_on_mailing_list_id  (mailing_list_id)
+#  index_messages_on_sender_id        (sender_id)
+#
+
+simple:
+  mailing_list: leaders
+  type: Message
+  subject: Simple

--- a/spec/models/mailing_list_spec.rb
+++ b/spec/models/mailing_list_spec.rb
@@ -515,4 +515,12 @@ describe MailingList do
     sub
   end
 
+  context 'messages' do
+    let(:message) { messages(:simple) }
+
+    it 'delete nullifies mailing_list on message' do
+      expect(message.mailing_list.destroy).to be_truthy
+      expect(message.reload.mailing_list).to be_nil
+    end
+  end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,54 @@
+# == Schema Information
+#
+# Table name: messages
+#
+#  id              :bigint           not null, primary key
+#  failed_count    :integer          default(0)
+#  recipient_count :integer          default(0)
+#  sent_at         :datetime
+#  state           :string(255)      default("draft")
+#  subject         :string(1024)     not null
+#  success_count   :integer          default(0)
+#  type            :string(255)      not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  mailing_list_id :bigint
+#  sender_id       :bigint
+#
+# Indexes
+#
+#  index_messages_on_mailing_list_id  (mailing_list_id)
+#  index_messages_on_sender_id        (sender_id)
+#
+
+#  Copyright (c) 2012-2021, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+describe Message do
+
+  it '#to_s shows truncated subject' do
+    subject.subject = 'This is a very long text'
+    expect(subject.to_s).to eq 'This is a very lo...'
+  end
+
+  it 'can create message without sender' do
+    mailing_lists(:leaders).messages.create!(subject: 'test', type: 'Message')
+  end
+
+  context '#destroy' do
+    subject { messages(:simple) }
+
+    it 'might be destroy when no dispatch exists' do
+      expect(subject.destroy).to be_truthy
+    end
+
+    it 'existing recipient prevents destruction' do
+      subject.message_recipients.create!(person: people(:top_leader))
+      expect(subject.reload.destroy).to eq false
+    end
+  end
+end


### PR DESCRIPTION
Modell für Messages und Dispatches. 

- `message` ist ein STI Model und erlaubt verschiedene Ausprägungen (SMS, Brief, BriefMitRechnung) 
- `message_dispatch` wird angelegt, wenn die Nachricht verschickt oder als Druckauftrag freigegeben wird
- `message_reciept` wird angelegt, wenn die Nachricht einer Person zugestellt/zugeordnet wird. Somit kann auf der Person einen Liste der Empfangen Nachrichten angezeigt werden. 

refs hitobito/hitobito_cvp#84