### PR TITLE
Generate templates for GH-Actions

### DIFF
--- a/bin/wagon
+++ b/bin/wagon
@@ -130,6 +130,7 @@ case $cmd in
     mv -nv "vendor/wagons/$wagon_name" "$new_wagon_dir"
 
     pushd "$new_wagon_dir"
+      mv github .github
       git init
       git ci -m "Create $wagon_name Wagon"
     popd

--- a/doc/development/04_wagons.md
+++ b/doc/development/04_wagons.md
@@ -38,10 +38,10 @@ environment variables to that wagons can be activated with a single statement.
 
 ### Instructions: create wagon
 
-As a "Work in Progress" the wagon-creation is automated with 
+As a "Work in Progress" the wagon-creation is automated with
 
     ./bin/wagon create [name]
-    
+
 This covers the first few steps (up until copying the configs) of the following instructions:
 
 The basic structure of a new wagon can be easily generated in the main project, the templates for it are in `lib/templates/wagon`):
@@ -51,6 +51,7 @@ The basic structure of a new wagon can be easily generated in the main project, 
 Afterwards you need to make the following adjustments:
 
 * Move files from `hitobito/vendor/wagons/[name]` to `hitobito_[name]`
+* Rename `github` to `.github` to enable GH-Actions
 * Initialize a new Git Repo for the wagon
 * Copy `.tool-versions` from the core into the wagon. (or use `wagon activate [name]`)
 * Copy `Gemfile.lock` from the core into the wagon. (or use `wagon gemfile`)

--- a/lib/templates/wagon/github/workflows/tests.yml.tt
+++ b/lib/templates/wagon/github/workflows/tests.yml.tt
@@ -1,0 +1,147 @@
+name: 'Rails Lint and Test'
+
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+
+defaults:
+  run:
+    working-directory: hitobito
+
+jobs:
+  build:
+    runs-on: 'ubuntu-20.04'
+    env:
+      HEADLESS: true
+      RAILS_DB_ADAPTER: mysql2
+      RAILS_DB_HOST: 127.0.0.1
+      RAILS_DB_PORT: 33066
+      RAILS_DB_USERNAME: hitobito
+      RAILS_DB_PASSWORD: hitobito
+      RAILS_DB_NAME: hitobito_test
+      RAILS_TEST_DB_NAME: hitobito_test
+
+    services:
+      mysql:
+        image: 'mysql:5.7'
+        env:
+          MYSQL_USER: 'hitobito'
+          MYSQL_PASSWORD: 'hitobito'
+          MYSQL_DATABASE: 'hitobito_test'
+          MYSQL_ROOT_PASSWORD: 'root'
+        ports:
+          - '33066:3306'
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 10
+      memcached:
+        image: 'memcached'
+        ports: [ '11211:11211' ]
+
+    steps:
+      - name: 'create default (hitobito) dir'
+        run: |
+          mkdir hitobito
+        working-directory: .
+
+      - name: 'Setup OS'
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get install sphinxsearch
+          echo "ruby version: $(ruby -v)"
+          echo "node version: $(node -v)"
+          echo "yarn version: $(yarn -v)"
+
+      - name: 'Extract branch name'
+        run: |
+          echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
+
+      - name: 'Choose branch for dependencies'
+        run: |
+          echo "BRANCH_NAME: $BRANCH_NAME"
+          HITOBITO_BRANCH=$([[ $BRANCH_NAME = 'stable' ]] && echo 'stable' || echo 'master')
+          echo "HITOBITO_BRANCH=$HITOBITO_BRANCH" >> $GITHUB_ENV
+
+      - name: 'Checkout hitobito'
+        uses: actions/checkout@v2
+        with:
+          repository: 'hitobito/hitobito'
+          ref: '${{ env.HITOBITO_BRANCH }}'
+          path: 'hitobito'
+
+      - name: 'Copy Wagonfile.ci'
+        run: |
+          cp -v Wagonfile.ci Wagonfile
+
+      - name: 'Set up Ruby'
+        env:
+          ImageOS: ubuntu20
+        uses: ruby/setup-ruby@v1.66.0
+        with:
+          working-directory: hitobito
+
+      - name: 'Checkout hitobito-<%= wagon_name %>'
+        uses: actions/checkout@v2
+        with:
+          path: 'hitobito_<%= wagon_name %>'
+
+      - name: 'create cache key'
+        run: cp Gemfile.lock Gemfile.lock.backup
+
+      - uses: actions/cache@v2
+        with:
+          path: hitobito/vendor/bundle
+          key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
+          restore-keys: |
+            ${{ runner.os }}-ruby-bundle-
+
+      - uses: actions/cache@v2
+        with:
+          path: hitobito_<%= wagon_name %>/vendor/bundle
+          key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
+          restore-keys: |
+            ${{ runner.os }}-ruby-bundle-
+
+      - name: 'Bundle install core'
+        run: |
+          bundle install --jobs 4 --retry 3 --path vendor/bundle
+
+      - name: 'Make changes to Gemfile.lock transparent'
+        run: |
+          git diff Gemfile.lock || true
+
+      - name: 'Bundle install wagons'
+        run: |
+          hitobito_dir=$(realpath ./)
+          for d in $hitobito_dir/../hitobito_*; do
+            cd $d
+            cp -v $hitobito_dir/Gemfile.lock ./
+            bundle install --jobs 4 --retry 3 --path vendor/bundle
+          done
+
+      - uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+
+      - name: 'Yarn install'
+        run: |
+          yarn install --frozen-lockfile
+
+      - name: 'Run Webpacker'
+        run: |
+          RAILS_ENV=test bundle exec rake webpacker:compile
+
+      - name: 'Run Wagon Lint and Tests'
+        run: |
+          bundle exec rake db:create ci:wagon --trace


### PR DESCRIPTION
I have chosen a simple approach that does not need altering the wagons-gem. I am telling myself that it is also good because it is specific to our repo, handled by documentation and helper-scripts.

The more clean approach would be to update the generator in the wagons-gem, so that it also copies and processes directories that start with a dot. But that is a another PR and shall be created another time.