### PR TITLE
Enable duplicating existing letters

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -49,6 +49,9 @@ class Message < ActiveRecord::Base
   i18n_enum :state, STATES, scopes: true, queries: true
   validates :state, inclusion: { in: STATES }
 
+  class_attribute :duplicatable_attrs
+  self.duplicatable_attrs = %w(subject type mailing_list_id)
+
   scope :list, -> { order(:created_at) }
 
   attr_readonly :type

--- a/app/models/message/letter.rb
+++ b/app/models/message/letter.rb
@@ -32,4 +32,6 @@ class Message::Letter < Message
   self.icon = :'envelope-open-text'
 
   validates_presence_of :body
+
+  self.duplicatable_attrs << 'body'
 end

--- a/app/views/messages/_actions_show.html.haml
+++ b/app/views/messages/_actions_show.html.haml
@@ -11,6 +11,8 @@
 - if entry.letter? && !entry.dispatched?
   = action_button(t('.button_preview'), message_preview_path(message_id: entry.id, format: :pdf), :eye, target: :_blank)
   = button_action_edit if can?(:edit, entry)
+  - if can?(:new, entry)
+    = action_button(t('.button_duplicate'), new_polymorphic_path(path_args(entry.class), duplicate_from: entry.id, message: { type: entry.type }), 'copy')
   = button_action_destroy if can?(:destroy, entry)
 
 - if entry.text_message? && !entry.dispatched?

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -854,6 +854,7 @@ de:
     actions_show:
       button_dispatch_letter: Druckauftrag erstellen
       button_show_assignment: Druckauftrag anzeigen
+      button_duplicate: Duplizieren
       button_preview: Vorschau
       button_dispatch_text_message: Senden
     letter:


### PR DESCRIPTION
Fixes https://github.com/hitobito/hitobito_cvp/issues/99

This allows to use an existing letter as a template for a new one, even after the existing one has been dispatched and is read-only.