### PR TITLE
Repair address completion

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -6,32 +6,11 @@
 #  https://github.com/hitobito/hitobito.
 
 class AddressesController < ApplicationController
+  include FullTextSearchStrategy
 
   skip_authorization_check
 
   def query
     render json: Address::FullTextSearch.new(query_param, search_strategy).typeahead_results
-  end
-
-  def query_param
-    params[:q]
-  end
-
-  private
-
-  def search_strategy
-    @search_strategy ||= search_strategy_class.new(current_user, query_param, params[:page])
-  end
-
-  def search_strategy_class
-    if sphinx?
-      SearchStrategies::Sphinx
-    else
-      SearchStrategies::Sql
-    end
-  end
-
-  def sphinx?
-    Hitobito::Application.sphinx_present?
   end
 end

--- a/app/controllers/concerns/full_text_search_strategy.rb
+++ b/app/controllers/concerns/full_text_search_strategy.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+# currently used by
+# - AddressesController
+# - FullTextController
+module FullTextSearchStrategy
+  private
+
+  def query_param
+    params[:q]
+  end
+
+  def search_strategy
+    @search_strategy ||= search_strategy_class.new(current_user, query_param, params[:page])
+  end
+
+  def search_strategy_class
+    if sphinx?
+      SearchStrategies::Sphinx
+    else
+      SearchStrategies::Sql
+    end
+  end
+
+  def sphinx?
+    Hitobito::Application.sphinx_present?
+  end
+end

--- a/app/controllers/full_text_controller.rb
+++ b/app/controllers/full_text_controller.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3

--- a/app/controllers/full_text_controller.rb
+++ b/app/controllers/full_text_controller.rb
@@ -6,6 +6,7 @@
 #  https://github.com/hitobito/hitobito.
 
 class FullTextController < ApplicationController
+  include FullTextSearchStrategy
 
   skip_authorization_check
 
@@ -34,22 +35,6 @@ class FullTextController < ApplicationController
     sets.select(&:present?).inject do |memo, set|
       memo + [{ label: '—' * 20 }] + set
     end
-  end
-
-  def search_strategy
-    @search_strategy ||= search_strategy_class.new(current_user, params[:q], params[:page])
-  end
-
-  def search_strategy_class
-    if sphinx?
-      SearchStrategies::Sphinx
-    else
-      SearchStrategies::Sql
-    end
-  end
-
-  def sphinx?
-    Hitobito::Application.sphinx_present?
   end
 
   def entries

--- a/app/controllers/full_text_controller.rb
+++ b/app/controllers/full_text_controller.rb
@@ -42,7 +42,7 @@ class FullTextController < ApplicationController
   end
 
   def with_query
-    params[:q].to_s.size >= 2 ? yield : []
+    query_param.to_s.size >= 2 ? yield : []
   end
 
   def active_tab

--- a/app/domain/address/full_text_search.rb
+++ b/app/domain/address/full_text_search.rb
@@ -9,7 +9,7 @@ class Address::FullTextSearch
 
   attr_reader :query, :search_strategy
 
-  ADDRESS_WITH_NUMBER_REGEX = /^.*[^\d](\d+[A-Z]?$)/
+  ADDRESS_WITH_NUMBER_REGEX = /^.*[^\d](\d+[A-Z]?$)/.freeze
 
   def initialize(query, search_strategy)
     @query = query

--- a/app/domain/address/full_text_search.rb
+++ b/app/domain/address/full_text_search.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
-#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  Copyright (c) 2012-2021, CVP Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
-#  https://github.com/hitobito/hitobito_cvp.
+#  https://github.com/hitobito/hitobito.
 
 class Address::FullTextSearch
 
   attr_reader :query, :search_strategy
 
-  ADDRESS_WITH_NUMBER_REGEX = /^.*[^\d](\d+[A-Z]?$)/.freeze
+  ADDRESS_WITH_NUMBER_REGEX = /^.*[^\d](\d+[A-Za-z]?$)/.freeze
 
   def initialize(query, search_strategy)
     @query = query

--- a/app/domain/address/importer.rb
+++ b/app/domain/address/importer.rb
@@ -11,11 +11,12 @@ class Address::Importer
   # Imports Swiss addresses
   # see https://service.post.ch/zopa/dlc/app/#/main
 
-  RECORDS = %w(01-zip_codes
-               03-locations
-               04-streets
-               06-house_numbers
-              ).freeze
+  RECORDS = %w(
+    01-zip_codes
+    03-locations
+    04-streets
+    06-house_numbers
+  ).freeze
 
   delegate :url, :token, to: 'Settings.addresses'
 
@@ -86,7 +87,7 @@ class Address::Importer
     end
   end
 
-  def parse_streets
+  def parse_streets # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
     parse(:streets).collect do |row|
       zip_code = zip_codes.fetch(row[2])
       numbers = house_numbers.fetch(row[1], []).to_a.compact.sort.uniq
@@ -117,6 +118,7 @@ class Address::Importer
   def parse_house_numbers
     parse(:house_numbers).each_with_object({}) do |row, hash|
       next if row[3].blank?
+
       hash[row[2]] ||= []
       hash[row[2]] << [row[3].to_i, row[4].presence&.downcase].join
     end

--- a/app/domain/search_strategies/base.rb
+++ b/app/domain/search_strategies/base.rb
@@ -42,6 +42,11 @@ module SearchStrategies
       Event.none.page(1)
     end
 
+    def query_addresses
+      # override
+      Address.none.page(1)
+    end
+
     protected
 
     def fetch_people(_ids)

--- a/app/domain/search_strategies/base.rb
+++ b/app/domain/search_strategies/base.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2017, Hitobito AG. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3

--- a/app/domain/search_strategies/sphinx.rb
+++ b/app/domain/search_strategies/sphinx.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2017, Hitobito AG. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
@@ -39,7 +39,8 @@ module SearchStrategies
     def query_addresses
       return Address.none.page(1) if @term.blank?
 
-      Address.search(Riddle::Query.escape(@term), default_search_options.merge(match_mode: :phrase))
+      Address.search(Riddle::Query.escape(@term),
+                     default_search_options.merge(match_mode: :phrase))
     end
 
     protected

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
 #  hitobito_cvp and licensed under the Affero General Public License version 3
@@ -29,8 +29,7 @@ class Address < ActiveRecord::Base
 
   validates_by_schema
 
-  scope :list, -> { order(:street_short, "LENGTH(numbers) DESC") }
-
+  scope :list, -> { order(:street_short, 'LENGTH(numbers) DESC') }
 
   def self.for(zip_code, street)
     where(zip_code: zip_code).
@@ -38,7 +37,6 @@ class Address < ActiveRecord::Base
             'LOWER(street_long) = :street OR LOWER(street_long_old) = :street',
             street: street.to_s.downcase)
   end
-
 
   def to_s(_format = :default)
     "#{street_short} #{zip_code} #{town}"

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -125,7 +125,7 @@ de:
               must_be_unique: 'existiert bereits'
 
         invoice:
-          recipient_address_or_email_required: 'Empfänger Addresse oder E-Mail muss ausgefüllt werden'
+          recipient_address_or_email_required: 'Empfänger Adresse oder E-Mail muss ausgefüllt werden'
           attributes:
             invoice_config:
               invalid: 'ist nicht gültig; passen Sie die Einstellungen an, bevor sie eine Rechnung erstellen'

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -901,11 +901,11 @@ de:
             other: "%{model_class} wird für %{count} Personen erstellt."
         invalid:
           message/letter:
-            one: "Eine Person hat keine vollständige Addresse hinterlegt."
-            other: "%{count} weitere haben keine vollständige Addresse hinterlegt."
+            one: "Eine Person hat keine vollständige Adresse hinterlegt."
+            other: "%{count} weitere haben keine vollständige Adresse hinterlegt."
           message/letter_with_invoice:
-            one: "Eine Person hat keine vollständige Addresse hinterlegt."
-            other: "%{count} weitere haben keine vollständige Addresse hinterlegt."
+            one: "Eine Person hat keine vollständige Adresse hinterlegt."
+            other: "%{count} weitere haben keine vollständige Adresse hinterlegt."
           message/text_message:
             one: "Eine Person hat keine vollständige Mobiltelefonnummer hinterlegt."
             other: "%{count} weitere haben keine Mobiltelefonnummer hinterlegt."
@@ -1120,7 +1120,7 @@ de:
         category_validation:
           email_primary_invalid: Haupt-E-Mail ungültig
           email_additional_invalid: Weitere E-Mail ungültig
-          address_invalid: Addresse befindet sich nicht im Verzeichnis
+          address_invalid: Adresse befindet sich nicht im Verzeichnis
 
   person/csv_imports:
     invalid_file: Bitte wählen Sie eine gültige CSV Datei aus.
@@ -1237,7 +1237,7 @@ de:
       add_tag: Tag hinzufügen…
       no_entry: (keine)
     export_enqueued: 'Export wird im Hintergrund gestartet und nach Fertigstellung heruntergeladen.'
-    export_email_needed: 'Für den Export wird eine Email Adresse benötigt.'
+    export_email_needed: 'Für den Export wird eine E-Mail Adresse benötigt.'
 
     multiselect_actions:
       remove_role: Rollen entfernen

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,6 +6,6 @@ Folgende Dokumentationen sind hier zu finden:
 * [Betrieb](betrieb/README.md)
 * [Entwicklung](development/README.md)
 * [E-Mail](e-mail/README.md)
-
+* [Optionale Features](features/README.md)
 
 Um die Code Dokumentation zu generieren, kann `rake doc:app` ausgeführt werden.

--- a/doc/features/README.md
+++ b/doc/features/README.md
@@ -1,0 +1,5 @@
+# Optional Features
+
+Some features of hitobito are activated by settings and therefore optional.
+
+- [Swiss Address Completion and Validation](./address-completion.md)

--- a/doc/features/address-completion.md
+++ b/doc/features/address-completion.md
@@ -1,0 +1,37 @@
+# Addresses
+
+[TOC]
+
+## Overview
+
+It is possible to provide an auto-complete and a validation for addresses.
+The Addresses are read from the Address model.
+
+Currently, address entries are swiss addresses imported from the Swiss Post.
+
+## Import
+
+If you have configured an API token, the addresses are imported every 6 months.
+You can import manually with a rake-task:
+
+  bundle exec rake address:import
+
+The API-Token can be provided as environment variable `ADDRESSES_TOKEN`.
+
+## Configuration
+
+Configuration is generally done through `config/settings.yml`.
+The key `addresses` contains a hash that has the following keys:
+
+- url (hardcoded URL to the post.ch service providing the swiss addresses)
+- token (access-token which is read from `ENV['ADDRESSES_TOKEN']`)
+- imported_countries (a list of countries to be imported, currently only 'CH')
+
+## Completion
+
+In the person#edit view, the address is auto-completed from all entries in the
+addresses-table. If Sphinx is present, sphinx indexes that table and answers
+queries. Otherwise, the table is queried by the database.
+
+The search-strategy is determined the same way as for the
+people/group/event-full-text search.

--- a/doc/features/address-completion.md
+++ b/doc/features/address-completion.md
@@ -7,7 +7,7 @@
 It is possible to provide an auto-complete and a validation for addresses.
 The Addresses are read from the Address model.
 
-Currently, address entries are swiss addresses imported from the Swiss Post.
+Currently, address entries are swiss addresses imported from Swiss Post.
 
 ## Import
 
@@ -34,4 +34,4 @@ addresses-table. If Sphinx is present, sphinx indexes that table and answers
 queries. Otherwise, the table is queried by the database.
 
 The search-strategy is determined the same way as for the
-people/group/event-full-text search.
+people/group/event-full-text search. (See `app/controllers/concerns/full_text_search_strategy.rb`)

--- a/lib/tasks/address.rake
+++ b/lib/tasks/address.rake
@@ -7,7 +7,7 @@
 
 namespace :address do
   desc 'Import Post Addresses'
-  task :import => [:environment] do
+  task import: [:environment] do
     Address::Importer.new.run
   end
 end

--- a/spec/config/locales_spec.rb
+++ b/spec/config/locales_spec.rb
@@ -8,20 +8,33 @@
 require 'spec_helper'
 
 describe 'locales' do
-  it 'do not contain wrong spellings of E-Mail' do
-    expect(`grep 'Email' config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
-    expect(`grep 'e-mail' config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
-    expect(`grep 'e-Mail' config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
+  context 'do not contain wrong spellings of "E-Mail":' do
+    it 'Email' do
+      expect(`grep 'Email' config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
+    end
 
-    # the spelling "email" has a few false positives :-)
-    email_lines = `grep -e ':.*email' config/locales/*.de.yml`
-                  .split("\n").map(&:chomp)
-                  .reject { |line| line =~ /.*Scope: email.*/ }
-                  .reject { |line| line =~ /.*%{email}.*/ }
-    expect(email_lines).to be_empty
+    it 'e-mail' do
+      expect(`grep 'e-mail' config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
+    end
+
+    it 'e-Mail' do
+      expect(`grep 'e-Mail' config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
+    end
+
+    it 'email' do
+      # the spelling "email" has a few false positives :-)
+      email_lines = `grep -e ':.*email' config/locales/*.de.yml`
+                    .split("\n").map(&:chomp)
+                    .reject { |line| line =~ /.*Scope: email.*/ }
+                    .reject { |line| line =~ /.*%{email}.*/ }
+
+      expect(email_lines).to be_empty
+    end
   end
 
-  it 'do not contain wrong spellings of Adress' do
-    expect(`grep Address config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
+  it 'do not contain wrong spellings of "Adresss":' do
+    it 'Address' do
+      expect(`grep Address config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
+    end
   end
 end

--- a/spec/config/locales_spec.rb
+++ b/spec/config/locales_spec.rb
@@ -32,7 +32,7 @@ describe 'locales' do
     end
   end
 
-  it 'do not contain wrong spellings of "Adresss":' do
+  context 'do not contain wrong spellings of "Adresss":' do
     it 'Address' do
       expect(`grep Address config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
     end

--- a/spec/config/locales_spec.rb
+++ b/spec/config/locales_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Pfadibewegung Schweiz. This file is part of
+#  hitobito_pbs and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_pbs.
+
+require 'spec_helper'
+
+describe 'locales' do
+  it 'do not contain wrong spellings of E-Mail' do
+    expect(`grep 'Email' config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
+    expect(`grep 'e-mail' config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
+    expect(`grep 'e-Mail' config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
+
+    # the spelling "email" has a few false positives :-)
+    email_lines = `grep -e ':.*email' config/locales/*.de.yml`
+                  .split("\n").map(&:chomp)
+                  .reject { |line| line =~ /.*Scope: email.*/ }
+                  .reject { |line| line =~ /.*%{email}.*/ }
+    expect(email_lines).to be_empty
+  end
+
+  it 'do not contain wrong spellings of Adress' do
+    expect(`grep Address config/locales/*.de.yml | wc -l`.chomp.to_i).to be_zero
+  end
+end

--- a/spec/domain/address/full_text_search_spec.rb
+++ b/spec/domain/address/full_text_search_spec.rb
@@ -4,9 +4,10 @@ require 'spec_helper'
 
 describe Address::FullTextSearch do
 
-  let(:person)   { people(:bottom_member) }
+  let(:person) { people(:bottom_member) }
 
-    [SearchStrategies::Sphinx, SearchStrategies::Sql].each do |strategy|
+  [SearchStrategies::Sphinx, SearchStrategies::Sql].each do |strategy|
+    context "with #{strategy}" do
       before do
         allow_any_instance_of(strategy).to receive(:query_addresses)
           .and_return(Address.where(id: addresses(:bs_bern)))
@@ -55,4 +56,5 @@ describe Address::FullTextSearch do
         end
       end
     end
+  end
 end

--- a/spec/domain/address/full_text_search_spec.rb
+++ b/spec/domain/address/full_text_search_spec.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+#  Copyright (c) 2021, Die Mitte Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
 require 'spec_helper'
 
 describe Address::FullTextSearch do
@@ -54,6 +59,46 @@ describe Address::FullTextSearch do
         numbers.each do |number|
           expect(labels).to include(bs_bern.label_with_number(number))
         end
+      end
+
+      it 'finds typeahead results from street query with street number with a lowercase letter' do
+        bs_bern = addresses(:bs_bern)
+        query = 'lpstra 5a'
+
+        search = Address::FullTextSearch.new(query, strategy.new(person, query, ''))
+        results = search.typeahead_results
+
+        # we found one street/number combination
+        expect(results.size).to eq(1)
+
+        # we found the right street
+        expect(results.first[:id]).to eq(bs_bern.id)
+
+        # we detected the right number
+        expect(results.map { |r| r[:number] }).to include('5a')
+
+        # with the right label
+        expect(results.map { |r| r[:label] }).to include(bs_bern.label_with_number('5a'))
+      end
+
+      it 'finds typeahead results from street query with street number with a uppercase letter' do
+        bs_bern = addresses(:bs_bern)
+        query = 'lpstra 6B'
+
+        search = Address::FullTextSearch.new(query, strategy.new(person, query, ''))
+        results = search.typeahead_results
+
+        # we found one street/number combination
+        expect(results.size).to eq(1)
+
+        # we found the right street
+        expect(results.first[:id]).to eq(bs_bern.id)
+
+        # we detected the right number
+        expect(results.map { |r| r[:number] }).to include('6B')
+
+        # with the right label
+        expect(results.map { |r| r[:label] }).to include(bs_bern.label_with_number('6B'))
       end
     end
   end

--- a/spec/features/messages_spec.rb
+++ b/spec/features/messages_spec.rb
@@ -35,7 +35,7 @@ describe :messages, js: true do
       click_link('Brief erstellen')
 
       is_expected.to have_selector('a', text: 'Brief wird für 3 Personen erstellt.')
-      is_expected.to have_text('(Eine Person hat keine vollständige Addresse hinterlegt.)')
+      is_expected.to have_text('(Eine Person hat keine vollständige Adresse hinterlegt.)')
     end
   end
 

--- a/spec/fixtures/addresses.yml
+++ b/spec/fixtures/addresses.yml
@@ -32,7 +32,7 @@ bs_bern:
   town: Bern
   state: BE
   zip_code: 3007
-  numbers: ['36', '37', '38', '40', '41']
+  numbers: ['36', '37', '38', '40', '41', '5a', '5b', '6A', '6B']
 
 bs_muri:
   street_short: Belpstrasse

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,9 +1,9 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
-#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  Copyright (c) 2012-2021, CVP Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
-#  https://github.com/hitobito/hitobito_cvp.
+#  https://github.com/hitobito/hitobito.
 #
 # == Schema Information
 #
@@ -25,6 +25,6 @@ require 'spec_helper'
 describe Address do
   it 'serializes numbers as array' do
     bs_bern = addresses(:bs_bern)
-    expect(bs_bern.numbers).to eq %w(36 37 38 40 41)
+    expect(bs_bern.numbers).to eq %w(36 37 38 40 41 5a 5b 6A 6B)
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -37,7 +37,7 @@ describe Invoice do
     invoice = Invoice.create(title: 'invoice', group: group)
     expect(invoice).not_to be_valid
     expect(invoice.errors.full_messages).
-      to include('Empfänger Addresse oder E-Mail muss ausgefüllt werden')
+      to include('Empfänger Adresse oder E-Mail muss ausgefüllt werden')
   end
 
   it 'validates that an invoice in state issued or sent has at least has one invoice_item' do


### PR DESCRIPTION
While debugging the address completion, I refactored the codebase a little. Therefore, you are now looking at an extraction, some spelling changes, several linter-changes and some new methods. Alongside these cosmetic changes, I added

- support for house numbers as they are imported right now
- some documentation on this optional feature
- a spec that ensures consistent spellings in the German locale

Fixes #1213 