### PR TITLE
Feature/148 mitte invoice without amount

### DIFF
--- a/app/domain/export/pdf/invoice/payment_slip_qr.rb
+++ b/app/domain/export/pdf/invoice/payment_slip_qr.rb
@@ -118,6 +118,7 @@ module Export::Pdf::Invoice
     def receipt_receiving_office
       padded_bounding_box(0.15, pad_right: true) do
         heading do
+          move_down 10
           pdf.text 'Annahmestelle', align: :right
         end
       end
@@ -142,15 +143,39 @@ module Export::Pdf::Invoice
     end
 
     def amount_box
-      amount = number_with_precision(@invoice.total, precision: 2, delimiter: ' ')
-
       heading do
         text_box 'Währung', at: [0, cursor]
         text_box 'Betrag', at: [20.mm, cursor]
       end
       content do
         text_box @invoice.currency, at: [0, cursor]
-        text_box amount, at: [20.mm, cursor]
+        if @invoice.total.zero?
+          blank_amount_rectangle
+        else
+          amount = number_with_precision(@invoice.total, precision: 2, delimiter: ' ')
+          text_box amount, at: [20.mm, cursor]
+        end
+      end
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    def blank_amount_rectangle(width: 90, height: 30, length: 10)
+      pdf.translate 20.mm, cursor do
+        pdf.stroke do
+          pdf.line_width = 0.5
+          # top left
+          pdf.line [0, 0], [length, 0] # right
+          pdf.line [0, 0], [0, -length] # down
+          # top right
+          pdf.line [width, 0], [width - length, 0] # left
+          pdf.line [width, 0], [width, -length] # down
+          # bottom left
+          pdf.line [0, -height], [length, -height] # right
+          pdf.line [0, -height], [0, -(height -length)] # up
+          # bottom right
+          pdf.line [width, -height], [width - length, -height] # left
+          pdf.line [width, -height], [width, -(height - length)] # down
+        end
       end
     end
 

--- a/app/domain/invoice/qrcode.rb
+++ b/app/domain/invoice/qrcode.rb
@@ -49,7 +49,8 @@ class Invoice::Qrcode
   end
 
   def payment
-    { amount: format('%<total>.2f', total: @invoice.total), currency: @invoice.currency }
+    amount = format('%<total>.2f', total: @invoice.total) unless @invoice.total.zero?
+    { amount: amount, currency: @invoice.currency }
   end
 
   def debitor

--- a/spec/domain/export/pdf/invoice_spec.rb
+++ b/spec/domain/export/pdf/invoice_spec.rb
@@ -139,11 +139,13 @@ describe Export::Pdf::Invoice do
       PDF::Inspector::Text.analyze(pdf)
     end
 
-    it 'renders qrcode' do
-      text_with_position = subject.positions.each_with_index.collect do |p, i|
+    def text_with_position
+      subject.positions.each_with_index.collect do |p, i|
         p.collect(&:round) + [subject.show_text[i]]
       end
+    end
 
+    it 'renders qrcode' do
       expect(text_with_position).to eq [
         [14, 276, 'Empfangsschein'],
         [14, 251, 'Konto / Zahlbar an'],
@@ -159,12 +161,45 @@ describe Export::Pdf::Invoice do
         [71, 89, 'Betrag'],
         [14, 78, 'CHF'],
         [71, 78, '1 500.00'],
-        [105, 49, 'Annahmestelle'],
+        [105, 39, 'Annahmestelle'],
         [190, 276, 'Zahlteil'],
         [190, 89, 'Währung'],
         [247, 89, 'Betrag'],
         [190, 78, 'CHF'],
         [247, 78, '1 500.00'],
+        [346, 278, 'Konto / Zahlbar an'],
+        [346, 266, 'CH93 0076 2011 6238 5295 7'],
+        [346, 255, 'Acme Corp'],
+        [346, 243, 'Hallesche Str. 37'],
+        [346, 232, '3007 Hinterdupfing'],
+        [346, 200, 'Zahlbar durch'],
+        [346, 188, 'Max Mustermann'],
+        [346, 177, 'Musterweg 2'],
+        [346, 165, '8000 Alt Tylerland']
+      ]
+    end
+
+    it 'does not render blank amount' do
+      invoice.total = 0
+      expect(text_with_position).to eq [
+        [14, 276, 'Empfangsschein'],
+        [14, 251, 'Konto / Zahlbar an'],
+        [14, 239, 'CH93 0076 2011 6238 5295 7'],
+        [14, 228, 'Acme Corp'],
+        [14, 216, 'Hallesche Str. 37'],
+        [14, 205, '3007 Hinterdupfing'],
+        [14, 173, 'Zahlbar durch'],
+        [14, 161, 'Max Mustermann'],
+        [14, 150, 'Musterweg 2'],
+        [14, 138, '8000 Alt Tylerland'],
+        [14, 89, 'Währung'],
+        [71, 89, 'Betrag'],
+        [14, 78, 'CHF'],
+        [105, 39, 'Annahmestelle'],
+        [190, 276, 'Zahlteil'],
+        [190, 89, 'Währung'],
+        [247, 89, 'Betrag'],
+        [190, 78, 'CHF'],
         [346, 278, 'Konto / Zahlbar an'],
         [346, 266, 'CH93 0076 2011 6238 5295 7'],
         [346, 255, 'Acme Corp'],

--- a/spec/domain/export/pdf/messages/letter_with_invoice_spec.rb
+++ b/spec/domain/export/pdf/messages/letter_with_invoice_spec.rb
@@ -64,7 +64,7 @@ describe Export::Pdf::Messages::LetterWithInvoice do
         [71, 89, 'Betrag'],
         [14, 78, 'CHF'],
         [71, 78, '10.00'],
-        [105, 49, 'Annahmestelle'],
+        [105, 39, 'Annahmestelle'],
         [190, 276, 'Zahlteil'],
         [190, 89, 'Währung'],
         [247, 89, 'Betrag'],

--- a/spec/domain/invoice/qrcode_spec.rb
+++ b/spec/domain/invoice/qrcode_spec.rb
@@ -69,6 +69,12 @@ describe Invoice::Qrcode do
       expect(subject[19]).to eq 'CHF'
     end
 
+    it 'has blank amount if invoice has no total' do
+      invoice.total = 0
+      expect(subject[18]).to be_blank
+      expect(subject[19]).to eq 'CHF'
+    end
+
     it 'has final payment recipient of combined type' do
       expect(subject[20]).to eq 'K'
       expect(subject[21]).to eq 'Max Mustermann'


### PR DESCRIPTION
Minimale Umsetzung, nur für RechnungsBrief / Sammelrechnungen

![Screenshot from 2021-04-15 13-59-09](https://user-images.githubusercontent.com/180780/114865607-c94f5c80-9df2-11eb-9d06-215a42b41d8b.png)

- Keine Anpassungen am UI (Betrag wird weiterhin mit 0.0 angezeigt)
- In dem QR Zahlteil wird der Betrag nicht mehr angezeigt (qr code validiert)
- Rechnung kann gestellt werden
- Zahlungen können erfasst werden

Weiteres Vorgehen TBD

- Sollen Anpassungen am UI gemacht werden?
- Auch normale Rechnung ohne Rechnungsartikel stellen?
- andere Einzahlungsscheine ?

