### PR TITLE
Events in the same layer should still be visible to anyone

### DIFF
--- a/app/abilities/event_ability.rb
+++ b/app/abilities/event_ability.rb
@@ -13,7 +13,7 @@ class EventAbility < AbilityDsl::Base
   on(Event) do
     class_side(:list_available, :typeahead).if_any_role
 
-    permission(:any).may(:show).if_globally_visible_or_participating
+    permission(:any).may(:show).in_same_layer_or_globally_visible_or_participating
 
     permission(:any).may(:index_participations)
                     .for_participations_read_events_or_visible_fellow_participants
@@ -55,6 +55,11 @@ class EventAbility < AbilityDsl::Base
     class_side(:list_available).everybody
     class_side(:list_all).if_full_permission_in_course_layer
     class_side(:export_list).if_layer_and_below_full_on_root
+  end
+
+  def in_same_layer_or_globally_visible_or_participating
+    if_globally_visible_or_participating ||
+      contains_any?(user.groups.map(&:layer_group_id), subject.groups.map(&:layer_group_id))
   end
 
   def if_globally_visible_or_participating

--- a/spec/abilities/event_ability_spec.rb
+++ b/spec/abilities/event_ability_spec.rb
@@ -570,20 +570,28 @@ describe EventAbility do
         is_expected.not_to be_able_to(:index_participations, other)
       end
 
-      it 'may not see sibling group events' do
+      it 'may see sibling group events' do
         other = Fabricate(:event, groups: [groups(:bottom_group_one_two)], globally_visible: false)
+        is_expected.to be_able_to(:show, other)
+      end
+
+      it 'may not see sibling layer events' do
+        sibling_layer = Fabricate(group.layer_group.type.to_sym, parent: group.layer_group.parent, name: 'SecondTopper')
+        other = Fabricate(:event, groups: [sibling_layer], globally_visible: false)
         is_expected.not_to be_able_to(:show, other)
       end
 
-      it 'may see sibling group events with a token' do
-        other = Fabricate(:event, groups: [groups(:bottom_group_one_two)], globally_visible: false,
+      it 'may see sibling layer events with a token' do
+        sibling_layer = Fabricate(group.layer_group.type.to_sym, parent: group.layer_group.parent, name: 'SecondTopper')
+        other = Fabricate(:event, groups: [sibling_layer], globally_visible: false,
                                   shared_access_token: token)
         user.shared_access_token = token
         is_expected.to be_able_to(:show, other)
       end
 
-      it 'may see sibling group globally visible events' do
-        other = Fabricate(:event, groups: [groups(:bottom_group_one_two)], globally_visible: true)
+      it 'may see sibling layer\'s globally visible events' do
+        sibling_layer = Fabricate(group.layer_group.type.to_sym, parent: group.layer_group.parent, name: 'SecondTopper')
+        other = Fabricate(:event, groups: [sibling_layer], globally_visible: true)
         is_expected.to be_able_to(:show, other)
       end
 
@@ -680,23 +688,29 @@ describe EventAbility do
         is_expected.to be_able_to(:show, other)
       end
 
-      it 'may not see sibling layers events' do
+      it 'may see sibling group events' do
         sibling_group = Fabricate(group.type.to_sym, parent: group.parent, name: 'SecondTopper')
         other = Fabricate(:event, groups: [sibling_group], globally_visible: false)
+        is_expected.to be_able_to(:show, other)
+      end
+
+      it 'may not see sibling layer events' do
+        sibling_layer = Fabricate(group.layer_group.type.to_sym, parent: group.layer_group.parent, name: 'SecondTopper')
+        other = Fabricate(:event, groups: [sibling_layer], globally_visible: false)
         is_expected.not_to be_able_to(:show, other)
       end
 
-      it 'may see sibling layers events' do
-        sibling_group = Fabricate(group.type.to_sym, parent: group.parent, name: 'SecondTopper')
-        other = Fabricate(:event, groups: [sibling_group], globally_visible: false,
+      it 'may see sibling layers events with access token' do
+        sibling_layer = Fabricate(group.layer_group.type.to_sym, parent: group.layer_group.parent, name: 'SecondTopper')
+        other = Fabricate(:event, groups: [sibling_layer], globally_visible: false,
                                   shared_access_token: token)
         user.shared_access_token = token
         is_expected.to be_able_to(:show, other)
       end
 
       it 'may see sibling layers globally visible events' do
-        sibling_group = Fabricate(group.type.to_sym, parent: group.parent, name: 'SecondTopper')
-        other = Fabricate(:event, groups: [sibling_group], globally_visible: true)
+        sibling_layer = Fabricate(group.layer_group.type.to_sym, parent: group.layer_group.parent, name: 'SecondTopper')
+        other = Fabricate(:event, groups: [sibling_layer], globally_visible: true)
         is_expected.to be_able_to(:show, other)
       end
     end


### PR DESCRIPTION
The following sentence in the original ticket was disregarded during the implementation of #1047: "Die Events des eigenen Kantons sollen aber weiterhin sichtbar bleiben."
This means that, even when I have no permissions (such as a bottom member in a group), having any role in a group in the layer should be enough to allow me to see the events of the layer.

See also https://help.puzzle.ch/#ticket/zoom/3370