### PR TITLE
Allow fetching past members in the API

### DIFF
--- a/app/controllers/oauth/profiles_controller.rb
+++ b/app/controllers/oauth/profiles_controller.rb
@@ -44,7 +44,9 @@ module Oauth
         {
           group_id: role.group_id,
           group_name: role.group.name,
+          group_type: role.group.type,
           role_name: role.class.model_name.human,
+          role_type: role.class.model_name,
           permissions: role.class.permissions
         }
       end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -253,7 +253,8 @@ class PeopleController < CrudController
   def person_filter
     @person_filter ||= Person::Filter::List.new(@group,
                                                 current_user || service_token_user,
-                                                list_filter_args)
+                                                list_filter_args,
+                                                can?(:show_past_members, @group))
   end
 
   def send_login_job(entry, current_user)

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -86,7 +86,7 @@ class PersonDecorator < ApplicationDecorator
   end
 
   def filtered_roles(group = nil)
-    filtered_functions(roles.to_a, :group, group)
+    filtered_functions(roles_with_deleted.to_a, :group, group)
   end
 
   # returns roles grouped by their group
@@ -158,7 +158,7 @@ class PersonDecorator < ApplicationDecorator
       functions.select { |r| r.send("#{scope_method}_id") == scope.id }
     else
       functions
-    end
+    end.select { |role| !role.deleted? || can?(:show_past_members, role.group) }
   end
 
   def functions_short(functions, scope: nil, edit: true)

--- a/app/domain/person/filter/list.rb
+++ b/app/domain/person/filter/list.rb
@@ -9,13 +9,14 @@ class Person::Filter::List
 
   attr_reader :group, :user, :chain, :range, :name, :multiple_groups
 
-  def initialize(group, user, params = {})
+  def initialize(group, user, params = {}, show_deleted = false)
     @group = group
     @user = user
     @chain = Person::Filter::Chain.new(params[:filters])
     @range = params[:range]
     @name = params[:name]
     @ids = params[:ids].to_s.split(',')
+    @show_deleted = show_deleted
   end
 
   def entries
@@ -45,7 +46,8 @@ class Person::Filter::List
   end
 
   def accessibles
-    ability = accessibles_class.new(user, group_range? ? @group : nil, chain.roles_join)
+    ability = accessibles_class.new(user, group_range? ? @group : nil, chain.roles_join,
+                                    @show_deleted)
     Person.accessible_by(ability)
   end
 

--- a/app/domain/person/filter/role.rb
+++ b/app/domain/person/filter/role.rb
@@ -36,6 +36,7 @@ class Person::Filter::Role < Person::Filter::Base
     case args[:kind]
     when 'active' then active_roles_join
     when 'deleted' then deleted_roles_join
+    when 'with_deleted' then with_deleted_roles_join
     end
   end
 
@@ -100,6 +101,14 @@ class Person::Filter::Role < Person::Filter::Base
     <<~SQL.split.map(&:strip).join(' ')
       INNER JOIN roles ON
         (roles.person_id = people.id AND roles.deleted_at IS NOT NULL)
+      INNER JOIN #{Group.quoted_table_name} ON roles.group_id = #{Group.quoted_table_name}.id
+    SQL
+  end
+
+  def with_deleted_roles_join
+    <<~SQL.split.map(&:strip).join(' ')
+      INNER JOIN roles ON
+        (roles.person_id = people.id)
       INNER JOIN #{Group.quoted_table_name} ON roles.group_id = #{Group.quoted_table_name}.id
     SQL
   end

--- a/app/helpers/oauth_applications_helper.rb
+++ b/app/helpers/oauth_applications_helper.rb
@@ -22,7 +22,7 @@ module OauthApplicationsHelper
   end
 
   def format_doorkeeper_application_scope(key)
-    Oauth::Application.human_scope(key) << " " << muted("(#{key})")
+    Oauth::Application.human_scope(key) + " " + muted("(#{key})")
   end
 
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -81,7 +81,9 @@ class Group < ActiveRecord::Base
   belongs_to :contact, class_name: 'Person'
 
   has_many :roles, dependent: :destroy, inverse_of: :group
+  has_many :roles_with_deleted, -> { with_deleted }, class_name: 'Role', dependent: :destroy
   has_many :people, through: :roles
+  has_many :people_with_deleted, through: :roles_with_deleted, source: :person
 
   has_many :people_filters, dependent: :destroy
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -122,6 +122,7 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   ### ASSOCIATIONS
 
   has_many :roles, inverse_of: :person
+  has_many :roles_with_deleted, -> { with_deleted }, class_name: 'Role', dependent: :destroy
   has_many :groups, through: :roles
 
   has_many :event_participations, class_name: 'Event::Participation',

--- a/app/serializers/group_serializer.rb
+++ b/app/serializers/group_serializer.rb
@@ -53,6 +53,7 @@ class GroupSerializer < ApplicationSerializer
 
     property :href, h.group_url(item, format: :json)
     property :group_type, item.klass.label
+    property :group_type_class, item.klass.name
 
     map_properties :layer, :name, :short_name, :email
 

--- a/app/views/people/_list.html.haml
+++ b/app/views/people/_list.html.haml
@@ -32,9 +32,11 @@
       .profil= image_tag(p.picture.thumb.url, size: '32x32')
     - sortable_grouped_person_attr(t, last_name: true, first_name: true, nickname: true) do |p|
       %strong
-        -# Any person listed can be shown
-        = link_to(p.to_s(:list),
-                  @person_filter.multiple_groups ? group_person_path(p.default_group_id, p) : group_person_path(@group, p))
+        - if p.roles.any?
+          = link_to(p.to_s(:list),
+                    @person_filter.multiple_groups ? group_person_path(p.default_group_id, p) : group_person_path(@group, p))
+        - else
+          = p.to_s(:list)
         %br/
         = muted p.additional_name
     - t.col(t.sort_header(:roles, Role.model_name.human(count: 2))) do |p|

--- a/spec/requests/oauth_profile_spec.rb
+++ b/spec/requests/oauth_profile_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe 'GET oauth/profile', type: :request do
 
   context 'with email scope in token' do
     let(:token)  { Fabricate(:access_token, application: application, scopes: { scopes: 'email' }, resource_owner_id: user.id ) }
-    
+
     context 'with bad token signature' do
       it 'fails with HTTP 401 (unauthorized)' do
         get '/oauth/profile', headers: { 'Authorization': 'Bearer ' + token.token + 'X'}
-  
+
         expect(response).to have_http_status(:unauthorized)
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe 'GET oauth/profile', type: :request do
     context 'with wrong scope in request' do
       it 'fails with HTTP 403 (forbidden)' do
         get '/oauth/profile', headers: { 'Authorization': 'Bearer ' + token.token, 'X-Scope': 'name' }
-        
+
         expect(response).to have_http_status(:forbidden)
         expect(response.content_type).to eq('application/json; charset=utf-8')
         expect(response.body).to eq('{"error":"invalid scope: name"}')
@@ -76,7 +76,7 @@ RSpec.describe 'GET oauth/profile', type: :request do
     it 'fails with 401 (unauthorized)' do
       get '/oauth/profile', headers: { 'Authorization': 'Bearer ' + token.token }
 
-      expect(response).to have_http_status(:unauthorized)  
+      expect(response).to have_http_status(:unauthorized)
     end
   end
 
@@ -105,7 +105,8 @@ RSpec.describe 'GET oauth/profile', type: :request do
 
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to eq('application/json; charset=utf-8')
-        expect(response.body).to include('"group_name":"Bottom One","role_name":"Member"')
+        expect(response.body).to include('"group_name":"Bottom One"')
+        expect(response.body).to include('"role_name":"Member"')
       end
     end
   end


### PR DESCRIPTION
This is an WIP effort to deprecate the group_health endpoints in the PBS wagon in favor of an alternative architecture based on OAuth API access.
Wagons can add an ability that grants the permission `:show_past_members` on a group in order to allow fetching people with deleted roles through the API and web application.
This PR also adds a convenience filter `with_deleted` in addition to the existing `deleted` role filter, for easier use of the API by third-party applications that need to read the deleted people.
Also exposes the group type and role type of all roles in the OAuth profile endpoint, since the PBS healthcheck application needs access to those as well. In fact, any application that includes some permission logic based on the hitobito roles exposed in OAuth can benefit from this addition.

See https://github.com/digio-ch/pbs-healthcheck-core/pull/22 for more context. Prerequisite for https://github.com/digio-ch/pbs-healthcheck-core/pull/28