### PR TITLE
Add API endpoint for person's event participations (Z-50)

### DIFF
--- a/app/controllers/api/event_participations_controller.rb
+++ b/app/controllers/api/event_participations_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Api
+  class EventParticipationsController < ApplicationController
+    def index
+      authorize!(:show, person)
+
+      respond_to do |format|
+        format.json do
+          render json: ListSerializer.new(list_entries.decorate,
+                                          group: person.primary_group,
+                                          serializer: EventParticipationSerializer,
+                                          controller: self)
+        end
+      end
+    end
+
+    private
+
+    def list_entries
+      Event::Participation.includes(:roles, event: :translations).where(person: person)
+    end
+
+    def person
+      @person ||= Person.includes(:primary_group).find(params[:person_id])
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -303,6 +303,12 @@ Hitobito::Application.routes.draw do
     end
   end # scope locale
 
+  namespace :api do
+    resources :people, only: [] do
+      resources :event_participations, only: [:index]
+    end
+  end
+
   # The priority is based upon order of creation:
   # first created -> highest priority.
 

--- a/spec/controllers/api/event_participations_controller_spec.rb
+++ b/spec/controllers/api/event_participations_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Api::EventParticipationsController do
+  let(:top_leader) { people(:top_leader) }
+
+  it 'fails without token' do
+    get :index, params: { person_id: top_leader.id }, format: :json
+    expect(response.status).to be(401)
+  end
+
+  it 'works with user login' do
+    sign_in(top_leader)
+    get :index, params: { person_id: top_leader.id }, format: :json
+    expect(response.status).to be(200)
+  end
+
+  it 'works with token' do
+    token = service_tokens(:permitted_top_group_token)
+    get :index, params: { person_id: top_leader.id, token: token.token }, format: :json
+    expect(response.status).to be(200)
+  end
+
+  it 'returns all participations' do
+    Fabricate(:event_participation, person: top_leader, active: true)
+    token = service_tokens(:permitted_top_group_token)
+    get :index, params: { person_id: top_leader.id, token: token.token }, format: :json
+    expect(JSON.parse(response.body)['event_participations']).to have(1).items
+  end
+end


### PR DESCRIPTION
This adds an API endpoint to **list a person's event participations**. It resolves a [feature request from PBS](https://trello.com/c/ck9avvD7/276-api-endpunkt-f%C3%BCr-person-history?menu=filter&filter=ges) listing the following requirements (cc @Michael-Schaer):

> Wir würden gerne eine Liste erstellen mit allen Personen, die in einem gewissen Zeitraum einen Kurs geleitet haben (Kursleiter, Kurshelfer, etc). Wenn es einen API Endpunkt für die History einer Person gäbe […], könnte ich die Informationen selber raussuchen.

The implementation adds a completely new top-level `api` route namespace as requested by @psunix.

Open points to discuss:
- Are the permissions correctly set?
- Are the right fields being serialized?