### PR TITLE
Fix invalid mail tagger

### DIFF
--- a/app/domain/contactable/invalid_email_tagger.rb
+++ b/app/domain/contactable/invalid_email_tagger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  Copyright (c) 2012-2021, CVP Schweiz. This file is part of
 #  hitobito_cvp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_cvp.
@@ -18,10 +18,8 @@ module Contactable
     def tag!
       tag = send(:"invalid_tag_#{email_kind}")
       ActsAsTaggableOn::Tagging
-        .find_or_create_by!(taggable: person,
-                            hitobito_tooltip: email,
-                            context: :tags,
-                            tag: tag)
+        .find_or_create_by!(taggable: person, context: :tags, tag: tag)
+        .tap { |tagging| tagging.update!(hitobito_tooltip: email) }
     end
 
     def invalid_tag_primary

--- a/app/domain/contactable/invalid_email_tagger.rb
+++ b/app/domain/contactable/invalid_email_tagger.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 #  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
 #  hitobito_cvp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
@@ -16,7 +16,7 @@ module Contactable
     end
 
     def tag!
-      tag = send("invalid_tag_#{email_kind}")
+      tag = send(:"invalid_tag_#{email_kind}")
       ActsAsTaggableOn::Tagging
         .find_or_create_by!(taggable: person,
                             hitobito_tooltip: email,

--- a/app/domain/person_tags/validation.rb
+++ b/app/domain/person_tags/validation.rb
@@ -3,10 +3,10 @@
 module PersonTags
   class Validation
 
-    EMAIL_PRIMARY_INVALID='category_validation:email_primary_invalid'.freeze
-    EMAIL_ADDITIONAL_INVALID='category_validation:email_additional_invalid'.freeze
-    ADDRESS_INVALID='category_validation:address_invalid'.freeze
-    INVALID_ADDRESS_OVERRIDE='category_validation:invalid_address_override'.freeze
+    EMAIL_PRIMARY_INVALID = 'category_validation:email_primary_invalid'
+    EMAIL_ADDITIONAL_INVALID = 'category_validation:email_additional_invalid'
+    ADDRESS_INVALID = 'category_validation:address_invalid'
+    INVALID_ADDRESS_OVERRIDE = 'category_validation:invalid_address_override'
 
     class << self
 
@@ -15,10 +15,12 @@ module PersonTags
       end
 
       def list
-        [email_primary_invalid,
-         email_additional_invalid,
-         address_invalid,
-         invalid_address_override].compact
+        [
+          email_primary_invalid,
+          email_additional_invalid,
+          address_invalid,
+          invalid_address_override
+        ].compact
       end
 
       def email_primary_invalid(create: false)

--- a/db/migrate/20200924084559_add_hitobito_detail_to_taggings.rb
+++ b/db/migrate/20200924084559_add_hitobito_detail_to_taggings.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class AddHitobitoDetailToTaggings < ActiveRecord::Migration[6.0]
-
   def change
     add_column :taggings, :hitobito_tooltip, :string
   end

--- a/spec/domain/contactable/invalid_email_tagger_spec.rb
+++ b/spec/domain/contactable/invalid_email_tagger_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  Copyright (c) 2012-2021, CVP Schweiz. This file is part of
 #  hitobito_cvp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_cvp.
@@ -30,5 +30,20 @@ describe Contactable::InvalidEmailTagger do
       described_class.new(person, person.email, :additional).tag!
     end
     expect(person).to have(2).tags
+  end
+
+  it 'does not fail when a similar tag is already present' do
+    ActsAsTaggableOn::Tagging.find_or_create_by!(
+      taggable: person,
+      context: :tags,
+      tag: PersonTags::Validation.email_primary_invalid(create: true)
+    )
+
+    expect(person).to have(1).tag
+    expect(person.tags.first.name).to eq 'category_validation:email_primary_invalid'
+
+    expect do
+      described_class.new(person, person.email, :primary).tag!
+    end.to_not(change { person.tags.count })
   end
 end

--- a/spec/domain/contactable/invalid_email_tagger_spec.rb
+++ b/spec/domain/contactable/invalid_email_tagger_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 #  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
 #  hitobito_cvp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
@@ -11,14 +11,14 @@ describe Contactable::InvalidEmailTagger do
   let(:person) { people(:top_leader) }
 
   it 'tags primary as invalid' do
-    Contactable::InvalidEmailTagger.new(person, person.email, :primary).tag!
+    described_class.new(person, person.email, :primary).tag!
     expect(person).to have(1).tag
     expect(person.tags.first.name).to eq 'category_validation:email_primary_invalid'
     expect(person.taggings.first.hitobito_tooltip).to eq person.email
   end
 
   it 'tags additional email as invalid' do
-    Contactable::InvalidEmailTagger.new(person, person.email, :additional).tag!
+    described_class.new(person, person.email, :additional).tag!
     expect(person).to have(1).tag
     expect(person.tags.first.name).to eq 'category_validation:email_additional_invalid'
     expect(person.taggings.first.hitobito_tooltip).to eq person.email
@@ -26,8 +26,8 @@ describe Contactable::InvalidEmailTagger do
 
   it 'does not re-tag already tagged person again' do
     2.times do
-      Contactable::InvalidEmailTagger.new(person, person.email, :primary).tag!
-      Contactable::InvalidEmailTagger.new(person, person.email, :additional).tag!
+      described_class.new(person, person.email, :primary).tag!
+      described_class.new(person, person.email, :additional).tag!
     end
     expect(person).to have(2).tags
   end


### PR DESCRIPTION
Der vorgeschlagene Fix aus #1321 wurde umgesetzt, zusammen mit einer Spec, um künftige "Optimierungen" zu verhindern :smile: 

Fixes #1321