### PR TITLE
Fix arc42 link

### DIFF
--- a/doc/architecture/README.md
+++ b/doc/architecture/README.md
@@ -1,6 +1,6 @@
 # Architekur Dokumentation
 
-Diese Dokumente beschreiben die wesentlichen architekturellen Aspekte von hitobito. Die Gliederung folgt [arc42](http://www.arc42.de/template/index.html). Mit `rake doc:arch` kann die eine HTML Datei mit der gesamten Dokumentation generiert werden.
+Diese Dokumente beschreiben die wesentlichen architekturellen Aspekte von hitobito. Die Gliederung folgt [arc42](https://www.arc42.de/template). Mit `rake doc:arch` kann die eine HTML Datei mit der gesamten Dokumentation generiert werden.
 
 ## Inhalt
 


### PR DESCRIPTION
Summary:
  * Link to the official arc42 documentation was outdated.
    Fix the URL so the link works again.