### PR TITLE
Mailchimp field selection flags (Z-48)

### DIFF
--- a/app/controllers/mailing_lists_controller.rb
+++ b/app/controllers/mailing_lists_controller.rb
@@ -13,7 +13,8 @@ class MailingListsController < CrudController
                           :additional_sender, :subscribable, :subscribers_may_post,
                           :anyone_may_post, :main_email, :delivery_report,
                           :mailchimp_list_id, :mailchimp_api_key,
-                          :mailchimp_include_additional_emails, preferred_labels: []]
+                          :mailchimp_include_additional_emails, :mailchimp_sync_first_name,
+                          :mailchimp_sync_last_name, :mailchimp_sync_gender, preferred_labels: []]
 
   decorates :group, :mailing_list
 

--- a/app/controllers/mailing_lists_controller.rb
+++ b/app/controllers/mailing_lists_controller.rb
@@ -14,7 +14,8 @@ class MailingListsController < CrudController
                           :anyone_may_post, :main_email, :delivery_report,
                           :mailchimp_list_id, :mailchimp_api_key,
                           :mailchimp_include_additional_emails, :mailchimp_sync_first_name,
-                          :mailchimp_sync_last_name, :mailchimp_sync_gender, preferred_labels: []]
+                          :mailchimp_sync_last_name, :mailchimp_sync_nickname,
+                          :mailchimp_sync_gender, preferred_labels: []]
 
   decorates :group, :mailing_list
 

--- a/app/decorators/mailing_list_decorator.rb
+++ b/app/decorators/mailing_list_decorator.rb
@@ -54,9 +54,9 @@ class MailingListDecorator < ApplicationDecorator
   end
 
   def mailchimp_synchronization_flags
-    %w(first_name last_name gender).select { |key| self["mailchimp_sync_#{key}"] }
-                                   .map { |key| Person.human_attribute_name(key) }
-                                   .join(', ')
+    %w(first_name last_name gender nickname).select { |key| self["mailchimp_sync_#{key}"] }
+                                            .map { |key| Person.human_attribute_name(key) }
+                                            .join(', ')
   end
 
 end

--- a/app/decorators/mailing_list_decorator.rb
+++ b/app/decorators/mailing_list_decorator.rb
@@ -53,5 +53,10 @@ class MailingListDecorator < ApplicationDecorator
     html << h.tag(:br)
   end
 
+  def mailchimp_synchronization_flags
+    %w(first_name last_name gender).select { |key| self["mailchimp_sync_#{key}"] }
+                                   .map { |key| Person.human_attribute_name(key) }
+                                   .join(', ')
+  end
 
 end

--- a/app/domain/synchronize/mailchimp/client.rb
+++ b/app/domain/synchronize/mailchimp/client.rb
@@ -14,7 +14,9 @@ module Synchronize
       def initialize(mailing_list, member_fields: [], merge_fields: [], count: 50, debug: false)
         @list_id = mailing_list.mailchimp_list_id
         @count   = count
-        @merge_fields = merge_fields
+        @merge_fields = merge_fields.select do |_, _, options, _|
+          !options.key?(:flag_name) || mailing_list["mailchimp_sync_#{options[:flag_name]}"]
+        end
         @member_fields = member_fields
         @max_attempts = Settings.mailchimp.max_attempts
 

--- a/app/domain/synchronize/mailchimp/client.rb
+++ b/app/domain/synchronize/mailchimp/client.rb
@@ -144,11 +144,8 @@ module Synchronize
 
       def subscriber_body(person)
         {
-          email_address: person.email.strip,
-          merge_fields: {
-            FNAME: person.first_name.to_s.strip,
-            LNAME: person.last_name.to_s.strip,
-          }.merge(merge_field_values(person))
+          email_address: person.email.to_s.strip,
+          merge_fields: merge_field_values(person)
         }.merge(member_field_values(person))
       end
 

--- a/app/domain/synchronize/mailchimp/synchronizator.rb
+++ b/app/domain/synchronize/mailchimp/synchronizator.rb
@@ -18,6 +18,7 @@ module Synchronize
       self.merge_fields = [
         ['FNAME', 'text', { flag_name: :first_name }, ->(p) { p.first_name.to_s.strip }],
         ['LNAME', 'text', { flag_name: :last_name }, ->(p) { p.last_name.to_s.strip }],
+        ['Nickname', 'text', { flag_name: :nickname }, ->(p) { p.nickname }],
         ['Gender', 'dropdown', { flag_name: :gender, choices: %w(m w) }, ->(p) { p.gender }]
       ]
 

--- a/app/domain/synchronize/mailchimp/synchronizator.rb
+++ b/app/domain/synchronize/mailchimp/synchronizator.rb
@@ -16,6 +16,8 @@ module Synchronize
       self.member_fields = []
 
       self.merge_fields = [
+        ['FNAME', 'text', {}, ->(p) { p.first_name.to_s.strip }],
+        ['LNAME', 'text', {}, ->(p) { p.last_name.to_s.strip }],
         ['Gender', 'dropdown', { choices: %w(m w) }, ->(p) { p.gender }]
       ]
 

--- a/app/domain/synchronize/mailchimp/synchronizator.rb
+++ b/app/domain/synchronize/mailchimp/synchronizator.rb
@@ -16,9 +16,9 @@ module Synchronize
       self.member_fields = []
 
       self.merge_fields = [
-        ['FNAME', 'text', {}, ->(p) { p.first_name.to_s.strip }],
-        ['LNAME', 'text', {}, ->(p) { p.last_name.to_s.strip }],
-        ['Gender', 'dropdown', { choices: %w(m w) }, ->(p) { p.gender }]
+        ['FNAME', 'text', { flag_name: :first_name }, ->(p) { p.first_name.to_s.strip }],
+        ['LNAME', 'text', { flag_name: :last_name }, ->(p) { p.last_name.to_s.strip }],
+        ['Gender', 'dropdown', { flag_name: :gender, choices: %w(m w) }, ->(p) { p.gender }]
       ]
 
       def initialize(mailing_list)

--- a/app/views/mailing_lists/_attrs.html.haml
+++ b/app/views/mailing_lists/_attrs.html.haml
@@ -9,10 +9,14 @@
     = render_attrs(entry, :mail_address_link, :publisher)
     - if can?(:edit, entry)
       = render_attrs(entry, :mailchimp_api_key,
-                            :mailchimp_list_id,
-                            :mailchimp_include_additional_emails)
-      - if entry.mailchimp? && entry.mailchimp_result
-        = render_attrs(entry, :mailchimp_sync)
+                            :mailchimp_list_id)
+      - if entry.mailchimp?
+        - if entry.mailchimp_result
+          = render_attrs(entry, :mailchimp_include_additional_emails,
+                                :mailchimp_synchronization_flags, :mailchimp_sync)
+        - else
+          = render_attrs(entry, :mailchimp_include_additional_emails,
+                                :mailchimp_synchronization_flags)
       = render_attrs(entry, :additional_sender)
 
 

--- a/app/views/mailing_lists/_form.html.haml
+++ b/app/views/mailing_lists/_form.html.haml
@@ -42,6 +42,10 @@
     = f.labeled_input_fields(:mailchimp_list_id, help: t('.help_mailchimp_sync'))
     = f.labeled_input_fields(:mailchimp_api_key)
     = f.labeled_boolean_field(:mailchimp_include_additional_emails)
+    = f.labeled(:mailchimp_synchronization_flags) do
+      = f.boolean_field(:mailchimp_sync_first_name, caption: Person.human_attribute_name('first_name'))
+      = f.boolean_field(:mailchimp_sync_last_name, caption: Person.human_attribute_name('last_name'))
+      = f.boolean_field(:mailchimp_sync_gender, caption: Person.human_attribute_name('gender'))
 
   %fieldset
     = f.indented do

--- a/app/views/mailing_lists/_form.html.haml
+++ b/app/views/mailing_lists/_form.html.haml
@@ -45,6 +45,7 @@
     = f.labeled(:mailchimp_synchronization_flags) do
       = f.boolean_field(:mailchimp_sync_first_name, caption: Person.human_attribute_name('first_name'))
       = f.boolean_field(:mailchimp_sync_last_name, caption: Person.human_attribute_name('last_name'))
+      = f.boolean_field(:mailchimp_sync_nickname, caption: Person.human_attribute_name('nickname'))
       = f.boolean_field(:mailchimp_sync_gender, caption: Person.human_attribute_name('gender'))
 
   %fieldset

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -680,6 +680,7 @@ de:
           partial: Teilweise
           failed: Fehlgeschlagen
         mailchimp_include_additional_emails: 'Alle Versandadressen synchronisieren'
+        mailchimp_synchronization_flags: 'Mailchimp-Felder'
 
       mail_log:
         updated_at: Bearbeitet am

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -829,7 +829,7 @@ de:
       caption_anyone_may_post: 'Beliebige Absender/-innen dürfen auf die Mailingliste schreiben'
       caption_delivery_report: 'E-Mail mit Bestätigung an Absender schicken'
       help_preferred_labels: 'E-Mails werden falls vorhanden, nur an E-Mailadressen mit dieser Bezeichnung verschickt. Dabei werden auch E-Mail Adressen verwendet, die nicht als Versand-Adresse markiert sind.'
-      help_mailchimp_sync: 'Abonnenten können an die MailChimp-Liste exportiert werden. Diese Aktion überschreibt die MailChimp-Liste und bestehende Kontakte werden gelöscht.'
+      help_mailchimp_sync: 'Abonnenten können an die Mailchimp-Liste exportiert werden. Diese Aktion überschreibt die Mailchimp-Liste und bestehende Kontakte werden gelöscht.'
 
   mailing_list_decorator:
     may_subscribe: 'Abonnenten dürfen sich selbst an/abmelden'

--- a/db/migrate/20210423144148_add_mailchimp_synching_flags.rb
+++ b/db/migrate/20210423144148_add_mailchimp_synching_flags.rb
@@ -9,6 +9,7 @@ class AddMailchimpSynchingFlags < ActiveRecord::Migration[6.0]
   def change
     add_column :mailing_lists, :mailchimp_sync_first_name, :boolean, default: true
     add_column :mailing_lists, :mailchimp_sync_last_name, :boolean, default: true
+    add_column :mailing_lists, :mailchimp_sync_nickname, :boolean, default: true
     add_column :mailing_lists, :mailchimp_sync_gender, :boolean, default: true
   end
 end

--- a/db/migrate/20210423144148_add_mailchimp_synching_flags.rb
+++ b/db/migrate/20210423144148_add_mailchimp_synching_flags.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class AddMailchimpSynchingFlags < ActiveRecord::Migration[6.0]
+  def change
+    add_column :mailing_lists, :mailchimp_sync_first_name, :boolean, default: true
+    add_column :mailing_lists, :mailchimp_sync_last_name, :boolean, default: true
+    add_column :mailing_lists, :mailchimp_sync_gender, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -494,6 +494,7 @@ ActiveRecord::Schema.define(version: 2021_04_23_144148) do
     t.boolean "mailchimp_include_additional_emails", default: false
     t.boolean "mailchimp_sync_first_name", default: true
     t.boolean "mailchimp_sync_last_name", default: true
+    t.boolean "mailchimp_sync_nickname", default: true
     t.boolean "mailchimp_sync_gender", default: true
     t.index ["group_id"], name: "index_mailing_lists_on_group_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_03_115635) do
+ActiveRecord::Schema.define(version: 2021_04_23_144148) do
 
   create_table "action_text_rich_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -492,6 +492,9 @@ ActiveRecord::Schema.define(version: 2021_03_03_115635) do
     t.datetime "mailchimp_last_synced_at"
     t.text "mailchimp_result"
     t.boolean "mailchimp_include_additional_emails", default: false
+    t.boolean "mailchimp_sync_first_name", default: true
+    t.boolean "mailchimp_sync_last_name", default: true
+    t.boolean "mailchimp_sync_gender", default: true
     t.index ["group_id"], name: "index_mailing_lists_on_group_id"
   end
 

--- a/spec/domain/synchronize/mailchimp/client_spec.rb
+++ b/spec/domain/synchronize/mailchimp/client_spec.rb
@@ -8,7 +8,7 @@ require 'spec_helper'
 describe Synchronize::Mailchimp::Client do
   let(:mailing_list) { MailingList.new(mailchimp_api_key: '1234567890d66d25cc5c9285ab5a5552-us12', mailchimp_list_id: 2) }
   let(:top_leader)   { people(:top_leader) }
-  let(:client)       { described_class.new(mailing_list) }
+  let(:client)       { described_class.new(mailing_list, merge_fields: Synchronize::Mailchimp::Synchronizator.merge_fields) }
 
 
   def stub_collection(path, offset, count = client.count, body: )
@@ -56,15 +56,6 @@ describe Synchronize::Mailchimp::Client do
       expect(body[:email_address]).to eq 'top@example.com'
       expect(body[:merge_fields][:FNAME]).to eq 'top'
       expect(body[:merge_fields][:LNAME]).to eq 'leader'
-    end
-
-    it 'handles nil values' do
-      top_leader.update(first_name: nil, last_name: nil, email: ' top@example.com ')
-      body = client.subscriber_body(top_leader)
-
-      expect(body[:email_address]).to eq 'top@example.com'
-      expect(body[:merge_fields][:FNAME]).to eq ''
-      expect(body[:merge_fields][:LNAME]).to eq ''
     end
 
     context 'merge_fields' do

--- a/spec/domain/synchronize/mailchimp/client_spec.rb
+++ b/spec/domain/synchronize/mailchimp/client_spec.rb
@@ -99,6 +99,18 @@ describe Synchronize::Mailchimp::Client do
         expect(body[:company]).to eq true
       end
     end
+
+    it 'respects synchronization flags' do
+      top_leader.update(gender: 'w')
+      mailing_list.mailchimp_sync_first_name = false
+      mailing_list.mailchimp_sync_last_name = false
+      mailing_list.mailchimp_sync_gender = false
+
+      body = client.subscriber_body(top_leader)
+      expect(body[:merge_fields]).not_to have_key :FNAME
+      expect(body[:merge_fields]).not_to have_key :LNAME
+      expect(body[:merge_fields]).not_to have_key :GENDER
+    end
   end
 
   context '#merge_fields' do

--- a/spec/domain/synchronize/mailchimp/client_spec.rb
+++ b/spec/domain/synchronize/mailchimp/client_spec.rb
@@ -100,16 +100,28 @@ describe Synchronize::Mailchimp::Client do
       end
     end
 
-    it 'respects synchronization flags' do
-      top_leader.update(gender: 'w')
-      mailing_list.mailchimp_sync_first_name = false
-      mailing_list.mailchimp_sync_last_name = false
-      mailing_list.mailchimp_sync_gender = false
+    context 'synchronization flags' do
+      before { top_leader.update(gender: 'w', nickname: 'Nick') }
+      subject { client.subscriber_body(top_leader)[:merge_fields] }
 
-      body = client.subscriber_body(top_leader)
-      expect(body[:merge_fields]).not_to have_key :FNAME
-      expect(body[:merge_fields]).not_to have_key :LNAME
-      expect(body[:merge_fields]).not_to have_key :GENDER
+      it 'includes all fields by default' do
+        expect(subject).to have_key :FNAME
+        expect(subject).to have_key :LNAME
+        expect(subject).to have_key :NICKNAME
+        expect(subject).to have_key :GENDER
+      end
+
+      it 'excludes when flags are set to false' do
+        mailing_list.mailchimp_sync_first_name = false
+        mailing_list.mailchimp_sync_last_name = false
+        mailing_list.mailchimp_sync_nickname = false
+        mailing_list.mailchimp_sync_gender = false
+
+        expect(subject).not_to have_key :FNAME
+        expect(subject).not_to have_key :LNAME
+        expect(subject).not_to have_key :NICKNAME
+        expect(subject).not_to have_key :GENDER
+      end
     end
   end
 

--- a/spec/domain/synchronize/mailchimp/synchronizator_spec.rb
+++ b/spec/domain/synchronize/mailchimp/synchronizator_spec.rb
@@ -262,7 +262,7 @@ describe Synchronize::Mailchimp::Synchronizator do
 
   context '#perform' do
     before do
-      sync.merge_fields  = []
+      sync.merge_fields = []
 
       allow(client).to receive(:fetch_merge_fields).and_return([])
       allow(client).to receive(:fetch_segments).and_return([])
@@ -352,6 +352,12 @@ describe Synchronize::Mailchimp::Synchronizator do
     end
 
     context 'subscriptions' do
+      before do
+        sync.merge_fields = Synchronize::Mailchimp::Synchronizator.merge_fields
+        client.instance_variable_set(:@merge_fields, Synchronize::Mailchimp::Synchronizator.merge_fields)
+        allow(client).to receive(:create_merge_fields)
+      end
+
       it 'calls operations with empty lists' do
         expect(client).to receive(:subscribe_members).with([])
         expect(client).to receive(:unsubscribe_members).with([])


### PR DESCRIPTION
This adds flags to the `MailingList` model to select **which fields are exported to Mailchimp**. It resolves a [feature request from PBS](https://trello.com/c/7AfaB9UQ/274-mailchimp-nur-e-mail-adresse-synchronisieren?menu=filter&filter=ges) listing the following requirements:

> Um möglichst wenig Daten an die amerikanische Firma MailChimp weiterzugeben, soll es möglich sein, nur die E-Mail-Adressen zu synchronisieren.
Dies soll per Checkbox steuerbar sein, damit weiterhin beide Optionen möglich sind. Weiter wäre eine Option für die Synchronisierung des Pfadinamens schön.

![grafik](https://user-images.githubusercontent.com/656013/116102804-4c07cf80-a6af-11eb-85b5-f5271c2f8887.png)

cc @Michael-Schaer @psunix