### PR TITLE
Repair ability-definition to fix Specs

### DIFF
--- a/app/abilities/assignment_ability.rb
+++ b/app/abilities/assignment_ability.rb
@@ -6,7 +6,6 @@
 #  https://github.com/hitobito/hitobito.
 
 class AssignmentAbility < AbilityDsl::Base
-
   on(Assignment) do
     class_side(:index).all
 

--- a/app/abilities/mailing_list_ability.rb
+++ b/app/abilities/mailing_list_ability.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -38,6 +38,14 @@ class MailingListAbility < AbilityDsl::Base
       in_same_layer
 
     general.group_not_deleted
+  end
+
+  on(Imap::Mail) do
+    permission(:admin).may(:manage).if_mail_config_present
+  end
+
+  def if_mail_config_present
+    Settings.email.retriever.config.present?
   end
 
   def in_same_group_if_no_subscriptions_in_below_groups

--- a/app/abilities/various_ability.rb
+++ b/app/abilities/various_ability.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -22,12 +22,6 @@ class VariousAbility < AbilityDsl::Base
     class_side(:manage_global).if_admin
     permission(:admin).may(:manage).all
     permission(:any).may(:create, :update, :destroy, :read).own
-  end
-
-  if Settings.email.retriever.config.present?
-    on(Imap::Mail) do
-      permission(:admin).may(:manage).all
-    end
   end
 
   if Group.course_types.present?

--- a/app/controllers/concerns/authenticatable.rb
+++ b/app/controllers/concerns/authenticatable.rb
@@ -15,7 +15,6 @@ module Authenticatable
     check_authorization if: :authorize?
   end
 
-
   private
 
   def current_person

--- a/spec/fixtures/assignments.yml
+++ b/spec/fixtures/assignments.yml
@@ -1,3 +1,8 @@
+#  Copyright (c) 2012-2021, CVP Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
 # == Schema Information
 #
 # Table name: assignments
@@ -18,11 +23,6 @@
 #  index_assignments_on_creator_id  (creator_id)
 #  index_assignments_on_person_id   (person_id)
 #
-
-#  Copyright (c) 2012-2021, CVP Schweiz. This file is part of
-#  hitobito_cvp and licensed under the Affero General Public License version 3
-#  or later. See the COPYING file at the top-level directory or at
-#  https://github.com/hitobito/hitobito.
 
 printing:
   title: Printing Assignment


### PR DESCRIPTION
An ability in a conditional might not be defined, with a qualifier it can always be loaded, yielding consistent results.

Otherwise, the presence of this permission is dependent on the order of
the specs which maybe set the configuration-setting to define the
permission.

I also moved the ability to the other mail-things as I expected it
there.

Fixes #1332 