### PR TITLE
Mehrsprachigkeit von Events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2020, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -32,7 +32,7 @@ class EventsController < CrudController
 
   self.remember_params += [:year]
 
-  self.sort_mappings = { name: 'events.name', state: 'events.state',
+  self.sort_mappings = { name: 'event_translations.name', state: 'events.state',
                          dates_full: 'event_dates.start_at',
                          group_ids: "#{Group.quoted_table_name}.name" }
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -86,6 +86,10 @@ class EventsController < CrudController
     event_filter.list_entries
   end
 
+  def model_scope
+    super.includes([:translations])
+  end
+
   def build_entry
     if params[:source_id]
       group.events.find(params[:source_id]).duplicate

--- a/app/controllers/full_text_controller.rb
+++ b/app/controllers/full_text_controller.rb
@@ -61,9 +61,10 @@ class FullTextController < ApplicationController
   end
 
   def active_tab
-    return :people if @people.length > 0
-    return :groups if @groups.length > 0
-    return :events if @events.length > 0
+    return :people if @people.present?
+    return :groups if @groups.present?
+    return :events if @events.present?
+
     :people
   end
 

--- a/app/controllers/subscriber/event_controller.rb
+++ b/app/controllers/subscriber/event_controller.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -12,11 +13,13 @@ module Subscriber
 
     before_render_form :replace_validation_errors
 
-    SEARCH_COLUMNS = %w(events.name
-                        events.number
-                        groups.name
-                        event_kind_translations.label
-                        event_kind_translations.short_name)
+    SEARCH_COLUMNS = %w(
+      event_translations.name
+      events.number
+      groups.name
+      event_kind_translations.label
+      event_kind_translations.short_name
+    ).freeze
 
     # GET query queries available events via ajax
     def query
@@ -42,6 +45,7 @@ module Subscriber
                      "AND events.type = '#{Event::Course.sti_name}' " \
                      'LEFT JOIN event_kind_translations ' \
                      'ON event_kinds.id  = event_kind_translations.event_kind_id').
+               left_joins(:translations). # event_translations
                where(search_condition(*SEARCH_COLUMNS)).
                order_by_date.
                distinct

--- a/app/controllers/subscriber/event_controller.rb
+++ b/app/controllers/subscriber/event_controller.rb
@@ -44,11 +44,11 @@ module Subscriber
                      'ON events.kind_id = event_kinds.id ' \
                      "AND events.type = '#{Event::Course.sti_name}' " \
                      'LEFT JOIN event_kind_translations ' \
-                     'ON event_kinds.id  = event_kind_translations.event_kind_id').
-               left_joins(:translations). # event_translations
-               where(search_condition(*SEARCH_COLUMNS)).
-               order_by_date.
-               distinct
+                     'ON event_kinds.id  = event_kind_translations.event_kind_id')
+              .left_joins(:translations) # event_translations
+              .where(search_condition(*SEARCH_COLUMNS))
+              .order_by_date
+              .distinct
     end
 
     def model_label

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -18,7 +18,7 @@ class SubscriptionsController < CrudController
 
   alias mailing_list parent
 
-  def index # rubocop:disable Metrics/MethodLength there are a lof of formats supported
+  def index # rubocop:disable Metrics/AbcSize,Metrics/MethodLength there are a lof of formats supported
     respond_to do |format|
       format.html do
         @person_add_requests = fetch_person_add_requests

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
@@ -73,7 +73,9 @@ class SubscriptionsController < CrudController
   end
 
   def event_subscriptions
-    subscriptions_for_type(Event).order('event_translations.name')
+    subscriptions_for_type(Event)
+      .joins('LEFT JOIN event_translations ON events.id = event_translations.event_id')
+      .order('event_translations.name')
   end
 
   def subscriptions_for_type(klass)

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -73,7 +73,7 @@ class SubscriptionsController < CrudController
   end
 
   def event_subscriptions
-    subscriptions_for_type(Event).order('events.name')
+    subscriptions_for_type(Event).order('event_translations.name')
   end
 
   def subscriptions_for_type(klass)

--- a/app/domain/event/filter.rb
+++ b/app/domain/event/filter.rb
@@ -22,13 +22,13 @@ class Event::Filter
   end
 
   def scope
-    Event. # nesting restricts to parent, we want more
-      where(type: type).
-      includes(:groups).
-      left_joins(:translations).
-      with_group_id(relevant_group_ids).
-      in_year(year).
-      preload_all_dates
+    Event # nesting restricts to parent, we want more
+      .where(type: type)
+      .includes(:groups)
+      .left_joins(:translations)
+      .with_group_id(relevant_group_ids)
+      .in_year(year)
+      .preload_all_dates
   end
 
   def to_h

--- a/app/domain/event/filter.rb
+++ b/app/domain/event/filter.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2018, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -25,6 +25,7 @@ class Event::Filter
     Event. # nesting restricts to parent, we want more
       where(type: type).
       includes(:groups).
+      left_joins(:translations).
       with_group_id(relevant_group_ids).
       in_year(year).
       preload_all_dates

--- a/app/domain/search_strategies/sql.rb
+++ b/app/domain/search_strategies/sql.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2017, Hitobito AG. This file is part of
+#  Copyright (c) 2017-2021, Hitobito AG. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -46,8 +46,11 @@ module SearchStrategies
                 "phone_numbers.contactable_type = 'Group'"]
       },
       'Event' => {
-        attrs: ['events.name', 'events.number', 'groups.name'],
-        joins: [:groups]
+        attrs: ['event_translations.name', 'events.number', 'groups.name'],
+        joins: ['LEFT JOIN event_translations ON event_translations.event_id = events.id',
+                'INNER JOIN events_groups ON events.id = events_groups.event_id',
+                "INNER JOIN #{Group.quoted_table_name} ON " \
+                "events_groups.group_id = #{Group.quoted_table_name}.id"]
       },
       'Address' => {
         attrs: ['addresses.street_short', 'addresses.town', 'addresses.state',

--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -33,8 +33,8 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
   # Render a corresponding input field for the given attribute.
   # The input field is chosen based on the ActiveRecord column type.
   # Use additional html_options for the input element.
-  def input_field(attr, html_options = {}) # rubocop:disable Metrics/PerceivedComplexity,Metrics/MethodLength,Metrics/CyclomaticComplexity
-    type = column_type(@object, attr)
+  def input_field(attr, html_options = {}) # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity
+    type = column_type(@object, attr.to_sym)
     custom_field_method = :"#{type}_field"
     if type == :text
       text_area(attr, html_options)

--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -320,8 +320,11 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
   # only an initial selection prompt or a blank option, respectively.
   def select_options(attr)
     assoc = association(@object, attr)
-    required?(attr) ? { prompt: ta(:please_select, assoc) } :
-                      { include_blank: ta(:no_entry, assoc) }
+    if required?(attr)
+      { prompt: ta(:please_select, assoc) }
+    else
+      { include_blank: ta(:no_entry, assoc) }
+    end
   end
 
   # Dispatch methods starting with 'labeled_' to render a label and the corresponding
@@ -404,6 +407,7 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
   # Returns true if the given attribute must be present.
   def required?(attr)
     return true if dynamic_required?(attr)
+
     attr = attr.to_s
     attr, attr_id = assoc_and_id_attr(attr)
     validators = klass.validators_on(attr) +
@@ -416,6 +420,7 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
 
   def dynamic_required?(attr)
     return false unless @object.respond_to?(:required_attributes)
+
     @object.required_attributes.include?(attr.to_s)
   end
 

--- a/app/indices/event_index.rb
+++ b/app/indices/event_index.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2017, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -8,7 +8,8 @@
 module EventIndex; end
 
 ThinkingSphinx::Index.define_partial :event do
-  indexes name, number, sortable: true
+  indexes number, sortable: true
+  indexes translations.name, as: :name, sortable: true
 
   indexes groups.name, as: :group_name
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2020, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -68,6 +68,9 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
   require_dependency 'event/role_ability'
 
   include Event::Participatable
+
+  include Globalized
+  translates :application_conditions, :description, :name, :signature_confirmation_text
 
   ### ATTRIBUTES
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -173,6 +173,7 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
     # Default scope for event lists
     def list
       order_by_date.
+        includes(:translations).
         order(:name).
         preload_all_dates.
         distinct

--- a/app/models/mailing_list.rb
+++ b/app/models/mailing_list.rb
@@ -4,6 +4,7 @@
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
+
 # == Schema Information
 #
 # Table name: mailing_lists

--- a/bin/wagon
+++ b/bin/wagon
@@ -79,10 +79,14 @@ case $cmd in
     done
     ;;
 
+  test-core)
+    WAGONS= RAILS_TEST_DB_NAME=hit_core_test rspec $@
+    ;;
+
   completion)
     cat <<"COMPLETION"
 function __wagon_commands() {
-  echo 'activate gemfile configs test-prepare grep help'
+  echo 'activate gemfile configs test-prepare test-core grep help'
 }
 
 function __wagon_list() {
@@ -120,7 +124,7 @@ COMPLETION
 
   help|*)
     echo "USAGE: $0 [activate] <PROJECT>"
-    echo "       $0 [test-prepare|gemfile|configs]"
+    echo "       $0 [test-prepare|test-core|gemfile|configs]"
     echo "       $0 [grep] <TERM>"
     echo
     echo "Enable bash-completion with \"source <($0 completion)\""

--- a/db/migrate/20141218140203_modify_event_counts.rb
+++ b/db/migrate/20141218140203_modify_event_counts.rb
@@ -10,6 +10,9 @@ class ModifyEventCounts < ActiveRecord::Migration[4.2]
     rename_column :events, :representative_participant_count, :applicant_count
     add_column :events, :teamer_count, :integer, default: 0
 
+    # let ActiveRecord discover above changes
+    Event.reset_column_information
+
     # Recalculate the counts of all events
     Event.find_each { |e| e.refresh_participant_counts! }
   end

--- a/db/migrate/20210107151626_translate_event_questions.rb
+++ b/db/migrate/20210107151626_translate_event_questions.rb
@@ -1,20 +1,19 @@
 class TranslateEventQuestions < ActiveRecord::Migration[6.0]
   def up
-    Event::Question.create_translation_table!(
-      {
-        question: :string,
-        choices: :string
-      },
-      { migrate_data: true }
-    )
-
-    remove_column :event_questions, :question
-    remove_column :event_questions, :choices
+    say_with_time('creating translation table for event-questions') do
+      Event::Question.create_translation_table!(
+        {
+          question: :string,
+          choices: :string
+        },
+        { migrate_data: true, remove_source_columns: true }
+      )
+    end
   end
 
   def down
-    add_column :event_questions, :question, :string
-    add_column :event_questions, :choices, :string
-    Event::Question.drop_translation_table! migrate_data: true
+    say_with_time('dropping translation-table for event-questions') do
+      Event::Question.drop_translation_table! migrate_data: true
+    end
   end
 end

--- a/db/migrate/20210118151446_translate_events.rb
+++ b/db/migrate/20210118151446_translate_events.rb
@@ -1,0 +1,23 @@
+class TranslateEvents < ActiveRecord::Migration[6.0]
+  def up
+    say_with_time('creating translation table for events') do
+      Event.create_translation_table!(
+        {
+          name: :string,
+          description: :text,
+          application_conditions: :text,
+          signature_confirmation_text: :string
+        },
+        { migrate_data: true, remove_source_columns: true }
+      )
+    end
+  end
+
+  def down
+    say_with_time('dropping translation-table for events') do
+      Event.drop_translation_table! migrate_data: true
+    end
+
+    change_column_null :events, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_13_131128) do
+ActiveRecord::Schema.define(version: 2021_01_18_151446) do
 
   create_table "action_text_rich_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.string "name", null: false
@@ -210,19 +210,29 @@ ActiveRecord::Schema.define(version: 2021_01_13_131128) do
     t.index ["type"], name: "index_event_roles_on_type"
   end
 
+  create_table "event_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.integer "event_id", null: false
+    t.string "locale", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "name"
+    t.text "description"
+    t.text "application_conditions"
+    t.string "signature_confirmation_text"
+    t.index ["event_id"], name: "index_event_translations_on_event_id"
+    t.index ["locale"], name: "index_event_translations_on_locale"
+  end
+
   create_table "events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "type"
-    t.string "name", null: false
     t.string "number"
     t.string "motto"
     t.string "cost"
     t.integer "maximum_participants"
     t.integer "contact_id"
-    t.text "description", size: :medium
-    t.text "location", size: :medium
+    t.text "location"
     t.date "application_opening_at"
     t.date "application_closing_at"
-    t.text "application_conditions", size: :medium
     t.integer "kind_id"
     t.string "state", limit: 60
     t.boolean "priorization", default: false, null: false
@@ -236,7 +246,6 @@ ActiveRecord::Schema.define(version: 2021_01_13_131128) do
     t.integer "teamer_count", default: 0
     t.boolean "signature"
     t.boolean "signature_confirmation"
-    t.string "signature_confirmation_text"
     t.integer "creator_id"
     t.integer "updater_id"
     t.boolean "applications_cancelable", default: false, null: false

--- a/db/seeds/support/event_seeder.rb
+++ b/db/seeds/support/event_seeder.rb
@@ -39,7 +39,9 @@ class EventSeeder
 
   def seed_base_event(values)
     date, number = values[:application_opening_at], values[:number]
-    event = Event.seed(:name, values.merge(name: "Anlass #{number}")).first
+    event = Event.find_or_initialize_by(name: "Anlass #{number}")
+    event.attributes = values
+    event.save!
     seed_dates(event, date + 90.days)
     seed_questions(event) if true?
     seed_leaders(event)
@@ -51,7 +53,10 @@ class EventSeeder
   end
 
   def seed_course(values)
-    event = Event::Course.seed(:name, course_attributes(values)).first
+    course_attrs = course_attributes(values)
+    event = Event::Course.find_or_initialize_by(name: course_attrs[:name])
+    event.attributes = course_attrs
+    event.save!
 
     seed_dates(event, values[:application_opening_at] + 90.days)
     seed_questions(event)

--- a/db/seeds/support/event_seeder.rb
+++ b/db/seeds/support/event_seeder.rb
@@ -43,7 +43,8 @@ class EventSeeder
     date, number = values[:application_opening_at], values[:number]
     event = Event.find_or_initialize_by(name: "Anlass #{number}")
     event.attributes = values
-    event.save!
+    event.save(validate: false)
+
     seed_dates(event, date + 90.days)
     seed_questions(event) if true?
     seed_leaders(event)
@@ -58,7 +59,7 @@ class EventSeeder
     course_attrs = course_attributes(values)
     event = Event::Course.find_or_initialize_by(name: course_attrs[:name])
     event.attributes = course_attrs
-    event.save!
+    event.save(validate: false)
 
     seed_dates(event, values[:application_opening_at] + 90.days)
     seed_questions(event)

--- a/db/seeds/support/person_seeder.rb
+++ b/db/seeds/support/person_seeder.rb
@@ -1,4 +1,3 @@
-
 Faker::Config.locale = I18n.locale
 
 class PersonSeeder
@@ -64,10 +63,19 @@ class PersonSeeder
 
   def seed_developer(name, email, group, role_type)
     first, last = name.split
-    attrs = { email: email,
-              first_name: first,
-              last_name: last,
-              encrypted_password: encrypted_password }
+    attrs = standard_attributes(first, last).merge({
+      email: email,
+      encrypted_password: encrypted_password
+    }).reject do |key, _value|
+      %i(
+        address
+        zip_code
+        town
+        gender
+        birthday
+      ).include? key
+    end
+
     Person.seed_once(:email, attrs)
     person = Person.find_by_email(attrs[:email])
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -517,7 +517,7 @@ describe EventsController do
       before do
         allow(controller).to receive(:doorkeeper_token) { token }
       end
-  
+
       it 'in current year' do
         get :index, params: { group_id: top_layer.id }
         expect(assigns(:events)).to be_empty

--- a/spec/controllers/subscriber/event_controller_spec.rb
+++ b/spec/controllers/subscriber/event_controller_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3

--- a/spec/controllers/subscriber/group_controller_spec.rb
+++ b/spec/controllers/subscriber/group_controller_spec.rb
@@ -50,18 +50,20 @@ describe Subscriber::GroupController do
 
   context 'GET roles.js' do
     it 'load role types' do
-      get :roles, xhr: true, params: { group_id: group.id,
-                                       mailing_list_id: list.id,
-                                       subscription: { subscriber_id: groups(:bottom_layer_one) } },
-      format: :js
+      get :roles, xhr: true, params: {
+        group_id: group.id,
+        mailing_list_id: list.id,
+        subscription: { subscriber_id: groups(:bottom_layer_one) }
+      }, format: :js
 
       expect(assigns(:role_types).root).to eq(Group::BottomLayer)
     end
 
     it 'does not load role types for nil group' do
-      get :roles, xhr: true, params: { group_id: group.id,
-                                       mailing_list_id: list.id },
-                                       format: :js
+      get :roles, xhr: true, params: {
+        group_id: group.id,
+        mailing_list_id: list.id
+      }, format: :js
 
       expect(assigns(:role_types)).to be_nil
     end
@@ -71,9 +73,9 @@ describe Subscriber::GroupController do
   context 'POST create' do
     it 'without subscriber_id replaces error' do
       post :create, params: {
-                      group_id: group.id,
-                      mailing_list_id: list.id
-                    }
+        group_id: group.id,
+        mailing_list_id: list.id
+      }
 
       is_expected.to render_template('crud/new')
       expect(assigns(:subscription).errors[:subscriber_id]).to be_blank
@@ -85,11 +87,11 @@ describe Subscriber::GroupController do
       expect do
         expect do
           post :create, params: {
-                          group_id: group.id,
-                          mailing_list_id: list.id,
-                          subscription: { subscriber_id: groups(:bottom_layer_one),
-                                          role_types: [Group::BottomLayer::Leader, Group::BottomGroup::Leader] }
-                        }
+            group_id: group.id,
+            mailing_list_id: list.id,
+            subscription: { subscriber_id: groups(:bottom_layer_one),
+                            role_types: [Group::BottomLayer::Leader, Group::BottomGroup::Leader] }
+          }
         end.to change { Subscription.count }.by(1)
       end.to change { RelatedRoleType.count }.by(2)
 

--- a/spec/domain/event/filter_spec.rb
+++ b/spec/domain/event/filter_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2018, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -36,8 +36,8 @@ describe Event::Filter do
   end
 
   it 'sorts according to sort_expression' do
-    expect(filter('layer', 'events.name').list_entries.first.name).to eq 'Eventus'
-    expect(filter('layer', 'events.name desc').list_entries.first.name).to eq 'Top Event'
+    expect(filter('layer', 'event_translations.name').list_entries.first.name).to eq 'Eventus'
+    expect(filter('layer', 'event_translations.name desc').list_entries.first.name).to eq 'Top Event'
   end
 
 end

--- a/spec/fixtures/event_translations.yml
+++ b/spec/fixtures/event_translations.yml
@@ -1,0 +1,21 @@
+#  Copyright (c) 2021, Stiftung junge Auslandschweizer. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+top_event_de:
+  event_id: <%= ActiveRecord::FixtureSet.identify(:top_event) %>
+  locale: de
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>
+
+  name: Top Event
+
+top_course_de:
+  event_id: <%= ActiveRecord::FixtureSet.identify(:top_course) %>
+  locale: de
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>
+
+  name: Top Course
+  description: Some kind of course, it seems

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -48,12 +48,10 @@
 #
 
 top_event:
-  name: Top Event
   groups: top_layer
   type:
 
 top_course:
-  name: Top Course
   groups: top_layer
   type: Event::Course
   number: TOP-007
@@ -61,4 +59,3 @@ top_course:
   priorization: true
   requires_approval: true
   external_applications: true
-  description: Some kind of course, it seems


### PR DESCRIPTION
Die SJAS bieten Ferienlager für Auslandschweizer an. Da hier die viele verschiedene Kulturen und Sprachen vorkommen, sollen Anlässe (also auch Ferienlager) übersetzbar sein. 

Dieser PR ermöglicht die Übersetzung von 
- Name
- Beschreibung (genannt Alterskategorie bei der SJAS)
- Anmeldebedingungen
- Zweitunterschrift von

Der Ablauf ist ähnlich den `CustomContent`-Übersetzungen. Man bearbeitet ein Event immer nur in einer Sprache, kann diese aber über den Webseitensprachwähler ("Sprachlink") wechseln.

Die notwendigen Anpassungen in der Wagon (fixtures, seeds, ggf. specs) verlinke ich noch.

See hitobito/hitobito_sjas#35