### PR TITLE
Fix flaky test due to wrong use of mock

### DIFF
--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -53,7 +53,7 @@ describe AssignmentsController do
     it 'assigns default_assignee' do
       assignments_settings = double
       expect(assignments_settings).to receive(:default_assignee_email).and_return(bottom_member.email)
-      Settings.assignments = assignments_settings
+      allow(Settings).to receive(:assignments).and_return(assignments_settings)
 
       assignment_double = double
       expect_any_instance_of(AssignmentsController).to receive(:build_entry).and_return(assignment_double)


### PR DESCRIPTION
Fixes #1204, hopefully

I'll re-run the Travis build a few times to see whether this is working as expected. It's hard to say whether this was the only cause, but it's one possible cause (the `Settings` stick around after the test, and the mock doesn't like being used in multiple tests). All other uses of `Settings` in the core specs are either read-only or use mocking correctly.