### PR TITLE
Attempt to fix node.js version in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,11 @@ jobs:
         uses: ruby/setup-ruby@v1.66.0
         env:
           ImageOS: ubuntu20
+      
+      - name: 'Set up Node'
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
 
       - name: 'Setup OS'
         run: |

--- a/bin/active_wagon.rb
+++ b/bin/active_wagon.rb
@@ -18,7 +18,7 @@ class Setup
     write_and_copy('.envrc', environment)
     write_and_copy('.tool-versions', <<~TOOL_VERSION)
       ruby #{USED_RUBY_VERSION}
-      node 14.18.1
+      nodejs 14.18.1
       yarn 1.22.17
     TOOL_VERSION
     write_and_copy('.ruby-version', USED_RUBY_VERSION)

--- a/bin/active_wagon.rb
+++ b/bin/active_wagon.rb
@@ -18,8 +18,8 @@ class Setup
     write_and_copy('.envrc', environment)
     write_and_copy('.tool-versions', <<~TOOL_VERSION)
       ruby #{USED_RUBY_VERSION}
-      nodejs 12.16.2
-      yarn 1.22.10
+      node 14.18.1
+      yarn 1.22.17
     TOOL_VERSION
     write_and_copy('.ruby-version', USED_RUBY_VERSION)
     write('Wagonfile', gemfile)


### PR DESCRIPTION
We can explicitly choose a node version by using the `setup-node` action. Otherwise, GitHub will just install the newest official Node version in the runner images, without prior warning as it seems.