### PR TITLE
Disable group archival

### DIFF
--- a/app/controllers/group/archive_controller.rb
+++ b/app/controllers/group/archive_controller.rb
@@ -28,7 +28,9 @@ class Group::ArchiveController < ApplicationController
   end
 
   def authorize_action
-    authorize!(:destroy, entry) # not exactly the same, but close enough
+    raise CanCan::AccessDenied # for now, feature is deactivated GROUP_ARCHIVE_DISABLED
+
+    # authorize!(:destroy, entry) # not exactly the same, but close enough
   end
 
   def archive_roles(archival_timestamp)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -227,7 +227,9 @@ class Group < ActiveRecord::Base
   end
 
   def archivable?
-    !archived? && children_without_deleted.none?
+    false # for now, feature is deactivated GROUP_ARCHIVE_DISABLED
+
+    # !archived? && children_without_deleted.none?
   end
 
   private

--- a/spec/controllers/group/archive_controller_spec.rb
+++ b/spec/controllers/group/archive_controller_spec.rb
@@ -9,7 +9,22 @@ require 'spec_helper'
 
 describe Group::ArchiveController, type: :controller do
 
-  describe 'POST #create' do
+  describe 'POST #create' do # delete this, once GROUP_ARCHIVE_DISABLED is over
+    let(:bottom_group) { groups(:bottom_group_one_two) }
+    let(:group_id) { bottom_group.id }
+
+    before do
+      sign_in(people(:top_leader))
+    end
+
+    it 'is forbidden' do
+      expect do
+        post :create, params: { id: group_id }
+      end.to raise_error CanCan::AccessDenied
+    end
+  end
+
+  xdescribe 'POST #create' do # reactivate once GROUP_ARCHIVE_DISABLED is over
     let(:bottom_group) { groups(:bottom_group_one_two) }
     let(:group_id) { bottom_group.id }
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -573,14 +573,18 @@ describe Group do
     end
 
     context 'archivable? is' do
-      it 'false when there are sub-groups' do
+      it 'currently always false, feature is deactivated' do # delete after GROUP_ARCHIVE_DISABLED
+        expect(groups(:toppers)).to_not be_archivable
+      end
+
+      xit 'false when there are sub-groups' do # reactivate after GROUP_ARCHIVE_DISABLED
         group = groups(:top_layer)
         expect(group.children).to be_present
 
         expect(group).not_to be_archivable
       end
 
-      it 'false when already archived' do
+      xit 'false when already archived' do # reactivate after GROUP_ARCHIVE_DISABLED
         group = groups(:toppers).tap do |g|
           g.update(archived_at: 1.day.ago)
         end
@@ -589,7 +593,7 @@ describe Group do
         expect(group).not_to be_archivable
       end
 
-      it 'true if there are no children' do
+      xit 'true if there are no children' do # reactivate after GROUP_ARCHIVE_DISABLED
         group = groups(:toppers)
         expect(group.children).to_not be_present
 


### PR DESCRIPTION
Search for GROUP_ARCHIVE_DISABLED to see all places, where it was disabled. Reverting the commit might also work.

Fixes #1443
