### PR TITLE
Delete sessions before securing them

### DIFF
--- a/db/migrate/20211125155817_upgrade_sessions_to_secure_storage.rb
+++ b/db/migrate/20211125155817_upgrade_sessions_to_secure_storage.rb
@@ -2,8 +2,9 @@
 
 class UpgradeSessionsToSecureStorage < ActiveRecord::Migration[6.1]
   def up
-    say_with_time('securing sessions...') do
-      ActionDispatch::Session::ActiveRecordStore.session_class.find_each(&:secure!)
-    end
+    session_class = ActionDispatch::Session::ActiveRecordStore.session_class
+
+    say_with_time('deleting sessions...') { session_class.delete_all }
+    say_with_time('securing sessions...') { session_class.find_each(&:secure!) }
   end
 end


### PR DESCRIPTION
Right now, this means that there are no sessions left to secure. If for
any reason a session cannot be deleted, it will be secured. This way,
all sessions are secured.

The deletion seems necessary because the serialization format has
changed.