### PR TITLE
Das Ende der Hausnummerindizierung

### DIFF
--- a/app/domain/address/full_text_search.rb
+++ b/app/domain/address/full_text_search.rb
@@ -9,10 +9,12 @@ class Address::FullTextSearch
 
   attr_reader :query, :search_strategy
 
-  ADDRESS_WITH_NUMBER_REGEX = /^.*[^\d](\d+[A-Za-z]?$)/.freeze
+  ADDRESS_WITH_NUMBER_REGEX = /^(.*)[^\d](\d+[A-Za-z]?$)/.freeze
 
   def initialize(query, search_strategy)
     @query = query
+
+    search_strategy.term = street_name_from_query
     @search_strategy = search_strategy
   end
 
@@ -62,7 +64,15 @@ class Address::FullTextSearch
     query.match?(ADDRESS_WITH_NUMBER_REGEX)
   end
 
+  def street_name_from_query
+    if query_ends_with_number?
+      query.match(ADDRESS_WITH_NUMBER_REGEX)[1]
+    else
+      query
+    end
+  end
+
   def street_number_from_query
-    query.match(ADDRESS_WITH_NUMBER_REGEX)[1]
+    query.match(ADDRESS_WITH_NUMBER_REGEX)[2]
   end
 end

--- a/app/domain/search_strategies/base.rb
+++ b/app/domain/search_strategies/base.rb
@@ -10,6 +10,8 @@ module SearchStrategies
 
     QUERY_PER_PAGE = 10
 
+    attr_accessor :term
+
     def initialize(user, term, page)
       @user = user
       @term = term
@@ -45,6 +47,10 @@ module SearchStrategies
     def query_addresses
       # override
       Address.none.page(1)
+    end
+
+    def inspect
+      "<#{self.class.name}: term: #{@term.inspect}>"
     end
 
     protected

--- a/app/domain/search_strategies/sphinx.rb
+++ b/app/domain/search_strategies/sphinx.rb
@@ -39,8 +39,7 @@ module SearchStrategies
     def query_addresses
       return Address.none.page(1) if @term.blank?
 
-      Address.search(Riddle::Query.escape(@term),
-                     default_search_options.merge(match_mode: :phrase))
+      Address.search(Riddle::Query.escape(@term), default_search_options)
     end
 
     protected

--- a/app/indices/address_index.rb
+++ b/app/indices/address_index.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Die Mitte Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -8,5 +8,5 @@
 module AddressIndex; end
 
 ThinkingSphinx::Index.define_partial :address do
-  indexes street_short, town, zip_code, numbers, sortable: true
+  indexes street_short, town, zip_code, sortable: true
 end


### PR DESCRIPTION
Und also begab es sich, dass ein Kunde ausging vom Kaiser Sphinxistus, dass die Hausnummern sich zu zählen habe... Stellt sich jedoch heraus, dass Sphinx relativ schlecht darin war, einzelne Zahlen zu finden, selbst wenn es nur solche gab. Daher gab sein Gefolge ihm nur noch Strassennamen, mit denen Sphinxistus exzellent umgehen konnte. Die Hausnummern durchsuchte der edle Rubinius dann selbst. Mit der Vorauswahl, die der Kaiser getroffen hatte, war er so schnell, das hier keine Beschwerden auftraten. Es führte sogar dazu, dass die Bittsteller nun bessere Ergebnisse bekamen, was natürlich komplett Sphinxistus zugerechnet wurde. Da Rubinius so nett war (weil Matz so nett ist), sagte er dazu nichts weiter und lächelte nur.

Es drohte nur an einer Stelle offenkundig zu werden: Rubinius Railsus gab dem Kaiser gar keine Hausnummern mehr bekannt, also nichts mehr für seinen Katalog. Anstatt sich zu beschweren, war dieser jedoch über den kleineren Katalog froh, da dieser sich in der Hälfte der Zeit niederschreiben liess.

Alle waren fröhlich und zufrieden, bis die Gutachter kamen, um das Ende der Hausnummerindizierung zu beurteilen. Werden auch sie der Meinung sein, dass dieses Ende wirklich der Anfang des Findens ist?

Alle Augen wandten sich @carlobeltrame und @amaierhofer zu, welchen diese Aufgabe zuteilwurde.

Fixes #1213 rief der Herold von der Seite, was aber niemand verstand oder einordnen konnte.