### PR TITLE
Anrede in Haushaltsexport

### DIFF
--- a/app/domain/export/tabular/people/household_row.rb
+++ b/app/domain/export/tabular/people/household_row.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2020, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -18,6 +18,10 @@ module Export::Tabular::People
           without_blanks([combined_first_name, last_name]).join(' ')
         end.join(', ')
       end
+    end
+
+    def salutation
+      nil
     end
 
     private

--- a/app/domain/export/tabular/people/household_row.rb
+++ b/app/domain/export/tabular/people/household_row.rb
@@ -21,7 +21,10 @@ module Export::Tabular::People
     end
 
     def salutation
-      nil
+      return nil unless entry.respond_to? :salutation # not nil, just w/o salutation
+      return nil if entry.household_key.present?
+
+      Salutation.new(entry).value
     end
 
     private

--- a/app/domain/export/tabular/people/households.rb
+++ b/app/domain/export/tabular/people/households.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2018, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -16,7 +16,7 @@ module Export::Tabular::People
     end
 
     def person_attributes
-      [:name, :address, :zip_code, :town, :country, :layer_group]
+      [:salutation, :name, :address, :zip_code, :town, :country, :layer_group]
     end
 
     def build_attribute_labels

--- a/app/domain/salutation.rb
+++ b/app/domain/salutation.rb
@@ -33,7 +33,7 @@ class Salutation
 
   def initialize(person, salutation = nil)
     @person = person
-    @salutation = salutation || person.try(:salutation)
+    @salutation = (salutation || person.try(:salutation)).to_s
   end
 
   def label

--- a/app/domain/salutation.rb
+++ b/app/domain/salutation.rb
@@ -7,7 +7,7 @@
 
 class Salutation
 
-  I18N_KEY_PREFIX = 'activerecord.models.salutation'.freeze
+  I18N_KEY_PREFIX = 'activerecord.models.salutation'
 
   attr_reader :person
 
@@ -17,8 +17,9 @@ class Salutation
     end
 
     def for_letters
-      [[ :default,  I18n.t("#{I18N_KEY_PREFIX}.default.label") ]].tap do |values|
+      [[:default, I18n.t("#{I18N_KEY_PREFIX}.default.label")]].tap do |values|
         next unless Settings.messages.personal_salutation
+
         values.append([:personal, I18n.t("#{I18N_KEY_PREFIX}.personal.label")])
       end.reverse.to_h
     end
@@ -49,7 +50,7 @@ class Salutation
       first_name: person.first_name,
       last_name: person.last_name,
       greeting_name: person.greeting_name,
-      company_name: person.company_name,
+      company_name: person.company_name
     }.tap do |attrs|
       next unless person.attributes.key?('title')
 

--- a/app/models/invoice_config.rb
+++ b/app/models/invoice_config.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -34,9 +34,9 @@ class InvoiceConfig < ActiveRecord::Base
   include PaymentSlips
   include ValidatedEmail
 
-  IBAN_REGEX = /\A[A-Z]{2}[0-9]{2}\s?([A-Z]|[0-9]\s?){12,30}\z/
-  ACCOUNT_NUMBER_REGEX = /\A[0-9]{2}-[0-9]{2,20}-[0-9]\z/
-  PARTICIPANT_NUMBER_INTERNAL_REGEX = /\A[0-9]{6}/
+  IBAN_REGEX = /\A[A-Z]{2}[0-9]{2}\s?([A-Z]|[0-9]\s?){12,30}\z/.freeze
+  ACCOUNT_NUMBER_REGEX = /\A[0-9]{2}-[0-9]{2,20}-[0-9]\z/.freeze
+  PARTICIPANT_NUMBER_INTERNAL_REGEX = /\A[0-9]{6}/.freeze
 
   belongs_to :group, class_name: 'Group'
 
@@ -77,15 +77,19 @@ class InvoiceConfig < ActiveRecord::Base
 
   def correct_address_wordwrap
     return if payee.to_s.split(/\n/).length <= 2
+
     errors.add(:payee, :to_long)
   end
 
   def correct_check_digit
     return if account_number.blank? || bank?
+
     payment_slip = Invoice::PaymentSlip.new
     splitted = account_number.delete('-').split('')
     check_digit = splitted.pop
+
     return if payment_slip.check_digit(splitted.join) == check_digit.to_i
+
     errors.add(:account_number, :invalid_check_digit)
   end
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,4 +1,9 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
 
 # == Schema Information
 #
@@ -14,11 +19,6 @@
 #
 #  index_payments_on_invoice_id  (invoice_id)
 #
-
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
-#  hitobito and licensed under the Affero General Public License version 3
-#  or later. See the COPYING file at the top-level directory or at
-#  https://github.com/hitobito/hitobito.
 
 class Payment < ActiveRecord::Base
 

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -374,6 +374,7 @@ de:
         origin: Host mit API-Zugriff
 
       person:
+        salutation: Anrede
         first_name: Vorname
         last_name: Nachname
         name: Name

--- a/spec/domain/export/tabular/people/household_row_spec.rb
+++ b/spec/domain/export/tabular/people/household_row_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2020, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -8,59 +8,100 @@
 require 'spec_helper'
 
 describe Export::Tabular::People::HouseholdRow do
+  subject { described_class.new(person) }
 
-  def name(first_names = [], last_names = [])
-    person = Person.new(first_name: first_names.join(','),
-                        last_name: last_names.join(','))
-    described_class.new(person).name
+  context 'for companies' do
+    let(:person) do
+      Person.new(first_name: 'Tom', last_name: 'Tester', company: true, company_name: 'ACME Corp.')
+    end
+
+    it 'shows the company name for companies' do
+      expect(subject.name).to eq 'ACME Corp.'
+    end
   end
 
-  it 'shows the company name for companies' do
-    person = Person.new(first_name: 'Tom', last_name: 'Tester',
-                        company: true, company_name: 'ACME Corp.')
+  context 'for people without name' do
+    let(:person) { Person.new }
 
-    expect(described_class.new(person).name).to eq 'ACME Corp.'
+    it 'handles nil first and last name' do
+      expect(subject.name).to eq ''
+    end
   end
 
-  it 'handles nil first and last name' do
-    expect(described_class.new(Person.new).name).to eq ''
+  context 'for people with a name' do
+    let(:person) do
+      Person
+        .new(first_name: 'Poe', last_name: 'Dameron', gender: 'm')
+        .tap do |person|
+          allow(person).to receive(:salutation).and_return(:lieber_vorname)
+        end
+    end
+
+    it 'shows the name' do
+      expect(subject.name).to eq 'Poe Dameron'
+    end
+
+    it 'shows the salutation of this person' do
+      expect(subject.salutation).to eq 'Lieber Poe'
+    end
   end
 
-  it 'treats blank last name as first present lastname' do
-    expect(name(%w(Andreas Mara), ['Mäder', '']))
-      .to eq 'Andreas und Mara Mäder'
+  describe 'for households' do
+    def household(first_names = [], last_names = [])
+      person = Person.new(
+        first_name: first_names.join(','),
+        last_name: last_names.join(','),
+        household_key: SecureRandom.uuid
+      ).tap do |p|
+        allow(p).to receive(:salutation).and_return('lieber_vorname')
+      end
 
-    expect(name(%w(Andreas Mara Blunsch), ['Mäder', '', 'Wyss']))
-      .to eq 'Andreas und Mara Mäder, Blunsch Wyss'
+      described_class.new(person)
+    end
 
-    expect(name(%w(Andreas Mara Rahel Blunsch), ['Mäder', '', 'Emmenegger', '']))
-      .to eq 'Andreas, Mara und Blunsch Mäder, Rahel Emmenegger'
+    it 'treats blank last name as first present lastname' do
+      expect(household(%w(Andreas Mara), ['Mäder', '']).name)
+        .to eq 'Andreas und Mara Mäder'
 
-    expect(name(%w(Andreas Mara), ['', '']))
-      .to eq 'Andreas und Mara'
+      expect(household(%w(Andreas Mara Blunsch), ['Mäder', '', 'Wyss']).name)
+        .to eq 'Andreas und Mara Mäder, Blunsch Wyss'
+
+      expect(household(%w(Andreas Mara Rahel Blunsch), ['Mäder', '', 'Emmenegger', '']).name)
+        .to eq 'Andreas, Mara und Blunsch Mäder, Rahel Emmenegger'
+
+      expect(household(%w(Andreas Mara), ['', '']).name)
+        .to eq 'Andreas und Mara'
+    end
+
+    it 'does not output anything if first and last names are blank' do
+      expect(household([''], ['']).name).to be_blank
+      expect(household([nil, nil], [nil]).name).to be_blank
+    end
+
+    it 'combines two people with same last_name' do
+      expect(household(%w(Andreas Mara), %w(Mäder Mäder)).name).to eq 'Andreas und Mara Mäder'
+    end
+
+    it 'combines multiple people with same last_name' do
+      expect(household(%w(Andreas Mara Ruedi), %w(Mäder Mäder Mäder)).name)
+        .to eq 'Andreas, Mara und Ruedi Mäder'
+    end
+
+    it 'joins two different names by SEPARATOR' do
+      expect(household(%w(Andreas Rahel), %w(Mäder Steiner)).name)
+        .to eq 'Andreas Mäder, Rahel Steiner'
+    end
+
+    it 'reduces first names to initial if line is too long' do
+      expect(household(
+        %w(Andreas Rahel Rahel Blunsch),
+        %w(Mäder Steiner Emmenegger Wyss)
+      ).name)
+        .to eq 'A. Mäder, R. Steiner, R. Emmenegger, B. Wyss'
+    end
+
+    it 'shows no salution' do
+      expect(household(%w(Andreas Rahel), %w(Mäder Steiner)).salutation).to be_nil
+    end
   end
-
-  it 'does not output anything if first and last names are blank' do
-    expect(name([''], [''])).to be_blank
-    expect(name([nil, nil], [nil])).to be_blank
-  end
-
-  it 'combines two people with same last_name' do
-    expect(name(%w(Andreas Mara), %w(Mäder Mäder))).to eq 'Andreas und Mara Mäder'
-  end
-
-  it 'combines multiple people with same last_name' do
-    expect(name(%w(Andreas Mara Ruedi), %w(Mäder Mäder Mäder)))
-      .to eq 'Andreas, Mara und Ruedi Mäder'
-  end
-
-  it 'joins two different names by SEPARATOR' do
-    expect(name(%w(Andreas Rahel), %w(Mäder Steiner))).to eq 'Andreas Mäder, Rahel Steiner'
-  end
-
-  it 'reduces first names to initial if line is too long' do
-    aggregated = name(%w(Andreas Rahel Rahel Blunsch), %w(Mäder Steiner Emmenegger Wyss))
-    expect(aggregated).to eq 'A. Mäder, R. Steiner, R. Emmenegger, B. Wyss'
-  end
-
 end

--- a/spec/domain/export/tabular/people/households_spec.rb
+++ b/spec/domain/export/tabular/people/households_spec.rb
@@ -1,5 +1,6 @@
-# encoding: utf-8
-#  Copyright (c) 2012-2018, Pfadibewegung Schweiz. This file is part of
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -16,36 +17,38 @@ describe Export::Tabular::People::Households do
   end
 
   context 'header' do
-    it 'includes name, address attributes and layer group columns' do
-      expect(households.attributes).to eq [:name, :address, :zip_code, :town,
-                                           :country, :layer_group]
+    it 'includes salutation, name, address attributes and layer group columns' do
+      expect(households.attributes).to eq [
+        :salutation, :name, :address, :zip_code, :town, :country, :layer_group
+      ]
     end
 
-    it 'translates name, address attributes and layer group columns' do
-      expect(households.attribute_labels.values).to eq ['Name', 'Adresse', 'PLZ',
-                                                        'Ort', 'Land', 'Hauptebene']
+    it 'translates salutation, name, address attributes and layer group columns' do
+      expect(households.attribute_labels.values).to eq [ # comment fool rubocop
+        'Anrede', 'Name', 'Adresse', 'PLZ', 'Ort', 'Land', 'Hauptebene'
+      ]
     end
   end
 
   it 'accepts non household people' do
     data = households([leader]).data_rows.to_a
     expect(data).to have(1).item
-    expect(data[0]).to eq ['Top Leader', nil, nil, 'Supertown', nil, 'Top']
+    expect(data[0]).to eq [nil, 'Top Leader', nil, nil, 'Supertown', nil, 'Top']
   end
 
   it 'accepts single person array' do
     data = households([people(:top_leader)]).data_rows.to_a
     expect(data).to have(1).item
-    expect(data[0]).to eq ['Top Leader', nil, nil, 'Supertown', nil, 'Top']
+    expect(data[0]).to eq [nil, 'Top Leader', nil, nil, 'Supertown', nil, 'Top']
   end
 
-  it 'aggregates household people, uses first person''s address' do
+  it "aggregates household people, uses first person's address" do
     leader.update(household_key: 1)
     member.update(household_key: 1)
 
     data = households([member, leader]).data_rows.to_a
     expect(data).to have(1).item
-    expect(data[0].shift).to eq 'Bottom Member, Top Leader'
+    expect(data[0].shift(2)).to eq [nil, 'Bottom Member, Top Leader']
     expect(data[0]).to eq ['Greatstreet 345', '3456', 'Greattown', 'Schweiz', 'Bottom One']
   end
 


### PR DESCRIPTION
Fixes hitobito/hitobito_die_mitte#162

Aktuell failen noch die Spec rund um den ImapMail-Bereich. Nachdem diese gefixt sind, solte man den branch nochmal rebasen, um hier verlässliche Infos zu bekommen.