### PR TITLE
Gruppen archivieren

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -147,3 +147,7 @@ Style/SingleLineBlockParams:
 # separated arguments allow for ruby to determine the right separator, making it more portable
 Rails/FilePath:
   EnforcedStyle: arguments
+
+Rails/SkipsModelValidations:
+  Exclude:
+    - spec/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hitobito Changelog
 
+## unreleased
+
+*  Gruppen können archiviert werden (#1275)
+
 ## Version 1.26
 
 *  Die API unterstützt jetzt, die Gruppen/Rollen, Anlässe und Einzelpersonen auszulesen, welche bei Abos abonniert sind. (#1398, danke @Michael-Schaer!)

--- a/app/abilities/ability_dsl/constraints/event.rb
+++ b/app/abilities/ability_dsl/constraints/event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2020, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -26,21 +26,37 @@ module AbilityDsl::Constraints
       permission_in_groups?(event.group_ids)
     end
 
+    def in_same_group_if_active
+      in_same_group && at_least_one_group_not_deleted
+    end
+
     def in_same_group_or_below
       permission_in_groups?(event.groups.collect(&:local_hierarchy).flatten.collect(&:id).uniq)
+    end
+
+    def in_same_group_or_below_if_active
+      in_same_group_or_below && at_least_one_group_not_deleted
     end
 
     def in_same_layer
       permission_in_layers?(event.groups.collect(&:layer_group_id))
     end
 
+    def in_same_layer_if_active
+      in_same_layer && at_least_one_group_not_deleted
+    end
+
     def in_same_layer_or_below
       permission_in_layers?(event.groups.collect(&:layer_hierarchy).flatten.collect(&:id).uniq)
     end
 
+    def in_same_layer_or_below_if_active
+      in_same_layer_or_below && at_least_one_group_not_deleted
+    end
+
     def at_least_one_group_not_deleted
       event.groups.present? &&
-      event.groups.any? { |group| !group.deleted? }
+        event.groups.any? { |group| !group.deleted? && !group.archived? }
     end
 
     private

--- a/app/abilities/ability_dsl/constraints/group.rb
+++ b/app/abilities/ability_dsl/constraints/group.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -31,8 +31,40 @@ module AbilityDsl::Constraints
       !group.deleted?
     end
 
+    def group_not_deleted_or_archived
+      group_not_deleted && in_active_group
+    end
+
     def if_layer_group
       group.layer?
+    end
+
+    def if_layer_group_if_active
+      if_layer_group && in_active_group
+    end
+
+    def in_active_group
+      !group.archived?
+    end
+
+    def in_archived_group
+      group.archived?
+    end
+
+    def in_same_group_if_active
+      in_same_group && in_active_group
+    end
+
+    def in_same_layer_if_active
+      in_same_layer && in_active_group
+    end
+
+    def in_same_group_or_below_if_active
+      in_same_group_or_below && in_active_group
+    end
+
+    def in_same_layer_or_below_if_active
+      in_same_layer_or_below && in_active_group
     end
 
     private

--- a/app/abilities/event/role_ability.rb
+++ b/app/abilities/event/role_ability.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -13,10 +13,10 @@ class Event::RoleAbility < AbilityDsl::Base
     permission(:any).may(:show, :create, :update).for_participations_full_events
     permission(:any).may(:destroy).for_participations_full_events_except_self
 
-    permission(:group_full).may(:manage).in_same_group
-    permission(:group_and_below_full).may(:manage).in_same_group_or_below
-    permission(:layer_full).may(:manage).in_same_layer
-    permission(:layer_and_below_full).may(:manage).in_same_layer_or_below
+    permission(:group_full).may(:manage).in_same_group_if_active
+    permission(:group_and_below_full).may(:manage).in_same_group_or_below_if_active
+    permission(:layer_full).may(:manage).in_same_layer_if_active
+    permission(:layer_and_below_full).may(:manage).in_same_layer_or_below_if_active
   end
 
   def for_participations_full_events_except_self

--- a/app/abilities/event_ability.rb
+++ b/app/abilities/event_ability.rb
@@ -14,33 +14,34 @@ class EventAbility < AbilityDsl::Base
 
     permission(:any).may(:show).if_globally_visible_or_participating
 
-    permission(:any).may(:index_participations).
-      for_participations_read_events_and_course_participants
+    permission(:any).may(:index_participations)
+                    .for_participations_read_events_and_course_participants
     permission(:any).may(:update).for_leaded_events
     permission(:any).may(:qualify, :qualifications_read).for_qualify_event
 
-    permission(:group_full)
-      .may(:index_participations, :index_invitations, :create, :update, :destroy, :show)
-      .in_same_group
+    permission(:group_full).may(:index_participations, :index_invitations, :show).in_same_group
+    permission(:group_full).may(:create, :update, :destroy).in_same_group_if_active
 
-    permission(:group_and_below_full).
-      may(:index_participations, :index_invitations, :create, :update, :destroy, :show).
-      in_same_group_or_below
+    permission(:group_and_below_full).may(:index_participations, :index_invitations, :show)
+                                     .in_same_group_or_below
+    permission(:group_and_below_full).may(:create, :update, :destroy)
+                                     .in_same_group_or_below_if_active
 
-    permission(:layer_full).
-      may(:index_participations, :index_invitations, :update,
-          :create, :destroy, :application_market,
-          :qualify, :qualifications_read, :show).
-      in_same_layer
+    permission(:layer_full).may(:index_participations, :index_invitations,
+                                :qualifications_read, :show)
+                           .in_same_layer
+    permission(:layer_full).may(:update, :create, :destroy, :application_market, :qualify)
+                           .in_same_layer_if_active
 
-    permission(:layer_and_below_full).
-      may(:index_participations, :index_invitations, :update, :show)
-      .in_same_layer_or_below
-    permission(:layer_and_below_full).
-      may(:create, :destroy, :application_market, :qualify, :qualifications_read).in_same_layer
+    permission(:layer_and_below_full).may(:index_participations, :index_invitations, :show)
+                                     .in_same_layer_or_below
+    permission(:layer_and_below_full).may(:update).in_same_layer_or_below_if_active
+    permission(:layer_and_below_full).may(:qualifications_read).in_same_layer
+    permission(:layer_and_below_full).may(:create, :destroy, :application_market, :qualify)
+                                     .in_same_layer_if_active
 
-    general(:create, :destroy, :application_market, :qualify, :qualifications_read).
-      at_least_one_group_not_deleted
+    general(:create, :destroy, :application_market, :qualify, :qualifications_read)
+      .at_least_one_group_not_deleted
   end
 
   on(Event::Course) do

--- a/app/abilities/group_ability.rb
+++ b/app/abilities/group_ability.rb
@@ -23,17 +23,17 @@ class GroupAbility < AbilityDsl::Base
       may(:show_details, :index_people, :index_local_people).
       in_same_group_or_below
 
-    permission(:group_full).
-      may(:index_full_people, :update, :reactivate, :export_events, :'export_event/courses').
-      in_same_group
+    permission(:group_full)
+      .may(:index_full_people, :export_events, :'export_event/courses', :reactivate)
+      .in_same_group
+    permission(:group_full).may(:update).in_same_group_if_active
 
-    permission(:group_and_below_full).
-      may(:index_full_people, :update, :reactivate, :export_events, :'export_event/courses').
-      in_same_group_or_below
+    permission(:group_and_below_full)
+      .may(:index_full_people, :reactivate, :export_events, :'export_event/courses')
+      .in_same_group_or_below
+    permission(:group_and_below_full).may(:update).in_same_group_or_below_if_active
     permission(:group_and_below_full).may(:create).with_parent_in_same_group_hierarchy
-    permission(:group_and_below_full).
-      may(:destroy).
-      in_below_group
+    permission(:group_and_below_full).may(:destroy).in_below_group
 
     permission(:layer_read).
       may(:show_details, :index_people, :index_local_people, :index_full_people,
@@ -43,11 +43,13 @@ class GroupAbility < AbilityDsl::Base
     permission(:layer_full).may(:create).with_parent_in_same_layer
     permission(:layer_full).may(:destroy).in_same_layer_except_permission_giving
     permission(:layer_full).may(:index_service_tokens).service_token_in_same_layer
-    permission(:layer_full).
-      may(:update, :reactivate, :index_person_add_requests, :index_notes,
-          :manage_person_tags, :activate_person_add_requests, :deactivate_person_add_requests,
-          :index_deleted_people).
-      in_same_layer
+    permission(:layer_full)
+      .may(:index_person_add_requests, :index_notes, :index_deleted_people)
+      .in_same_layer
+    permission(:layer_full)
+      .may(:update, :reactivate,
+           :manage_person_tags, :activate_person_add_requests, :deactivate_person_add_requests)
+      .in_same_layer_if_active
 
     permission(:layer_and_below_read).
       may(:show_details, :index_people, :index_full_people, :index_deep_full_people,
@@ -60,16 +62,16 @@ class GroupAbility < AbilityDsl::Base
     permission(:layer_and_below_full).
       may(:update, :reactivate, :index_person_add_requests, :index_notes,
           :manage_person_tags, :index_deleted_people).in_same_layer_or_below
-    permission(:layer_and_below_full).may(:modify_superior).in_below_layers
+    permission(:layer_and_below_full).may(:modify_superior).in_below_layers_if_active
     permission(:layer_and_below_full).may(:index_service_tokens).service_token_in_same_layer
     permission(:layer_and_below_full).
       may(:activate_person_add_requests, :deactivate_person_add_requests).
-      in_same_layer
+      in_same_layer_if_active
 
     permission(:finance).may(:index_invoices).in_layer_group
-    permission(:finance).may(:create_invoices_from_list).in_same_layer_or_below
+    permission(:finance).may(:create_invoices_from_list).in_same_layer_or_below_if_active
 
-    permission(:admin).may(:manage_person_duplicates).if_layer_group
+    permission(:admin).may(:manage_person_duplicates).if_layer_group_if_active
     permission(:layer_and_below_full).may(:manage_person_duplicates).if_permission_in_layer
 
     general(:update).group_not_deleted
@@ -127,6 +129,10 @@ class GroupAbility < AbilityDsl::Base
 
   def in_below_layers
     permission_in_layers?(group.upper_layer_hierarchy.collect(&:id))
+  end
+
+  def in_below_layers_if_active
+    in_below_layers && in_active_group
   end
 
   # Member is a general role kind. Return true if user has any member role anywhere.

--- a/app/abilities/invoice_ability.rb
+++ b/app/abilities/invoice_ability.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -8,19 +8,23 @@
 class InvoiceAbility < AbilityDsl::Base
 
   on(Invoice) do
-    permission(:finance).may(:create, :show, :edit, :update, :destroy).in_layer
+    permission(:finance).may(:show).in_layer
+    permission(:finance).may(:create, :edit, :update, :destroy).in_layer_if_active
   end
 
   on(InvoiceList) do
-    permission(:finance).may(:create, :index_invoices).in_layer_with_receiver
+    permission(:finance).may(:create).in_layer_with_receiver
+    permission(:finance).may(:index_invoices).in_layer_with_receiver_if_active
   end
 
   on(InvoiceArticle) do
-    permission(:finance).may(:new, :create, :show, :edit, :update, :destroy).in_layer
+    permission(:finance).may(:show).in_layer
+    permission(:finance).may(:new, :create, :edit, :update, :destroy).in_layer_if_active
   end
 
   on(InvoiceConfig) do
-    permission(:finance).may(:show, :edit, :update).in_layer
+    permission(:finance).may(:show).in_layer
+    permission(:finance).may(:edit, :update).in_layer_if_active
   end
 
   on(Payment) do
@@ -28,7 +32,7 @@ class InvoiceAbility < AbilityDsl::Base
   end
 
   on(PaymentReminder) do
-    permission(:finance).may(:create).in_layer
+    permission(:finance).may(:create).in_layer_if_active
   end
 
   def any_finance_group
@@ -41,7 +45,16 @@ class InvoiceAbility < AbilityDsl::Base
 
   def in_layer_with_receiver
     return in_layer unless subject.receiver
+
     in_layer && in_layer(subject.receiver.group.layer_group)
+  end
+
+  def in_layer_if_active
+    in_layer && !subject.group&.archived?
+  end
+
+  def in_layer_with_receiver_if_active
+    in_layer_with_receiver && !subject.receiver.group.archived?
   end
 
 end

--- a/app/abilities/mailing_list_ability.rb
+++ b/app/abilities/mailing_list_ability.rb
@@ -12,30 +12,28 @@ class MailingListAbility < AbilityDsl::Base
   on(::MailingList) do
     permission(:any).may(:show).subscribable
 
-    permission(:group_full).
-      may(:show, :index_subscriptions, :create, :update, :destroy).
-      in_same_group
+    permission(:group_full).may(:show, :index_subscriptions).in_same_group
+    permission(:group_full).may(:create, :update, :destroy).in_same_group_if_active
     permission(:group_full).
       may(:export_subscriptions).
       in_same_group_if_no_subscriptions_in_below_groups
 
-    permission(:group_and_below_full).
-      may(:show, :index_subscriptions, :create, :update, :destroy).
-      in_same_group_or_below
+    permission(:group_and_below_full).may(:show, :index_subscriptions).in_same_group_or_below
+    permission(:group_and_below_full).may(:create, :update, :destroy)
+                                     .in_same_group_or_below_if_active
     permission(:group_and_below_full).
       may(:export_subscriptions).
       in_same_group_or_below_if_no_subscriptions_in_below_layers
 
-    permission(:layer_full).
-      may(:show, :index_subscriptions, :create, :update, :destroy).
-      in_same_layer
+    permission(:layer_full).may(:show, :index_subscriptions).in_same_layer
+    permission(:layer_full).may(:create, :update, :destroy).in_same_layer_if_active
     permission(:layer_full).
       may(:export_subscriptions).
       in_same_layer_if_no_subscriptions_in_below_layers
 
-    permission(:layer_and_below_full).
-      may(:show, :index_subscriptions, :export_subscriptions, :create, :update, :destroy).
-      in_same_layer
+    permission(:layer_and_below_full).may(:show, :index_subscriptions, :export_subscriptions)
+                                     .in_same_layer
+    permission(:layer_and_below_full).may(:create, :update, :destroy).in_same_layer_if_active
 
     general.group_not_deleted
   end

--- a/app/abilities/message_ability.rb
+++ b/app/abilities/message_ability.rb
@@ -9,11 +9,17 @@ class MessageAbility < AbilityDsl::Base
 
   on(Message) do
     permission(:layer_and_below_full)
-      .may(:create, :show)
+      .may(:create)
+      .in_layer_or_below_if_active
+
+    permission(:layer_and_below_full)
+      .may(:show)
       .in_layer_or_below
+
     permission(:layer_and_below_full)
       .may(:edit, :update, :destroy)
       .in_layer_or_below_if_not_dispatched
+
     permission(:any)
       .may(:show)
       .if_assignment_assignee_or_creator
@@ -27,8 +33,12 @@ class MessageAbility < AbilityDsl::Base
     permission_in_layers?(subject.group.layer_hierarchy.collect(&:id))
   end
 
+  def in_layer_or_below_if_active
+    in_layer_or_below && !subject.group.archived?
+  end
+
   def in_layer_or_below_if_not_dispatched
-    in_layer_or_below && !subject.dispatched?
+    in_layer_or_below_if_active && !subject.dispatched?
   end
 
 end

--- a/app/abilities/note_ability.rb
+++ b/app/abilities/note_ability.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2017, Dachverband Schweizer Jugendparlamente. This file is part of
+#  Copyright (c) 2012-2021, Dachverband Schweizer Jugendparlamente. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -8,13 +8,11 @@
 class NoteAbility < AbilityDsl::Base
 
   on(Note) do
-    permission(:layer_full).
-      may(:create, :show, :destroy).
-      in_same_layer
+    permission(:layer_full).may(:show).in_same_layer
+    permission(:layer_full).may(:create, :destroy).in_same_layer_if_active
 
-    permission(:layer_and_below_full).
-      may(:create, :show, :destroy).
-      in_same_layer_or_below
+    permission(:layer_and_below_full).may(:show).in_same_layer_or_below
+    permission(:layer_and_below_full).may(:create, :destroy).in_same_layer_or_below_if_active
   end
 
   def in_same_layer
@@ -25,6 +23,10 @@ class NoteAbility < AbilityDsl::Base
     end
   end
 
+  def in_same_layer_if_active
+    in_same_layer && active_subject
+  end
+
   def in_same_layer_or_below
     case subj
     when Group then permission_in_layers?(subj.layer_hierarchy.collect(&:id))
@@ -33,7 +35,18 @@ class NoteAbility < AbilityDsl::Base
     end
   end
 
+  def in_same_layer_or_below_if_active
+    in_same_layer_or_below && active_subject
+  end
+
   private
+
+  def active_subject
+    case subj
+    when Group then !subj.archived?
+    else true
+    end
+  end
 
   def subj
     subject.subject

--- a/app/abilities/oauth_ability.rb
+++ b/app/abilities/oauth_ability.rb
@@ -7,22 +7,24 @@ class OauthAbility < AbilityDsl::Base
 
   on(Oauth::Application) do
     class_side(:index).if_admin
+
     permission(:admin).may(:manage).all
   end
 
   on(Oauth::AccessGrant) do
     class_side(:index).if_admin
+
     permission(:admin).may(:manage).all
     permission(:any).may(:destroy).own_access_grants
-  end
-
-  def own_access_grants
-    subject.resource_owner_id == user.id
   end
 
   on(Oauth::AccessToken) do
     class_side(:index).if_admin
     permission(:admin).may(:manage).all
+  end
+
+  def own_access_grants
+    subject.resource_owner_id == user.id
   end
 
 end

--- a/app/abilities/qualification_ability.rb
+++ b/app/abilities/qualification_ability.rb
@@ -24,8 +24,8 @@ class QualificationAbility < AbilityDsl::Base
 
   def in_course_layer_with(permission, person_layer_ids)
     layers = user.groups_with_permission(permission).collect(&:layer_group).uniq
-    qualify_layer_ids = layers.select { |g| g.event_types.include?(Event::Course) }.
-                               collect(&:id)
+    qualify_layer_ids = layers.select { |g| g.event_types.include?(Event::Course) }
+                              .collect(&:id)
 
     qualify_layer_ids.present? &&
     contains_any?(qualify_layer_ids, person_layer_ids)

--- a/app/abilities/role_ability.rb
+++ b/app/abilities/role_ability.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -12,24 +12,31 @@ class RoleAbility < AbilityDsl::Base
   on(Role) do
     class_side(:role_types, :details).all
 
-    permission(:group_full).may(:create, :update, :destroy).in_same_group
+    permission(:group_full).may(:create, :update, :destroy)
+                           .in_same_group_if_active
 
-    permission(:group_and_below_full).may(:create, :update, :destroy).in_same_group_or_below
+    permission(:group_and_below_full).may(:create, :update, :destroy)
+                                     .in_same_group_or_below_if_active
 
-    permission(:layer_full).may(:create, :create_in_subgroup, :update, :destroy).in_same_layer
+    permission(:layer_full).may(:create, :create_in_subgroup, :update, :destroy)
+                           .in_same_layer_if_active
 
     permission(:layer_and_below_full).
       may(:create, :create_in_subgroup, :update, :destroy).
       in_same_layer_or_visible_below
 
     general.non_restricted
-    general(:create).group_not_deleted
+    general(:create).group_not_deleted_or_archived
     general(:destroy).not_permission_giving
   end
 
   def in_same_layer_or_visible_below
-    in_same_layer ||
-    (subject.visible_from_above? && permission_in_layers?(group.layer_hierarchy.collect(&:id)))
+    in_same_layer_if_active ||
+      (
+        subject.visible_from_above? &&
+        permission_in_layers?(group.layer_hierarchy.collect(&:id)) &&
+        in_active_group
+      )
   end
 
   def non_restricted

--- a/app/abilities/service_token_ability.rb
+++ b/app/abilities/service_token_ability.rb
@@ -15,7 +15,7 @@ class ServiceTokenAbility < AbilityDsl::Base
   end
 
   def service_token_in_same_layer
-    in_same_layer
+    in_same_layer_if_active
   end
 
   private

--- a/app/abilities/subscription_ability.rb
+++ b/app/abilities/subscription_ability.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -16,7 +16,7 @@ class SubscriptionAbility < AbilityDsl::Base
     permission(:layer_full).may(:manage).in_same_layer
     permission(:layer_and_below_full).may(:manage).in_same_layer
 
-    general.group_not_deleted
+    general.group_not_deleted_or_archived
   end
 
   def her_own

--- a/app/controllers/group/archive_controller.rb
+++ b/app/controllers/group/archive_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, CEVI Regionalverband ZH-SH-GL. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class Group::ArchiveController < ApplicationController
+
+  before_action :authorize_action
+
+  def create
+    ActiveRecord::Base.transaction do
+      archival_timestamp = Time.zone.now
+
+      archive_roles(archival_timestamp) and
+        archive_group(archival_timestamp) and
+        entry.save!
+    end
+
+    redirect_to group_path(entry), notice: I18n.t('group.archive.flash.success')
+  end
+
+  private
+
+  def entry
+    @entry ||= Group.find_by!(id: params[:id])
+  end
+
+  def authorize_action
+    authorize!(:destroy, entry) # not exactly the same, but close enough
+  end
+
+  def archive_roles(archival_timestamp)
+    Role.where(group_id: entry.id)
+        .touch_all(:archived_at, time: archival_timestamp)
+  end
+
+  def archive_group(archival_timestamp)
+    entry.archived_at = archival_timestamp
+  end
+
+end

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -38,6 +38,10 @@ class ApplicationDecorator < Draper::Decorator
     modification_info(deleted_at, deleter)
   end
 
+  def archived_info
+    modification_info(archived_at, nil)
+  end
+
   private
 
   def modification_info(at, person)
@@ -48,7 +52,7 @@ class ApplicationDecorator < Draper::Decorator
       html << ' '
       html << h.link_to_if(can?(:show, person), person.to_s, h.person_path(person.id))
     end
-    html.html_safe
+    h.sanitize(html)
   end
 
 end

--- a/app/domain/export/tabular/groups/list.rb
+++ b/app/domain/export/tabular/groups/list.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2014-2019 Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2014-2021, Pfadibewegung Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -9,7 +9,7 @@ module Export::Tabular::Groups
   class List < Export::Tabular::Base
 
     EXCLUDED_ATTRS = %w(lft rgt contact_id require_person_add_requests logo
-                        created_at updated_at deleted_at
+                        created_at updated_at deleted_at archived_at
                         creator_id updater_id deleter_id).freeze
 
     self.model_class = Group

--- a/app/domain/person/filter/list.rb
+++ b/app/domain/person/filter/list.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2017-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.

--- a/app/helpers/dropdown/group_edit.rb
+++ b/app/helpers/dropdown/group_edit.rb
@@ -1,9 +1,11 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
+
+# rubocop:disable Rails/HelperInstanceVariable This is a domain-class in the wrong directory
 
 module Dropdown
   class GroupEdit < Base
@@ -12,24 +14,32 @@ module Dropdown
 
     def initialize(template, group)
       super(template, template.ti('link.edit'), :edit)
+
       @group = group
-      @main_link = template.edit_group_path(group)
+      @main_link = (group.archived? ? nil : template.edit_group_path(group))
+
       init_items
     end
 
     private
 
-    def init_items
-      add_item(translate(:merge), template.merge_group_path(group))
-      add_item(translate(:move), template.move_group_path(group))
+    def init_items # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+      unless group.archived?
+        add_item(translate(:merge), template.merge_group_path(group))
+        add_item(translate(:move), template.move_group_path(group))
+      end
+
+      if group.archivable?
+        add_item(translate(:archive), template.archive_group_path(group),
+                 data: { confirm: template.ti(:confirm_archive), method: :post })
+      end
 
       if !group.protected? && template.can?(:destroy, group)
-        add_divider
-        add_item(template.ti('link.delete'),
-                 template.group_path(group),
-                 data: { confirm: template.ti(:confirm_delete),
-                         method: :delete })
+        add_divider unless group.archived?
+        add_item(template.ti('link.delete'), template.group_path(group),
+                 data: { confirm: template.ti(:confirm_delete), method: :delete })
       end
     end
   end
 end
+# rubocop:enable Rails/HelperInstanceVariable

--- a/app/helpers/plain_object_form_builder.rb
+++ b/app/helpers/plain_object_form_builder.rb
@@ -6,11 +6,11 @@
 #  https://github.com/hitobito/hitobito.
 
 class PlainObjectFormBuilder < StandardFormBuilder
-  def required?(_attr)
+  def required?(attr)
     false
   end
 
-  def errors_on?(_attr)
+  def errors_on?(attr)
     false
   end
 end

--- a/app/helpers/sheet/group.rb
+++ b/app/helpers/sheet/group.rb
@@ -53,9 +53,7 @@ module Sheet
 
     tab 'activerecord.models.group_setting.other',
         :group_group_settings_path,
-        if: (lambda do |view, group|
-          view.can?(:update, group)
-        end)
+        if: :update
 
     delegate :group_path, to: :view
 

--- a/app/javascript/stylesheets/hitobito/modules/_nav_left.scss
+++ b/app/javascript/stylesheets/hitobito/modules/_nav_left.scss
@@ -35,7 +35,9 @@
 		border-left: 3px solid $linkColor;
 	}
 
-
+	a.is-archived, li.is-archived > a {
+		color: desaturate(lighten($linkColor, 20%), 80%);
+	}
 
 	.nav-left-section {
 		background-color: $grayLighter;

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,9 +1,10 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
+
 # == Schema Information
 #
 # Table name: roles
@@ -64,6 +65,7 @@ class Role < ActiveRecord::Base
   after_create :set_first_primary_group
   after_destroy :reset_contact_data_visible
   after_destroy :reset_primary_group
+  before_save :prevent_changes, if: ->(r) { r.archived? }
 
   ### CLASS METHODS
 
@@ -87,12 +89,16 @@ class Role < ActiveRecord::Base
   end
 
   # Soft destroy if older than certain amount of days, hard if younger
-  def destroy
+  def destroy # rubocop:disable Rails/ActiveRecordOverride
     if old_enough_to_archive?
       super
     else
       really_destroy!
     end
+  end
+
+  def archived?
+    archived_at.present?
   end
 
   private
@@ -119,7 +125,8 @@ class Role < ActiveRecord::Base
   end
 
   def reset_primary_group
-    if person.primary_group_id == group_id && person.roles.where(group_id: group_id).count == 0
+    if person.primary_group_id == group_id &&
+        person.roles.where(group_id: group_id).count.zero?
       person.update_column :primary_group_id, alternative_primary_group.try(:id)
     end
   end
@@ -136,5 +143,14 @@ class Role < ActiveRecord::Base
 
   def old_enough_to_archive?
     (Time.zone.now - created_at) > Settings.role.minimum_days_to_archive.days
+  end
+
+  def prevent_changes
+    allowed = %w(archived_at updater_id)
+    only_archival = changes
+                    .reject { |_attr, (from, to)| from.blank? && to.blank? }
+                    .keys.all? { |key| allowed.include? key }
+
+    raise ActiveRecord::ReadOnlyRecord unless new_record? || only_archival
   end
 end

--- a/app/models/service_token.rb
+++ b/app/models/service_token.rb
@@ -2,6 +2,7 @@
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
+
 # == Schema Information
 #
 # Table name: service_tokens

--- a/app/views/group_settings/_list.html.haml
+++ b/app/views/group_settings/_list.html.haml
@@ -10,5 +10,6 @@
     = s.name
   - t.col('') do |s|
     = s.translated_values
-  - action_col(t) do |s|
-    = link_action_edit(edit_group_group_setting_path(@group, s.var), remote: true)
+  - unless @group.archived?
+    - action_col(t) do |s|
+      = link_action_edit(edit_group_group_setting_path(@group, s.var), remote: true)

--- a/app/views/groups/_actions_show.html.haml
+++ b/app/views/groups/_actions_show.html.haml
@@ -1,13 +1,13 @@
--#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
 - if can?(:edit, entry)
   = Dropdown::GroupEdit.new(self, entry)
-- if entry.possible_children.any? { |type| can?(:create, type.new(parent: entry))  }
+- if !entry.archived? && entry.possible_children.any? { |type| can?(:create, type.new(parent: entry))  }
   = Dropdown::GroupAdd.new(self, entry)
-- if can?(:export_subgroups, entry)
+- if !entry.archived? && can?(:export_subgroups, entry)
   = action_button(t('.export_subgroups'), export_subgroups_group_path(@group, format: :csv), :download)
 - if entry.deleted? && can?(:reactivate, entry)
   = action_button(t('.reactivate'), reactivate_group_path(@group), :retweet, method: :post)

--- a/app/views/groups/_attrs.html.haml
+++ b/app/views/groups/_attrs.html.haml
@@ -12,7 +12,7 @@
     = render_attrs(entry, :type_name)
     = render_present_attrs(entry, *entry.used_attributes(:description))
     = render_extensions :attrs
-    = render_present_attrs(entry, :created_info, :updated_info, :deleted_info) if can?(:show_details, @group)
+    = render_present_attrs(entry, :created_info, :updated_info, :deleted_info, :archived_info) if can?(:show_details, @group)
 
     - if can?(:index_notes, entry)
       = render 'notes/section', create_path: group_notes_path(@group)

--- a/app/views/service_tokens/_actions_index.html.haml
+++ b/app/views/service_tokens/_actions_index.html.haml
@@ -1,0 +1,7 @@
+-#
+  Copyright (c) 2021-2021, CEVI Regionalverband ZH-SH-GL. This file is part of
+  hitobito and licensed under the Affero General Public License version 3
+  or later. See the COPYING file at the top-level directory or at
+  https://github.com/hitobito/hitobito.
+
+= button_action_add if can?(:new, model_class) && !@group.archived?

--- a/app/views/service_tokens/_list.html.haml
+++ b/app/views/service_tokens/_list.html.haml
@@ -12,5 +12,6 @@
     - service_token.abilities
   - t.attr(:last_access)
 
-  - add_table_actions(t)
+  - unless @group.archived?
+    - add_table_actions(t)
 

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -32,6 +32,7 @@ de:
     created_info: Erstellt
     updated_info: Geändert
     deleted_info: Gelöscht
+    archived_info: Archiviert
 
   activerecord:
     errors:

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -144,6 +144,7 @@ de:
   dropdown/group_edit:
     move: 'Verschieben'
     merge: 'Fusionieren'
+    archive: 'Archivieren'
 
   dropdown/people_export:
     button: 'Export'
@@ -577,10 +578,16 @@ de:
       incomplete_search_request: 'Bitte geben Sie mindestens zwei Zeichen ein.'
 
   group:
+    archive:
+      flash:
+        success: Gruppe wurde erfolgreich archiviert.
+        failure: Es ist ein Fehler beim Archivieren der Gruppe aufgetreten.
+
     merge:
       select:
         title: '%{group} fusionieren'
-        explanation: Beim Fusionieren zweier Gruppen werden sämtliche Untergruppen, Anlässe und Personen
+        explanation: >
+          Beim Fusionieren zweier Gruppen werden sämtliche Untergruppen, Anlässe und Personen
           samt Rollen beider Gruppen zusammengeführt.  Abos werden nicht übernommen.
           Die bisherigen Gruppen werden danach unter 'Gelöscht' weiterhin einsehbar sein.
         merge_is_irreversible:  Dieser Vorgang kann nicht mehr rückgängig gemacht werden!
@@ -619,6 +626,9 @@ de:
     actions_show:
       export_subgroups: 'CSV Untergruppen'
       reactivate: 'Reaktivieren'
+      confirm_archive: >
+        Wollen Sie diese Gruppe wirklich archivieren? Sie kann dann nicht mehr
+        bearbeitet werden und sämtliche Rollen werden ebenfalls archiviert.
     attrs:
       contact_details: 'Kontaktangaben'
       additional_information: 'Weitere Angaben'
@@ -647,16 +657,23 @@ de:
   group/merge:
     success: 'Die gewählten Gruppen wurden zur neuen Gruppe %{new_group_name} fusioniert.'
     failure: 'Die gewählten Gruppen können nicht fusioniert werden.'
-    no_candidates: 'Es sind keine gleichen Gruppen zum Fusionieren vorhanden oder Du verfügst dort nicht über die nötigen Berechtigungen.'
+    no_candidates: >
+      Es sind keine gleichen Gruppen zum Fusionieren vorhanden oder Du verfügst
+      dort nicht über die nötigen Berechtigungen.
     group_name_missing: 'Name für neue Gruppe muss definiert werden.'
     no_group_selected: 'Bitte wähle eine Gruppe mit der fusioniert werden soll.'
     not_allowed: 'Leider fehlt dir die Berechtigung um diese Gruppen zu fusionieren.'
-    invoice_config_not_merged: 'Die Rechnungseinstellungen werden nicht automatisch übernommen. Bitte nimm hierfür die jetzt korrekten Einstellungen manuell vor.'
+    invoice_config_not_merged: >
+      Die Rechnungseinstellungen werden nicht automatisch übernommen. Bitte
+      nimm hierfür die jetzt korrekten Einstellungen manuell vor.
 
   group/move:
     success: '%{group} wurde nach %{target} verschoben.'
     failure: 'Diese Gruppe kann nicht verschoben werden oder Du verfügst nicht über die nötigen Berechtigungen.'
     choose_group: 'Bitte wähle eine Gruppe aus.'
+
+  group_decorator:
+    archived_suffix: ' (archiviert)'
 
   import/csv_parser:
     read_error: "Fehler beim Lesen von %{filename}: %{error}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Hitobito::Application.routes.draw do
         get 'move' => 'group/move#select'
         post 'move' => 'group/move#perform'
 
+        post 'archive' => 'group/archive#create'
       end
 
       resources :settings, only: [:index, :edit, :update], controller: 'group_settings', as: 'group_settings'

--- a/db/migrate/20211019110016_add_archived_at_to_groups.rb
+++ b/db/migrate/20211019110016_add_archived_at_to_groups.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, CEVI Regionalverband ZH-SH-GL. This file is part of
+#  hitobito_cevi and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cevi.
+
+class AddArchivedAtToGroups < ActiveRecord::Migration[6.0]
+  def change
+    add_column :groups, :archived_at, :datetime
+  end
+end

--- a/db/migrate/20211019153543_add_archived_at_to_roles.rb
+++ b/db/migrate/20211019153543_add_archived_at_to_roles.rb
@@ -1,0 +1,5 @@
+class AddArchivedAtToRoles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :roles, :archived_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_14_200000) do
+ActiveRecord::Schema.define(version: 2021_10_19_153543) do
 
   create_table "action_text_rich_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -341,6 +341,7 @@ ActiveRecord::Schema.define(version: 2021_10_14_200000) do
     t.boolean "require_person_add_requests", default: false, null: false
     t.text "description", size: :medium
     t.string "logo"
+    t.datetime "archived_at"
     t.index ["layer_group_id"], name: "index_groups_on_layer_group_id"
     t.index ["lft", "rgt"], name: "index_groups_on_lft_and_rgt"
     t.index ["parent_id"], name: "index_groups_on_parent_id"
@@ -832,6 +833,7 @@ ActiveRecord::Schema.define(version: 2021_10_14_200000) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "deleted_at"
+    t.datetime "archived_at"
     t.index ["person_id", "group_id"], name: "index_roles_on_person_id_and_group_id"
     t.index ["type"], name: "index_roles_on_type"
   end

--- a/spec/controllers/group/archive_controller_spec.rb
+++ b/spec/controllers/group/archive_controller_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, CEVI Regionalverband ZH-SH-GL. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+describe Group::ArchiveController, type: :controller do
+
+  describe 'POST #create' do
+    let(:bottom_group) { groups(:bottom_group_one_two) }
+    let(:group_id) { bottom_group.id }
+
+    before do
+      sign_in(people(:top_leader))
+    end
+
+    it 'returns http success' do
+      post :create, params: { id: group_id }
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it 'finishes all roles' do
+      Fabricate(Group::BottomGroup::Member.sti_name,
+                person_id: people(:bottom_member).id,
+                group_id: group_id)
+
+      expect do
+        post :create, params: { id: group_id }
+      end.to change { Role.where(group_id: group_id, archived_at: nil).count }.by(-1)
+    end
+
+    it 'archives the group' do
+      expect do
+        post :create, params: { id: group_id }
+      end.to change { bottom_group.reload.archived? }.from(false).to(true)
+    end
+  end
+
+end

--- a/spec/decorators/group_decorator_spec.rb
+++ b/spec/decorators/group_decorator_spec.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -78,4 +78,47 @@ describe GroupDecorator, :draper_with_helpers do
     end
   end
 
+  context 'archived groups' do
+    let(:model) do
+      groups(:bottom_group_one_two).tap { |g| g.update(archived_at: 1.day.ago) }
+    end
+
+    it 'suffix to_s' do
+      expect(subject.to_s).to end_with(' (archiviert)')
+    end
+
+    it 'suffix to_s with argument' do
+      expect(subject.to_s(:default)).to end_with(' (archiviert)')
+    end
+
+    it 'suffix to_s with argument' do
+      expect(subject.to_s(:long_format)).to end_with(' (archiviert)')
+    end
+
+    it 'suffix display_name' do
+      expect(subject.display_name).to end_with(' (archiviert)')
+    end
+  end
+
+  context 'not archived groups' do
+    let(:model) do
+      groups(:bottom_group_one_two).tap { |g| g.update(archived_at: nil) }
+    end
+
+    it 'suffix to_s' do
+      expect(subject.to_s).to_not end_with(' (archiviert)')
+    end
+
+    it 'suffix to_s with argument' do
+      expect(subject.to_s(:default)).to_not end_with(' (archiviert)')
+    end
+
+    it 'suffix to_s with argument' do
+      expect(subject.to_s(:long_format)).to_not end_with(' (archiviert)')
+    end
+
+    it 'suffix display_name' do
+      expect(subject.display_name).to_not end_with(' (archiviert)')
+    end
+  end
 end

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -2,6 +2,7 @@
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
+
 # == Schema Information
 #
 # Table name: groups

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -53,7 +53,8 @@ describe Group do
         group = Group::BottomLayer.new(name: 'AAA', parent_id: parent.id)
         group.save!
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-          'AAA', 'Bottom One', 'Bottom Two', 'TopGroup', 'Toppers']
+          'AAA', 'Bottom One', 'Bottom Two', 'TopGroup', 'Toppers'
+        ]
         # :updated_at should not change, tests patch from config/awesome_nested_set_patch.rb
         expect(groups(:top_layer).reload.updated_at.to_date).to eq(updated)
         expect(groups(:bottom_layer_one).reload.updated_at.to_date).to eq(updated)
@@ -65,7 +66,8 @@ describe Group do
         group = Group::BottomLayer.new(name: 'Bottom One', parent_id: parent.id)
         group.save!
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-          'Bottom One', 'Bottom One', 'Bottom Two', 'TopGroup', 'Toppers']
+          'Bottom One', 'Bottom One', 'Bottom Two', 'TopGroup', 'Toppers'
+        ]
       end
 
       it 'in the middle' do
@@ -73,7 +75,8 @@ describe Group do
         group = Group::BottomLayer.new(name: 'Frosch', parent_id: parent.id)
         group.save!
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-         'Bottom One', 'Bottom Two', 'Frosch', 'TopGroup', 'Toppers']
+          'Bottom One', 'Bottom Two', 'Frosch', 'TopGroup', 'Toppers'
+        ]
       end
 
       it 'in the middle with same name' do
@@ -81,7 +84,8 @@ describe Group do
         group = Group::BottomLayer.new(name: 'Bottom Two', parent_id: parent.id)
         group.save!
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-         'Bottom One', 'Bottom Two', 'Bottom Two', 'TopGroup', 'Toppers']
+          'Bottom One', 'Bottom Two', 'Bottom Two', 'TopGroup', 'Toppers'
+        ]
       end
 
       it 'at the end' do
@@ -89,7 +93,8 @@ describe Group do
         group = Group::TopGroup.new(name: 'ZZ Top', parent_id: parent.id)
         group.save!
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-         'Bottom One', 'Bottom Two', 'TopGroup', 'Toppers', 'ZZ Top']
+          'Bottom One', 'Bottom Two', 'TopGroup', 'Toppers', 'ZZ Top'
+        ]
       end
 
       it 'at the end with same name' do
@@ -97,16 +102,19 @@ describe Group do
         group = Group::TopGroup.new(name: 'Toppers', parent_id: parent.id)
         group.save!
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-         'Bottom One', 'Bottom Two', 'TopGroup', 'Toppers', 'Toppers']
+          'Bottom One', 'Bottom Two', 'TopGroup', 'Toppers', 'Toppers'
+        ]
       end
 
       context 'with short_name' do
         it 'in the middle' do
           parent = groups(:top_layer)
-          group = Group::TopGroup.new(name: 'Bottom A', short_name: 'Bottom X', parent_id: parent.id)
+          group = Group::TopGroup.new(name: 'Bottom A', short_name: 'Bottom X',
+                                      parent_id: parent.id)
           group.save!
-          expect = expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-           'Bottom One', 'Bottom Two','Bottom A', 'TopGroup', 'Toppers']
+          expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
+            'Bottom One', 'Bottom Two', 'Bottom A', 'TopGroup', 'Toppers'
+          ]
         end
       end
 
@@ -115,8 +123,9 @@ describe Group do
           parent = groups(:top_layer)
           group = Group::TopGroup.new(name: 'bottom x', parent_id: parent.id)
           group.save!
-          expect = expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-           'Bottom One', 'Bottom Two', 'bottom x', 'TopGroup', 'Toppers']
+          expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
+            'Bottom One', 'Bottom Two', 'bottom x', 'TopGroup', 'Toppers'
+          ]
         end
       end
     end
@@ -125,62 +134,75 @@ describe Group do
       it 'at the beginning' do
         groups(:bottom_layer_two).update!(name: 'AAA')
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-          'AAA', 'Bottom One', 'TopGroup', 'Toppers']
+          'AAA', 'Bottom One', 'TopGroup', 'Toppers'
+        ]
       end
 
       it 'at the beginning with same name' do
         groups(:bottom_layer_two).update!(name: 'Bottom One')
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-          'Bottom One', 'Bottom One', 'TopGroup', 'Toppers']
+          'Bottom One', 'Bottom One', 'TopGroup', 'Toppers'
+        ]
       end
 
       it 'in the middle keeping position right' do
         groups(:bottom_layer_two).update!(name: 'Frosch')
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-         'Bottom One', 'Frosch', 'TopGroup', 'Toppers']
+          'Bottom One', 'Frosch', 'TopGroup', 'Toppers'
+        ]
       end
 
       it 'in the middle keeping position left' do
         groups(:bottom_layer_two).update!(name: 'Bottom P')
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-         'Bottom One', 'Bottom P', 'TopGroup', 'Toppers']
+          'Bottom One', 'Bottom P', 'TopGroup', 'Toppers'
+        ]
       end
 
       it 'in the middle moving right' do
         groups(:bottom_layer_two).update!(name: 'TopGzzz')
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-         'Bottom One', 'TopGroup', 'TopGzzz', 'Toppers']
+          'Bottom One', 'TopGroup', 'TopGzzz', 'Toppers'
+        ]
       end
 
       it 'in the middle moving left' do
         groups(:top_group).update!(name: 'Bottom P')
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-         'Bottom One', 'Bottom P', 'Bottom Two', 'Toppers']
+          'Bottom One', 'Bottom P', 'Bottom Two', 'Toppers'
+        ]
       end
 
       it 'in the middle with same name' do
         groups(:bottom_layer_two).update!(name: 'TopGroup')
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-         'Bottom One', 'TopGroup', 'TopGroup', 'Toppers']
+          'Bottom One', 'TopGroup', 'TopGroup', 'Toppers'
+        ]
       end
 
       it 'at the end' do
         groups(:bottom_layer_two).update!(name: 'ZZ Top')
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-         'Bottom One', 'TopGroup', 'Toppers', 'ZZ Top']
+          'Bottom One', 'TopGroup', 'Toppers', 'ZZ Top'
+        ]
       end
 
       it 'at the end with same name' do
         groups(:bottom_layer_two).update!(name: 'Toppers')
         expect(groups(:top_layer).children.order(:lft).collect(&:name)).to eq [
-         'Bottom One', 'TopGroup', 'Toppers', 'Toppers']
+          'Bottom One', 'TopGroup', 'Toppers', 'Toppers'
+        ]
       end
 
       context 'with short_name' do
         it 'at the end' do
-          groups(:bottom_layer_two).update!(short_name: 'XXX')
+          groups(:bottom_layer_two).update!(short_name: 'ZZZ')
           expect(groups(:top_layer).children.order(:lft).collect(&:display_name)).to eq [
-           'Bottom One', 'TopGroup', 'Toppers', "XXX"]
+            'Bottom One',
+            'TopGroup',
+            'Toppers',
+            'ZZZ'
+          ]
         end
       end
 
@@ -188,7 +210,8 @@ describe Group do
         it 'in the middle' do
           groups(:bottom_layer_two).update!(name: 'topGroupX')
           expect(groups(:top_layer).children.order(:lft).collect(&:display_name)).to eq [
-           'Bottom One', 'TopGroup', 'topGroupX', 'Toppers']
+            'Bottom One', 'TopGroup', 'topGroupX', 'Toppers'
+          ]
         end
       end
 
@@ -201,7 +224,13 @@ describe Group do
     end
 
     it 'contains all ancestors' do
-      expect(groups(:bottom_group_one_one).hierarchy).to eq([groups(:top_layer), groups(:bottom_layer_one), groups(:bottom_group_one_one)])
+      expect(groups(:bottom_group_one_one).hierarchy).to eq(
+        [
+          groups(:top_layer),
+          groups(:bottom_layer_one),
+          groups(:bottom_group_one_one)
+        ]
+      )
     end
   end
 
@@ -215,7 +244,8 @@ describe Group do
     end
 
     it 'is all upper layers for regular layer' do
-      expect(groups(:bottom_layer_one).layer_hierarchy).to eq([groups(:top_layer), groups(:bottom_layer_one)])
+      expect(groups(:bottom_layer_one).layer_hierarchy).to eq([groups(:top_layer),
+                                                               groups(:bottom_layer_one)])
     end
   end
 
@@ -288,7 +318,8 @@ describe Group do
       let(:group) { groups(:bottom_layer_one) }
 
       it 'contains other layers and their descendants' do
-        is_expected.to match_array([group.self_and_descendants, groups(:bottom_layer_two).self_and_descendants].flatten)
+        is_expected.to match_array([group.self_and_descendants,
+                                    groups(:bottom_layer_two).self_and_descendants].flatten)
       end
     end
 
@@ -296,7 +327,8 @@ describe Group do
       let(:group) { groups(:bottom_group_one_one) }
 
       it 'contains other groups and their descendants' do
-        is_expected.to match_array([group, groups(:bottom_group_one_one_one), groups(:bottom_group_one_two)])
+        is_expected.to match_array([group, groups(:bottom_group_one_one_one),
+                                    groups(:bottom_group_one_two)])
       end
     end
   end
@@ -304,7 +336,8 @@ describe Group do
   context '.all_types' do
     it 'lists all types' do
       expect(Group.all_types.count).to eq(5)
-      [Group::TopLayer, Group::TopGroup, Group::BottomLayer, Group::BottomGroup, Group::GlobalGroup].each do |t|
+      [Group::TopLayer, Group::TopGroup, Group::BottomLayer, Group::BottomGroup,
+       Group::GlobalGroup].each do |t|
         expect(Group.all_types).to include(t)
       end
     end
@@ -313,23 +346,23 @@ describe Group do
   context '.order_by_type' do
     it 'has correct ordering without group' do
       expect(Group.order_by_type).to eq([groups(:top_layer),
-                                     groups(:top_group),
-                                     groups(:bottom_layer_one),
-                                     groups(:bottom_layer_two),
-                                     groups(:bottom_group_one_one),
-                                     groups(:bottom_group_one_one_one),
-                                     groups(:bottom_group_one_two),
-                                     groups(:bottom_group_two_one),
-                                     groups(:toppers)])
+                                         groups(:top_group),
+                                         groups(:bottom_layer_one),
+                                         groups(:bottom_layer_two),
+                                         groups(:bottom_group_one_one),
+                                         groups(:bottom_group_one_one_one),
+                                         groups(:bottom_group_one_two),
+                                         groups(:bottom_group_two_one),
+                                         groups(:toppers)])
     end
 
     it 'has correct ordering with parent group' do
       parent = groups(:top_layer)
       expect(parent.children.order_by_type(parent)).to eq(
-          [groups(:top_group),
-           groups(:bottom_layer_one),
-           groups(:bottom_layer_two),
-           groups(:toppers)]
+        [groups(:top_group),
+         groups(:bottom_layer_one),
+         groups(:bottom_layer_two),
+         groups(:toppers)]
       )
     end
 
@@ -338,7 +371,6 @@ describe Group do
       expect(parent.children.order_by_type(parent)).to be_empty
     end
   end
-
 
   context '#set_layer_group_id' do
     it 'sets layer_group_id on group' do
@@ -373,7 +405,7 @@ describe Group do
 
     it 'destroys self' do
       expect { bottom_group.destroy }.to change { Group.without_deleted.count }.by(-1)
-      expect(Group.only_deleted.collect(&:id)).to  match_array([bottom_group.id])
+      expect(Group.only_deleted.collect(&:id)).to match_array([bottom_group.id])
       expect(Group).to be_valid
     end
 
@@ -383,17 +415,17 @@ describe Group do
     end
 
     it 'protects group with children' do
-      expect { bottom_layer.destroy }.not_to change { Group.without_deleted.count }
+      expect { bottom_layer.destroy }.not_to(change { Group.without_deleted.count })
     end
 
     it 'does not destroy anything for root group' do
-      expect { top_layer.destroy }.not_to change { Group.count }
+      expect { top_layer.destroy }.not_to(change { Group.count })
     end
 
     context 'role assignments'  do
       it 'terminates own roles' do
-        role = Fabricate(Group::BottomGroup::Member.name.to_s, group: bottom_group)
-        deleted_ids = bottom_group.roles.collect(&:id)
+        _role = Fabricate(Group::BottomGroup::Member.name.to_s, group: bottom_group)
+        _deleted_ids = bottom_group.roles.collect(&:id)
         # role is deleted permanantly as it is less than Settings.role.minimum_days_to_archive old
         expect { bottom_group.destroy }.to change { Role.with_deleted.count }.by(-1)
       end
@@ -404,7 +436,7 @@ describe Group do
 
       it 'does not destroy exclusive events on soft destroy' do
         Fabricate(:event, groups: [group])
-        expect { group.destroy }.not_to change { Event.count }
+        expect { group.destroy }.not_to change(Event, :count)
       end
 
       it 'destroys exclusive events on hard destroy' do
@@ -414,7 +446,7 @@ describe Group do
 
       it 'does not destroy events belonging to other groups as well' do
         Fabricate(:event, groups: [group, groups(:bottom_group_one_one)])
-        expect { group.really_destroy! }.not_to change { Event.count }
+        expect { group.really_destroy! }.not_to change(Event, :count)
       end
 
       it 'destroys event when removed from association' do
@@ -430,7 +462,7 @@ describe Group do
     subject { group }
     before { group.update!(contactable) }
 
-    context 'no contactable but contact info'  do
+    context 'no contactable but contact info' do
       its(:contact)   { should be_blank }
       its(:address)   { should eq 'foobar' }
       its(:town)      { should eq 'thun' }
@@ -444,15 +476,15 @@ describe Group do
 
       before { group.update_attribute(:contact, contact) }
 
-      its(:address)   { should eq 'barfoo' }
-      its(:address?)   { should be_truthy }
-      its(:zip_code?)   { should be_falsey }
+      its(:address) { should eq 'barfoo' }
+      its(:address?) { should be_truthy }
+      its(:zip_code?) { should be_falsey }
     end
 
   end
 
   context 'invoice_config' do
-    let (:parent) { groups(:top_layer) }
+    let(:parent) { groups(:top_layer) }
 
     it 'is created for layer group' do
       group = Fabricate(Group::BottomLayer.sti_name, name: 'g', parent: parent)
@@ -508,6 +540,73 @@ describe Group do
       group.email = 'group42@puzzle.ch'
 
       expect(group).to be_valid
+    end
+  end
+
+  context 'archived: ' do
+    subject(:archived_group) do
+      groups(:bottom_group_one_two).tap { |g| g.update(archived_at: 1.day.ago) }
+    end
+
+    context 'archived? is' do
+      subject { groups(:bottom_group_one_two) }
+
+      it 'false without a date' do
+        expect(subject.archived_at).to be_falsey
+
+        is_expected.not_to be_archived
+      end
+
+      it 'true with an archived_at date' do
+        expect(archived_group.archived_at).to be_truthy
+
+        expect(archived_group).to be_archived
+      end
+
+      it 'making the group read-only' do
+        expect(archived_group).to be_archived
+
+        expect do
+          archived_group.update!(name: 'Followers of Blørbaël')
+        end.to raise_error(ActiveRecord::ReadOnlyRecord)
+      end
+    end
+
+    context 'archivable? is' do
+      it 'false when there are sub-groups' do
+        group = groups(:top_layer)
+        expect(group.children).to be_present
+
+        expect(group).not_to be_archivable
+      end
+
+      it 'false when already archived' do
+        group = groups(:toppers).tap do |g|
+          g.update(archived_at: 1.day.ago)
+        end
+        expect(group.children).to_not be_present
+
+        expect(group).not_to be_archivable
+      end
+
+      it 'true if there are no children' do
+        group = groups(:toppers)
+        expect(group.children).to_not be_present
+
+        expect(group).to be_archivable
+      end
+    end
+
+    context 'soft-deletion' do
+      it 'is supported' do
+        expect(archived_group.class.ancestors).to include(Paranoia)
+
+        expect do
+          archived_group.destroy!
+        end.to change { Group.without_deleted.count }.by(-1)
+
+        expect(archived_group.reload.deleted_at).to_not be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Gruppen können, wenn sie keine Untergruppen enthalten, archiviert werden. Rollen in dieser Gruppe werden ebenfalls archiviert. Archivierte Gruppen können gelöscht werden, aber nicht anderweitig bearbeitet werden. Andere Elemente, die von der archivierten Gruppe abhängen, dürften ebenfalls nicht mehr bearbeitet werden.

In der Rollenübersicht werden sie noch angezeigt, können aber nicht mehr bearbeitet werden. Dies könnte man noch anpassen, ich finde es erstmal so sinnvoll, da die Gruppen auch dort als _archiviert_ markiert ist. Alternativ könnte man überlegen, ob die archivierten Rollen in einer eigenen Liste oder auch gar nicht mehr angezeigt werden. (Siehe `PersonDecorator`)

Fixes #1275 