### PR TITLE
Show messages tab on mailing lists by default

### DIFF
--- a/app/helpers/sheet/mailing_list.rb
+++ b/app/helpers/sheet/mailing_list.rb
@@ -9,15 +9,15 @@ module Sheet
   class MailingList < Base
     self.parent_sheet = Sheet::Group
 
-    tab 'global.tabs.info',
-        :group_mailing_list_path,
-        no_alt: true
-
     tab 'activerecord.models.message.other',
         :group_mailing_list_messages_path,
         if: (lambda do |view, _group, mailing_list|
           view.can?(:update, mailing_list)
         end)
+
+    tab 'global.tabs.settings',
+        :group_mailing_list_path,
+        no_alt: true
 
     tab 'activerecord.models.subscription.other',
         :group_mailing_list_subscriptions_path,

--- a/app/views/mailing_lists/_list.html.haml
+++ b/app/views/mailing_lists/_list.html.haml
@@ -8,7 +8,7 @@
 = crud_table do |t|
   - t.col(MailingList.human_attribute_name(:name)) do |list|
     %strong
-      = link_to(list.name, group_mailing_list_path(@group, list.id))
+      = link_to(list.name, group_mailing_list_messages_path(@group, list.id))
   - t.col(MailingList.human_attribute_name(:description)) do |list|
     = list.description.to_s.truncate(60)
   - t.attrs(:publisher)


### PR DESCRIPTION
When coming from the "my subscriptions" page, we still link to the info / settings page, because that's where the subscribe / unsubscribe button is located.