### PR TITLE
Implement IMAP Client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../hitobito_generic
   specs:
-    hitobito_generic (1.22.17)
+    hitobito_generic (1.26.0)
 
 GEM
   remote: https://rubygems.org/

--- a/app/abilities/various_ability.rb
+++ b/app/abilities/various_ability.rb
@@ -24,6 +24,12 @@ class VariousAbility < AbilityDsl::Base
     permission(:any).may(:create, :update, :destroy, :read).own
   end
 
+  if Settings.email.retriever.config.present?
+    on(Imap::Mail) do
+      permission(:admin).may(:manage).all
+    end
+  end
+
   if Group.course_types.present?
     on(Event::Kind) do
       class_side(:index).if_admin
@@ -39,4 +45,5 @@ class VariousAbility < AbilityDsl::Base
   def own
     subject.person_id == user.id
   end
+
 end

--- a/app/controllers/concerns/mailing_lists/imap_mails.rb
+++ b/app/controllers/concerns/mailing_lists/imap_mails.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2021, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'net/imap'
+
+module MailingLists::ImapMails
+  extend ActiveSupport::Concern
+
+  IMAP_SERVER_ERRORS = [Net::IMAP::ResponseError,
+                        Errno::EADDRNOTAVAIL,
+                        SocketError].freeze
+
+  private
+
+  def mailbox(param_name = :mailbox)
+    mailbox = params[param_name]
+    mailbox = mailbox.to_s.downcase
+    mailboxes.include?(mailbox) ? mailbox.to_sym : :inbox
+  end
+
+  def dst_mailbox
+    mailbox(:dst_mailbox)
+  end
+
+  def imap
+    @imap ||= Imap::Connector.new
+  end
+
+  def mailboxes
+    Imap::Connector::MAILBOXES.keys
+  end
+
+  def perform_imap
+    return if @server_error
+
+    yield
+  rescue *IMAP_SERVER_ERRORS => e
+    @server_error = true
+    @server_error_message = e.message
+  end
+
+  def i18n_prefix
+    'mailing_lists.imap_mails'
+  end
+
+  def server_error_message
+    if @server_error
+      [I18n.t("#{i18n_prefix}.flash.server_error"), @server_error_message]
+    end
+  end
+
+end

--- a/app/controllers/mailing_lists/imap_mails_controller.rb
+++ b/app/controllers/mailing_lists/imap_mails_controller.rb
@@ -1,0 +1,67 @@
+#  frozen_string_literal: true
+
+#  Copyright (c) 2012-2021, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class MailingLists::ImapMailsController < ApplicationController
+
+  include MailingLists::ImapMails
+
+  helper_method :mails, :mailbox, :counts
+
+  before_action :authorize_action
+
+  def index
+    perform_imap do
+      @mails = fetch_mails
+    end
+
+    flash.now[:alert] = server_error_message
+  end
+
+  def destroy
+    perform_imap do
+      list_param(:ids).each do |id|
+        imap.delete_by_uid(id.to_i, mailbox)
+      end
+    end
+
+    redirect_to imap_mails_path(mailbox: mailbox), notice: destroy_flash_message
+  end
+
+  private
+
+  def mails
+    @mails || []
+  end
+
+  def fetch_mails
+    mails = imap.fetch_mails(mailbox)
+
+    mails.sort! { |a, b| a.date.to_i <=> b.date.to_i }
+    mails = mails.reverse
+
+    Kaminari.paginate_array(mails).page(params[:page].to_i)
+  end
+
+  def counts
+    fetch_counts || {}
+  end
+
+  def fetch_counts
+    perform_imap do
+      imap.counts
+    end
+  end
+
+  def destroy_flash_message
+    server_error_message || I18n.t("#{i18n_prefix}.flash.deleted")
+  end
+
+  def authorize_action
+    authorize!(:manage, Imap::Mail)
+  end
+
+end

--- a/app/controllers/mailing_lists/imap_mails_move_controller.rb
+++ b/app/controllers/mailing_lists/imap_mails_move_controller.rb
@@ -1,0 +1,41 @@
+#  frozen_string_literal: true
+
+#  Copyright (c) 2012-2021, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+include MailingLists::ImapMails
+
+require 'net/imap'
+
+class MailingLists::ImapMailsMoveController < ApplicationController
+
+  before_action :authorize_action
+
+  helper_method :mailbox
+
+  def create
+    raise 'failed mails cannot be moved' if mailbox == :failed
+
+    perform_imap do
+      list_param(:ids).each do |id|
+        imap.move_by_uid(id.to_i, mailbox, dst_mailbox)
+      end
+    end
+
+    redirect_to imap_mails_path(mailbox: mailbox), notice: moved_flash_message
+  end
+
+  private
+
+  def authorize_action
+    authorize!(:manage, Imap::Mail)
+  end
+
+  def moved_flash_message
+    server_error_message || I18n.t("#{i18n_prefix}.flash.moved")
+  end
+
+end
+

--- a/app/helpers/filter_navigation/mailing_lists/imap_mails.rb
+++ b/app/helpers/filter_navigation/mailing_lists/imap_mails.rb
@@ -1,0 +1,46 @@
+#  frozen_string_literal: true
+
+#  Copyright (c) 2012-2021, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module FilterNavigation::MailingLists
+  class ImapMails < FilterNavigation::Base
+
+    def initialize(template)
+      super(template)
+      init_items
+    end
+
+    def active_label
+      label_for_filter(template.mailbox)
+    end
+
+    private
+
+    def init_items
+      filter_item('inbox')
+      filter_item('spam')
+      filter_item('failed')
+    end
+
+    def filter_item(name)
+      item(label_for_filter(name), filter_path(name))
+    end
+
+    def counts
+      template.counts
+    end
+
+    def label_for_filter(mailbox_name)
+      count_str = counts[mailbox_name]
+      template.t("mailing_lists.imap_mails.mailboxes.#{mailbox_name.downcase}") + " (#{count_str})"
+    end
+
+    def filter_path(name)
+      template.url_for(mailbox: name.downcase, only_path: true)
+    end
+
+  end
+end

--- a/app/helpers/mailing_lists/imap_mails_helper.rb
+++ b/app/helpers/mailing_lists/imap_mails_helper.rb
@@ -1,0 +1,54 @@
+#  Copyright (c) 2012-2021, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module MailingLists::ImapMailsHelper
+
+  def imap_mail_table(template, *attrs)
+    options = attrs.extract_options!
+    template.add_css_class(options, 'table table-striped table-hover')
+
+    table(mails, options.merge(data: { checkable: true })) do |t|
+      yield t if block_given?
+    end
+  end
+
+  def imap_mail_mailbox?(name)
+    mailbox == name
+  end
+
+  def imap_mail_move_button(to)
+    return if to == mailbox
+
+    action_button(t(('mailing_lists.imap_mails.move_to.' + to.to_s).to_sym),
+                  imap_mails_move_path(dst_mailbox: to),
+                  :'arrow-right',
+                  data: { checkable: true, method: :patch })
+  end
+
+  def imap_mail_subject(mail)
+    subject = mail.subject
+    if subject.length > 43
+      subject = subject[0..40] + '...'
+    end
+    sanitize(subject)
+  end
+
+  def imap_mail_body(mail)
+    body = mail.body
+    if body.length > 43
+      body = body[0..40] + '...'
+    end
+    sanitize(body)
+  end
+
+  def imap_mail_date(mail)
+    date = mail.date
+    if date.today?
+      I18n.l(date, format: :time)
+    else
+      I18n.l(date.to_date) + ' ' + I18n.l(date, format: :time)
+    end
+  end
+end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -43,7 +43,8 @@ module NavigationHelper
                      help_texts
                      oauth/active_authorizations
                      event_feed
-                     tags),
+                     tags
+                     mailing_lists/imap_mails),
       if: ->(_) { can?(:index, LabelFormat) } }
   ]
 

--- a/app/helpers/sheet/mailing_lists/imap_mail.rb
+++ b/app/helpers/sheet/mailing_lists/imap_mail.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+module Sheet
+  class MailingLists::ImapMail < Sheet::Admin; end
+end

--- a/app/utils/imap/connector.rb
+++ b/app/utils/imap/connector.rb
@@ -1,0 +1,121 @@
+#  frozen_string_literal: true
+
+#  Copyright (c) 2012-2021, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'net/imap'
+
+class Imap::Connector
+
+  MAILBOXES = { inbox: 'INBOX', spam: 'Junk', failed: 'Failed' }.with_indifferent_access.freeze
+
+  def initialize
+    @connected = false
+    raise 'no imap settings present' unless settings_present?
+  end
+
+  def move_by_uid(uid, from_mailbox, to_mailbox)
+    perform do
+      select_mailbox(from_mailbox)
+      @imap.uid_move(uid, MAILBOXES[to_mailbox])
+    end
+  end
+
+  def delete_by_uid(uid, mailbox)
+    perform do
+      select_mailbox(mailbox)
+      @imap.uid_store(uid, '+FLAGS', [:Deleted])
+      @imap.expunge
+    end
+  end
+
+  def fetch_mails(mailbox)
+    perform do
+      mails_count = count(mailbox)
+      return [] if mails_count.zero?
+
+      fetch_data = @imap.fetch(1..mails_count, attributes)
+      fetch_data.map { |mail| Imap::Mail.build(mail) }
+    end
+  end
+
+  def counts
+    @counts ||= fetch_mailbox_counts
+  end
+
+  private
+
+  def count(mailbox)
+    select_mailbox(mailbox)
+    @imap.status(MAILBOXES[mailbox], ['MESSAGES'])['MESSAGES']
+  end
+
+  def fetch_mailbox_counts
+    counts = {}
+    perform do
+      MAILBOXES.keys.each do |m|
+        counts[m] = count(m)
+      end
+    end
+    counts.with_indifferent_access
+  end
+
+  def perform
+    connect
+    result = yield
+  ensure
+    disconnect
+    result
+  end
+
+  def connect
+    return if @connected
+
+    # rubocop:disable LineLength
+    @imap = Net::IMAP.new(setting(:address), setting(:imap_port) || 993, setting(:enable_ssl) || true)
+    # rubocop:enable LineLength
+    @imap.login(setting(:user_name), setting(:password))
+    @connected = true
+  end
+
+  def disconnect
+    return unless @connected
+
+    unless @imap.nil?
+      @imap.close
+      @imap.disconnect
+      @connected = false
+    end
+  end
+
+  def create_if_missing(mailbox, error)
+    if (MAILBOXES[mailbox] == MAILBOXES[:failed]) &&
+      error.response.data.text.include?("Mailbox doesn't exist")
+      @imap.create(MAILBOXES[:failed])
+      @imap.select(MAILBOXES[:failed])
+    else
+      raise error
+    end
+  end
+
+  def select_mailbox(mailbox)
+    @imap.select(MAILBOXES[mailbox])
+  rescue Net::IMAP::NoResponseError => e
+    create_if_missing(mailbox, e)
+  end
+
+  def setting(key)
+    Settings.email.retriever.config.send(key)
+  end
+
+  def settings_present?
+    Settings.email&.retriever&.config.present?
+  end
+
+  def attributes
+    %w(ENVELOPE UID BODYSTRUCTURE BODY[TEXT] RFC822)
+  end
+
+end

--- a/app/utils/imap/mail.rb
+++ b/app/utils/imap/mail.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'net/imap'
+
+class Imap::Mail
+
+  attr_accessor :net_imap_mail
+
+  delegate :subject, :sender, to: :envelope
+
+  def self.build(net_imap_mail)
+    entry = new
+    entry.net_imap_mail = net_imap_mail
+    entry
+  end
+
+  def uid
+    @net_imap_mail.attr['UID']
+  end
+
+  def date
+    Time.zone.utc_to_local(DateTime.parse(envelope.date))
+  end
+
+  def sender_email
+    envelope.sender[0].mailbox + '@' + envelope.sender[0].host
+  end
+
+  def sender_name
+    envelope.sender[0].name
+  end
+
+  def body
+    if @net_imap_mail.attr['BODYSTRUCTURE'].media_type == 'TEXT'
+      @net_imap_mail.attr['BODY[TEXT]']
+    else
+      mail = Mail.read_from_string @net_imap_mail.attr['RFC822']
+      mail.text_part.body.to_s
+    end
+  end
+
+  private
+
+  def envelope
+    @net_imap_mail.attr['ENVELOPE']
+  end
+
+end

--- a/app/views/mailing_lists/imap_mails/_multiselect_actions.html.haml
+++ b/app/views/mailing_lists/imap_mails/_multiselect_actions.html.haml
@@ -1,0 +1,15 @@
+.hidden
+  .multiselect
+    .count
+    = ti('selected')
+    .actions
+      = imap_mail_move_button :inbox
+      = imap_mail_move_button :spam
+      = imap_mail_move_button :failed
+
+      = action_button(ti(:"link.delete"),
+      imap_mails_destroy_path(mailbox: mailbox),
+      :'trash-alt',
+      data: { confirm: ti(:confirm_delete),
+              checkable: true, method: :delete },
+      )

--- a/app/views/mailing_lists/imap_mails/index.html.haml
+++ b/app/views/mailing_lists/imap_mails/index.html.haml
@@ -1,0 +1,32 @@
+-#  Copyright (c) 2012-2021, Hitobito AG. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+- title t('mailing_lists.imap_mails.manage')
+- content_for(:filter, FilterNavigation::MailingLists::ImapMails.new(self).to_s)
+
+#main
+  = imap_mail_table(self) do |t|
+    - if not imap_mail_mailbox?(:failed)
+      - t.col(check_box_tag(:all, 0, false, { data: :multiselect })) do |i|
+        - check_box_tag('ids[]', i.uid, false, data: { multiselect: true })
+
+    - t.col(t('mailing_lists.imap_mails.headers.subject')) do |m|
+      - imap_mail_subject(m)
+
+    - t.attr(:sender, t('mailing_lists.imap_mails.headers.sender')) do |e|
+      - safe_join([e.sender_name, content_tag(:p, mail_to(e.sender_email))], ' ')
+
+    - t.col(t('mailing_lists.imap_mails.headers.preview')) do |m|
+      - imap_mail_body(m)
+
+    - t.col(t('mailing_lists.imap_mails.headers.date')) do |m|
+      - imap_mail_date(m)
+
+  - unless imap_mail_mailbox?(:failed)
+    = render 'multiselect_actions'
+
+  - if mails.present?
+    .pagination-bar
+    = paginate mails

--- a/app/views/shared/_admin_left_nav.html.haml
+++ b/app/views/shared/_admin_left_nav.html.haml
@@ -25,5 +25,7 @@
     = nav t('navigation.admin/oauth_authorizations'), oauth_active_authorizations_path, %w(oauth_active_authorizations)
   - if can?(:index, ActsAsTaggableOn::Tag)
     = nav ActsAsTaggableOn::Tag.model_name.human(count: 2), tags_path, %w(tags)
+  - if can?(:manage, Imap::Mail)
+    = nav t('mailing_lists.imap_mails.manage'), imap_mails_path(mailbox: 'inbox'), %w(mailing_lists/imap_mails)
 
   = render_extensions(:admin_nav_kinds)

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -525,7 +525,6 @@ de:
         create: Adresse wurde erstellt.
         reset: Adresse wurde aktualisiert.
 
-
   filter_navigation/dropdown:
     additional_views: 'Weitere Ansichten'
 
@@ -830,6 +829,26 @@ de:
       caption_delivery_report: 'E-Mail mit Bestätigung an Absender schicken'
       help_preferred_labels: 'E-Mails werden falls vorhanden, nur an E-Mailadressen mit dieser Bezeichnung verschickt. Dabei werden auch E-Mail Adressen verwendet, die nicht als Versand-Adresse markiert sind.'
       help_mailchimp_sync: 'Abonnenten können an die MailChimp-Liste exportiert werden. Diese Aktion überschreibt die MailChimp-Liste und bestehende Kontakte werden gelöscht.'
+    imap_mails:
+      manage: Abo Mails
+      mailboxes:
+        inbox: Eingang
+        spam: Spam
+        failed: Fehlgeschlagen
+      move_to:
+        inbox: in Eingang
+        spam: in Spam
+        failed: in Fehlgeschlagen
+      headers:
+        subject: Betreff
+        sender: Absender
+        date: Datum
+        preview: Vorschau
+      not_available: Keine Mails in dieser Mailbox vorhanden.
+      flash:
+        deleted: Mail(s) erfolgreich gelöscht
+        moved: Mail(s) erfolgreich verschoben
+        server_error: Verbindung zum Mailserver nicht möglich, bitte versuche es später erneut
 
   mailing_list_decorator:
     may_subscribe: 'Abonnenten dürfen sich selbst an/abmelden'
@@ -924,6 +943,7 @@ de:
     admin: 'Einstellungen'
     admin/event_feed: 'Kalender integrieren'
     admin/oauth_authorizations: 'OAuth-Autorisierungen'
+    imap_mails: 'Abo Mails'
     invoices: 'Rechnungen'
 
   notes:

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -462,6 +462,7 @@ en:
       flash:
         create: Address was created.
         reset: Address has been updated.
+
   filter_navigation/dropdown:
     additional_views: 'Further views'
   filter_navigation/people:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -465,6 +465,10 @@ fr:
       flash:
         create: L'adresse a été créée.
         reset: L'adresse a été actualisée.
+
+  mails:
+    manage: Gérer les mails
+
   filter_navigation/dropdown:
     additional_views: 'Autres vues'
   filter_navigation/people:
@@ -809,6 +813,7 @@ fr:
     admin: 'Paramètres'
     admin/event_feed: 'Intégrer le calendrier'
     admin/oauth_authorizations: 'Autoriser OAuth'
+    mails: 'Mails'
     invoices: 'Factures'
   notes:
     new_note: Ajouter une note

--- a/config/locales/views.it.yml
+++ b/config/locales/views.it.yml
@@ -453,6 +453,10 @@ it:
       flash:
         create: È stato creato l'indirizzo.
         reset: L'indirizzo è stato attualizzato.
+
+  mails:
+    manage: Gestire le mail
+
   filter_navigation/dropdown:
     additional_views: 'altre opinioni'
   filter_navigation/people:
@@ -739,6 +743,7 @@ it:
     admin: 'admin'
     admin/event_feed: 'Integrare il calendario.'
     admin/oauth_authorizations: 'Autorizzazioni OAuth'
+    mails: 'Mails'
     invoices: 'Fatture'
   notes:
     new_note: Nuova nota

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -254,6 +254,14 @@ Hitobito::Application.routes.draw do
 
     resources :event_kinds, module: 'event', controller: 'kinds'
 
+    scope 'mailing_lists', module: :mailing_lists do
+      scope 'imap_mails' do
+        get ':mailbox' => 'imap_mails#index', as: :imap_mails
+        delete ':mailbox' => 'imap_mails#destroy', as: :imap_mails_destroy
+        patch ':mailbox/move' => 'imap_mails_move#create', as: :imap_mails_move
+      end
+    end
+
     resources :qualification_kinds
     resources :tags, except: :show do
       collection do
@@ -298,6 +306,7 @@ Hitobito::Application.routes.draw do
     resources :assignments, only: [:new, :create]
     resources :table_displays, only: [:create]
     resources :messages, only: [:show] do
+      resource :preview, only: [:show], module: :messages
       resource :dispatch, only: [:create, :show], module: :messages
     end
   end # scope locale

--- a/spec/controllers/mailing_lists/imap_mails_controller_spec.rb
+++ b/spec/controllers/mailing_lists/imap_mails_controller_spec.rb
@@ -1,0 +1,273 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'net/imap'
+
+describe MailingLists::ImapMailsController do
+
+  let(:top_leader) { people(:top_leader) }
+
+  let(:imap_connector) { double(:imap_connector) }
+
+  let(:imap_mail_1) { new_mail }
+  let(:imap_mail_2) { new_mail(false) }
+  let(:imap_mail_data) { [imap_mail_1, imap_mail_2] }
+
+  let(:now) { Time.zone.now }
+
+  before do
+    email = double
+    retriever = double
+    config = double('config',
+                    address: 'imap.example.com',
+                    imap_port: 995,
+                    enable_ssl: true,
+                    user_name: 'catch-all@example.com',
+                    password: 'holly-secret')
+    allow(Settings).to receive(:email).and_return(email)
+    allow(email).to receive(:retriever).and_return(retriever)
+    allow(retriever).to receive(:config).and_return(config)
+  end
+
+  context 'GET #index' do
+    it 'lists all mails when admin' do
+      sign_in(top_leader)
+
+      # mock imap_connector
+      expect(controller).to receive(:imap).and_return(imap_connector)
+      expect(imap_connector).to receive(:fetch_mails).with(:inbox).and_return(imap_mail_data)
+
+      get :index, params: { mailbox: 'inbox' }
+
+      expect(response).to have_http_status(:success)
+
+      mails = assigns(:mails)
+
+      expect(mails.count).to eq(2)
+
+      mail1 = mails.last
+      expect(mail1.uid).to eq('42')
+      expect(mail1.subject).to be(imap_mail_1.subject)
+      expect(mail1.date).to eq(Time.zone.utc_to_local(DateTime.parse(now.to_s)))
+      expect(mail1.sender_email).to eq('john@sender.example.com')
+      expect(mail1.sender_name).to eq('sender')
+      expect(mail1.body).to eq('SpaceX rocks!')
+
+      mail2 = mails.first
+      expect(mail2.uid).to eq('43')
+      expect(mail2.subject).to be(imap_mail_2.subject)
+      expect(mail2.date).to eq(Time.zone.utc_to_local(DateTime.parse(now.to_s)))
+      expect(mail2.sender_email).to eq('john@sender.example.com')
+      expect(mail2.sender_name).to eq('sender')
+      expect(mail2.body).to eq('<h1>Starship flies!</h1>')
+    end
+
+    it 'returns inbox mails if invalid mailbox given' do
+      # sign in
+      sign_in(top_leader)
+
+      # mock imap_connector
+      expect(controller).to receive(:imap).and_return(imap_connector)
+      expect(imap_connector).to receive(:fetch_mails).with(:inbox).and_return(imap_mail_data)
+
+      get :index, params: { mailbox: 'invalid_mailbox' }
+
+      expect(response).to have_http_status(:success)
+      mails = assigns(:mails)
+      expect(mails.count).to eq(2)
+    end
+
+    it 'displays alert if mail server not reachable' do
+      sign_in(top_leader)
+
+      # mock imap_connector
+      expect(controller).to receive(:imap).and_return(imap_connector)
+      expect(imap_connector)
+        .to receive(:fetch_mails)
+        .with(:inbox)
+        .and_raise(Net::IMAP::NoResponseError, ImapErrorDataDouble)
+
+      get :index, params: { mailbox: 'inbox' }
+
+      expect(response).to have_http_status(:success)
+
+      mails = controller.send(:mails)
+
+      expect(mails.count).to eq(0)
+      expect(flash[:alert])
+        .to eq(["Verbindung zum Mailserver nicht möglich, bitte versuche es später erneut", "Authentication failed."])
+    end
+
+    it 'denies access for non admin' do
+      sign_in(people(:bottom_member))
+
+      expect do
+        get :index, params: { mailbox: 'inbox' }
+      end.to raise_error(CanCan::AccessDenied)
+    end
+
+    it 'displays flash if imap server not reachable' do
+      sign_in(top_leader)
+
+      # mock imap_connector
+      expect(controller).to receive(:imap).and_return(imap_connector)
+
+      expect(imap_connector).to receive(:fetch_mails).with(:inbox).and_raise(Errno::EADDRNOTAVAIL)
+
+      get :index, params: { mailbox: 'inbox' }
+
+      expect(response).to have_http_status(:success)
+
+      mails = controller.send(:mails)
+
+      expect(mails.count).to eq(0)
+      expect(flash[:alert])
+        .to eq(["Verbindung zum Mailserver nicht möglich, bitte versuche es später erneut", "Cannot assign requested address"])
+    end
+
+    it 'displays flash if imap server dns unresolvable' do
+      sign_in(top_leader)
+
+      # mock imap_connector
+      expect(controller).to receive(:imap).and_return(imap_connector)
+
+      expect(imap_connector).to receive(:fetch_mails).with(:inbox).and_raise(SocketError)
+
+      get :index, params: { mailbox: 'inbox' }
+
+      expect(response).to have_http_status(:success)
+
+      mails = controller.send(:mails)
+
+      expect(mails.count).to eq(0)
+      expect(flash[:alert])
+        .to eq(['Verbindung zum Mailserver nicht möglich, bitte versuche es später erneut', 'SocketError'])
+    end
+
+    it 'displays flash if imap server credentials invalid' do
+      sign_in(top_leader)
+
+      # mock imap_connector
+      expect(controller).to receive(:imap).and_return(imap_connector)
+
+      expect(imap_connector).to receive(:fetch_mails).with(:inbox).and_raise(Net::IMAP::NoResponseError, ImapErrorDataDouble)
+
+      get :index, params: { mailbox: 'inbox' }
+
+      expect(response).to have_http_status(:success)
+
+      mails = controller.send(:mails)
+
+      expect(mails.count).to eq(0)
+      expect(flash[:alert])
+        .to eq(['Verbindung zum Mailserver nicht möglich, bitte versuche es später erneut', 'Authentication failed.'])
+    end
+  end
+
+  context 'DELETE #destroy' do
+    it 'deletes specific mails from inbox' do
+      sign_in(top_leader)
+
+      # mock imap_connector for counts and mails
+      expect(controller).to receive(:imap).and_return(imap_connector).twice
+
+      expect(imap_connector).to receive(:delete_by_uid).with(42, :inbox)
+      expect(imap_connector).to receive(:delete_by_uid).with(43, :inbox)
+
+      delete :destroy, params: { mailbox: 'inbox', ids: '42, 43'}
+
+      expect(flash[:notice]).to include 'Mail(s) erfolgreich gelöscht'
+      expect(response).to redirect_to imap_mails_path(:inbox)
+    end
+
+    it 'cannot be deleted by non-admin' do
+      sign_in(people(:bottom_member))
+      expect do
+        delete :destroy, params: { mailbox: 'inbox', ids: '42' }
+      end.to raise_error(CanCan::AccessDenied)
+    end
+
+    it 'displays flash notice if imap server not reachable' do
+      sign_in(top_leader)
+
+      # mock imap_connector
+      expect(controller).to receive(:imap).and_return(imap_connector)
+
+      expect(imap_connector)
+        .to receive(:delete_by_uid)
+              .with(42, :inbox)
+              .and_raise(Net::IMAP::NoResponseError, ImapErrorDataDouble)
+
+      delete :destroy, params: { mailbox: 'unavailable_mailbox', ids: '42' }
+
+      expect(response).to have_http_status(:redirect)
+
+      expect(flash[:notice])
+        .to eq(["Verbindung zum Mailserver nicht möglich, bitte versuche es später erneut", "Authentication failed."])
+    end
+  end
+
+  private
+
+  def new_mail(text_body = true)
+    imap_mail = Net::IMAP::FetchData.new(Faker::Number.number(digits: 1), mail_attrs(text_body))
+    Imap::Mail.build(imap_mail)
+  end
+
+  def mail_attrs(text_body)
+    {
+      'UID' => text_body ? '42' : '43',
+      'RFC822' => text_body ? '' : new_html_message,
+      'ENVELOPE' => new_envelope,
+      'BODY[TEXT]' => text_body ? 'SpaceX rocks!' : 'Tesla rocks!',
+      'BODYSTRUCTURE' => text_body ? new_text_body : new_html_body_type
+    }
+  end
+
+  def new_envelope
+    Net::IMAP::Envelope.new(
+      now.to_s,
+      'Testflight from 24.4.2021',
+      [new_address('from')],
+      [new_address('sender')],
+      [new_address('reply_to')],
+      [new_address('to')]
+    )
+  end
+
+  def new_address(name)
+    Net::IMAP::Address.new(
+      name,
+      nil,
+      'john',
+      "#{name}.example.com"
+    )
+  end
+
+  def new_text_body
+    Net::IMAP::BodyTypeText.new('TEXT')
+  end
+
+  def new_html_body_type
+    Net::IMAP::BodyTypeMultipart.new('MULTIPART')
+  end
+
+  def new_html_message
+    html_message = Mail::Message.new
+    html_message.body('<h1>Starship flies!</h1>')
+    html_message.text_part = ''
+    html_message
+  end
+
+  # and_raise only accepts either String or Module
+  # so creating a double with a Module
+  module ImapErrorDataDouble
+    Data = Struct.new(:text)
+    def self.data
+      data = Data.new('Authentication failed.')
+      data
+    end
+  end
+
+end

--- a/spec/controllers/mailing_lists/imap_mails_move_controller_spec.rb
+++ b/spec/controllers/mailing_lists/imap_mails_move_controller_spec.rb
@@ -1,0 +1,174 @@
+#  frozen_string_literal: true
+
+#  Copyright (c) 2012-2021, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+require 'net/imap'
+
+describe MailingLists::ImapMailsMoveController do
+
+  let(:top_leader) { people(:top_leader) }
+
+  let(:imap_connector) { double(:imap_connector) }
+
+  let(:imap_mail_1) { new_mail }
+  let(:imap_mail_2) { new_mail(false) }
+  let(:imap_mail_data) { [imap_mail_1, imap_mail_2] }
+
+  let(:now) { Time.zone.now }
+
+  before do
+    email = double
+    retriever = double
+    config = double('config',
+                    address: 'imap.example.com',
+                    imap_port: 995,
+                    enable_ssl: true,
+                    user_name: 'catch-all@example.com',
+                    password: 'holly-secret')
+    allow(Settings).to receive(:email).and_return(email)
+    allow(email).to receive(:retriever).and_return(retriever)
+    allow(retriever).to receive(:config).and_return(config)
+  end
+
+  context 'PATCH #create' do
+    it 'moves Mail to given mailbox' do
+      sign_in(top_leader)
+
+      # mock imap_connector
+      expect(controller).to receive(:imap).and_return(imap_connector).twice
+
+      expect(imap_connector).to receive(:move_by_uid).with(42, :inbox, :failed)
+      expect(imap_connector).to receive(:move_by_uid).with(43, :inbox, :failed)
+
+      patch :create, params: { mailbox: 'inbox', ids: '42,43', dst_mailbox: 'failed' }
+
+      expect(flash[:notice]).to include 'Mail(s) erfolgreich verschoben'
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to imap_mails_path
+    end
+
+    it 'returns inbox if given mailbox is invalid' do
+      sign_in(top_leader)
+
+      # mock imap_connector
+      expect(controller).to receive(:imap).and_return(imap_connector)
+
+      expect(imap_connector).to receive(:move_by_uid).with(42, :inbox, :inbox)
+
+      patch :create, params: { mailbox: 'inbox', ids: '42', dst_mailbox: 'invalid_mailbox' }
+
+      expect(flash[:notice]).to include 'Mail(s) erfolgreich verschoben'
+      expect(response).to have_http_status(:found)
+      expect(response.location).to eq('http://test.host/mailing_lists/imap_mails/inbox')
+    end
+
+    it 'does not allow non-admins to move mails' do
+      sign_in(people(:bottom_member))
+
+      expect(controller).to receive(:imap).never
+
+      expect do
+        patch :create, params: { mailbox: 'inbox', ids: '42' }
+      end.to raise_error(CanCan::AccessDenied)
+    end
+
+    it 'displays flash notice if mail server not reachable' do
+      sign_in(top_leader)
+
+      # mock imap_connector
+      expect(controller).to receive(:imap).and_return(imap_connector)
+
+      expect(imap_connector)
+        .to receive(:move_by_uid)
+        .with(42, :inbox, :failed)
+        .and_raise(Net::IMAP::NoResponseError, ImapMoveErrorDataDouble)
+
+      patch :create, params: { mailbox: 'inbox', ids: '42', dst_mailbox: 'failed' }
+
+      expect(response).to have_http_status(:redirect)
+
+      expect(flash[:notice])
+        .to eq(["Verbindung zum Mailserver nicht möglich, bitte versuche es später erneut", "Authentication failed."])
+    end
+
+    it 'cannot move mails from failed mailbox' do
+      sign_in(top_leader)
+
+      # mock imap_connector
+      expect(controller).to receive(:imap).and_return(imap_connector).never
+
+      expect do
+        patch :create, params: { mailbox: 'failed', ids: '42', mail_dst: 'inbox' }
+      end.to raise_error('failed mails cannot be moved')
+    end
+
+  end
+
+  private
+
+  def new_mail(text_body = true)
+    imap_mail = Net::IMAP::FetchData.new(Faker::Number.number(digits: 1), mail_attrs(text_body))
+    Imap::Mail.build(imap_mail)
+  end
+
+  def mail_attrs(text_body)
+    {
+      'UID' => text_body ? '42' : '43',
+      'RFC822' => text_body ? '' : new_html_message,
+      'ENVELOPE' => new_envelope,
+      'BODY[TEXT]' => text_body ? 'SpaceX rocks!' : 'Tesla rocks!',
+      'BODYSTRUCTURE' => text_body ? new_text_body : new_html_body_type
+    }
+  end
+
+  def new_envelope
+    Net::IMAP::Envelope.new(
+      now.to_s,
+      'Testflight from 24.4.2021',
+      [new_address('from')],
+      [new_address('sender')],
+      [new_address('reply_to')],
+      [new_address('to')]
+    )
+  end
+
+  def new_address(name)
+    Net::IMAP::Address.new(
+      name,
+      nil,
+      'john',
+      "#{name}.example.com"
+    )
+  end
+
+  def new_text_body
+    Net::IMAP::BodyTypeText.new('TEXT')
+  end
+
+  def new_html_body_type
+    Net::IMAP::BodyTypeMultipart.new('MULTIPART')
+  end
+
+  def new_html_message
+    html_message = Mail::Message.new
+    html_message.body('<h1>Starship flies!</h1>')
+    html_message.text_part = ''
+    html_message
+  end
+
+  # and_raise only accepts either String or Module
+  # so creating a double with a Module
+  module ImapMoveErrorDataDouble
+    Data = Struct.new(:text)
+    def self.data
+      data = Data.new('Authentication failed.')
+      data
+    end
+  end
+
+end

--- a/spec/utils/imap/connector_spec.rb
+++ b/spec/utils/imap/connector_spec.rb
@@ -1,0 +1,262 @@
+#  frozen_string_literal: true
+
+#  Copyright (c) 2012-2021, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+require 'net/imap'
+
+describe Imap::Connector do
+
+  let(:net_imap) { double(:net_imap) }
+  let(:imap_connector) { Imap::Connector.new }
+  let(:now) { Time.zone.now }
+
+  let(:imap_mail_1) { new_mail(1) }
+  let(:imap_mail_2) { new_mail(2, false) }
+  let(:imap_fetch_data) { [imap_mail_1, imap_mail_2] }
+
+  let(:fetch_attributes) { %w(ENVELOPE UID BODYSTRUCTURE BODY[TEXT] RFC822) }
+
+  before do
+    email = double
+    retriever = double
+    config = double('config',
+                    address: 'imap.example.com',
+                    imap_port: 995,
+                    enable_ssl: true,
+                    user_name: 'catch-all@example.com',
+                    password: 'holly-secret')
+    allow(Settings).to receive(:email).and_return(email)
+    allow(email).to receive(:retriever).and_return(retriever)
+    allow(retriever).to receive(:config).and_return(config)
+  end
+
+  describe '#move_by_uid' do
+    it 'moves mail to existing mailbox' do
+      # connect
+      expect(Net::IMAP).to receive(:new).and_return(net_imap)
+      expect(net_imap).to receive(:login)
+
+      # move
+      expect(net_imap).to receive(:select).with("INBOX")
+      expect(net_imap).to receive(:uid_move).with('42', "Failed")
+
+      # disconnect
+      expect(net_imap).to receive(:disconnect)
+      expect(net_imap).to receive(:close)
+
+      imap_connector.move_by_uid('42', :inbox, :failed)
+    end
+
+    it 'moves mail to not existing mailbox' do
+      # connect
+      expect(Net::IMAP).to receive(:new).and_return(net_imap)
+      expect(net_imap).to receive(:login)
+
+      # move
+      expect(net_imap).to receive(:select).with("INBOX").and_raise(no_mailbox_error)
+      expect(net_imap).to receive(:uid_move).with('42', nil)
+
+      expect(imap_connector).to receive(:create_if_missing)
+
+      # disconnect
+      expect(net_imap).to receive(:disconnect)
+      expect(net_imap).to receive(:close)
+
+      imap_connector.move_by_uid('42', :inbox, :invalid)
+    end
+  end
+
+  describe 'delete_by_uid' do
+    it 'deletes mail' do
+      # connect
+      expect(Net::IMAP).to receive(:new).and_return(net_imap)
+      expect(net_imap).to receive(:login)
+
+      # select
+      expect(net_imap).to receive(:select).with(nil)
+
+      # expect(net_imap).to receive(:uid_copy).with(uid, 'TRASH')
+      expect(net_imap).to receive(:uid_store).with('42', '+FLAGS', [:Deleted])
+      expect(net_imap).to receive(:expunge)
+
+      # disconnect
+      expect(net_imap).to receive(:close)
+      expect(net_imap).to receive(:disconnect)
+
+      imap_connector.delete_by_uid('42', 'INBOX')
+    end
+  end
+
+  describe '#fetch_mails' do
+    it 'fetches mails from inbox' do
+      # connect
+      expect(Net::IMAP).to receive(:new).and_return(net_imap)
+      expect(net_imap).to receive(:login)
+
+      # count
+      expect(net_imap).to receive(:select).with('INBOX')
+      expect(net_imap).to receive(:status).with('INBOX', array_including('MESSAGES')).and_return({ 'MESSAGES' => 2 })
+
+      # fetch
+      expect(net_imap).to receive(:fetch).with(1..2, fetch_attributes).and_return(imap_fetch_data)
+
+      # disconnect
+      expect(net_imap).to receive(:close)
+      expect(net_imap).to receive(:disconnect)
+
+      mails = imap_connector.fetch_mails(:inbox)
+
+      mail1 = mails.first
+
+      # check mail content
+      expect(mail1.uid).to eq('42')
+      expect(mail1.subject).to be(imap_mail_1.attr['ENVELOPE'].subject)
+      expect(mail1.date).to eq(Time.zone.utc_to_local(DateTime.parse(now.to_s)))
+      expect(mail1.sender_email).to eq('john@sender.example.com')
+      expect(mail1.sender_name).to eq('sender')
+      expect(mail1.body).to eq('SpaceX rocks!')
+    end
+
+    it 'fetch empty array from an empty mailbox' do
+      # connect
+      expect(Net::IMAP).to receive(:new).and_return(net_imap)
+      expect(net_imap).to receive(:login)
+
+      # count
+      expect(net_imap).to receive(:select).with("INBOX")
+      expect(net_imap).to receive(:status).with("INBOX", array_including('MESSAGES')).and_return('MESSAGES' => 0)
+
+      # disconnect
+      expect(net_imap).to receive(:close)
+      expect(net_imap).to receive(:disconnect)
+
+      mails = imap_connector.fetch_mails(:inbox)
+      expect(mails).to eq([])
+    end
+
+    it 'creates failed mailbox if not existing' do
+      # connect
+      expect(Net::IMAP).to receive(:new).and_return(net_imap)
+      expect(net_imap).to receive(:login)
+
+      # select mailbox
+      expect(net_imap).to receive(:select).with('Failed').and_raise(no_mailbox_error("Mailbox doesn't exist")).once
+
+      # create mailbox
+      expect(net_imap).to receive(:create).with('Failed')
+
+      # count mails and select mailbox again
+      expect(net_imap).to receive(:select).with('Failed')
+      expect(net_imap).to receive(:status).with('Failed', array_including('MESSAGES')).and_return('MESSAGES' => 0)
+
+      # disconnect
+      expect(net_imap).to receive(:close)
+      expect(net_imap).to receive(:disconnect)
+
+      imap_connector.fetch_mails(:failed)
+    end
+
+    it 'raises error if junk mailbox does not exist' do
+      # connect
+      expect(Net::IMAP).to receive(:new).and_return(net_imap)
+      expect(net_imap).to receive(:login)
+
+      # select
+      expect(net_imap).to receive(:select).with('Junk').and_raise(no_mailbox_error("Mailbox doesn't exist"))
+
+      # disconnect
+      expect(net_imap).to receive(:close)
+      expect(net_imap).to receive(:disconnect)
+
+      expect do
+        imap_connector.fetch_mails(:spam)
+      end.to raise_error(Net::IMAP::NoResponseError)
+    end
+  end
+
+  describe '#counts' do
+    it 'counts number of all mailboxes' do
+      # connect
+      expect(Net::IMAP).to receive(:new).once.and_return(net_imap)
+      expect(net_imap).to receive(:login).once
+
+      # select
+      expect(net_imap).to receive(:select).with('INBOX')
+      expect(net_imap).to receive(:select).with('Junk')
+      expect(net_imap).to receive(:select).with('Failed')
+
+      # count each mailbox
+      expect(net_imap).to receive(:status).with('INBOX', ['MESSAGES']).and_return('MESSAGES' => 1)
+      expect(net_imap).to receive(:status).with('Junk', ['MESSAGES']).and_return('MESSAGES' => 1)
+      expect(net_imap).to receive(:status).with('Failed', ['MESSAGES']).and_return('MESSAGES' => 1)
+
+      # disconnect
+      expect(net_imap).to receive(:close)
+      expect(net_imap).to receive(:disconnect)
+
+      counts = imap_connector.counts
+
+      expect(counts).to eq('failed' => 1, 'inbox' => 1, 'spam' => 1)
+      expect(imap_connector.counts['failed']).to eq(1)
+    end
+  end
+
+  private
+
+  def no_mailbox_error(text = '')
+    response_text = Net::IMAP::ResponseText.new(nil, text)
+    Net::IMAP::NoResponseError.new(Net::IMAP::TaggedResponse.new(nil, nil, response_text, nil))
+  end
+
+  def new_mail(id, text_body = true)
+    Net::IMAP::FetchData.new(id, mail_attrs(text_body))
+  end
+
+  def mail_attrs(text_body)
+    {
+      'UID' => text_body ? '42' : '43',
+      'RFC822' => text_body ? '' : new_html_message,
+      'ENVELOPE' => new_envelope,
+      'BODY[TEXT]' => text_body ? 'SpaceX rocks!' : 'Tesla rocks!',
+      'BODYSTRUCTURE' => text_body ? new_text_body : new_html_body_type
+    }
+  end
+
+  def new_envelope
+    Net::IMAP::Envelope.new(
+      now.to_s,
+      'Testflight from 24.4.2021',
+      [new_address('from')],
+      [new_address('sender')],
+      [new_address('reply_to')],
+      [new_address('to')]
+    )
+  end
+
+  def new_address(name)
+    Net::IMAP::Address.new(
+      name,
+      nil,
+      'john',
+      "#{name}.example.com"
+    )
+  end
+
+  def new_text_body
+    Net::IMAP::BodyTypeText.new('TEXT')
+  end
+
+  def new_html_body_type
+    Net::IMAP::BodyTypeMultipart.new('MULTIPART')
+  end
+
+  def new_html_message
+    Mail::Message.new("<h1>#{Faker::Lorem.sentences[0]}</h1>")
+  end
+
+end


### PR DESCRIPTION
# IMAP Client implementation
## Still Failing Tests
Unit Tests located in the MailingLists Folder within rspec's spec Root Directory are still failing. In cooperation with @psunix and @miosidler, we've already tried to fix this issue. Strangely, if the tests got executed one-by-one they have worked properly.

The reason why they are still failing, could be the caching of the :manage Ability within the various_ability.rb:27 file. Because every single test, throws an

```
CanCan::AccessDenied:
       You are not authorized to access this page.
```

Execption.

# ToDos

- [ ] Review Code
- [ ] Test Client in UI (there's a test mailinglist e-mail account, https://cryptopus.puzzle.ch/accounts/5359)
- [ ] Fix Mocking of Ability in specs