### PR TITLE
Repair fatal json decode

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,15 +1,17 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
 # Used to generate static error pages with the application layout:
 # RAILS_GROUPS=assets rails generate error_page {status}
+#
+# Can also be used for dynamic error pages if those static files do not exist.
 class ErrorsController < ActionController::Base
   layout 'application'
-  helper_method :current_user, :origin_user
+  helper_method :current_person, :current_user, :origin_user
 
   protect_from_forgery with: :exception
 
@@ -23,6 +25,10 @@ class ErrorsController < ActionController::Base
   private
 
   def current_user
+    nil
+  end
+
+  def current_person
     nil
   end
 

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid


### PR DESCRIPTION
Dieser PR löst auf recht entspannte Weise zwei Probleme, die meist gleichzeitig auftreten. Die Fehler selbst lesen sich deutlich dramatischer:

1. `765: unexpected token at 'I"ZW9uoZhOFpHCdnPfgnQIA:EF'):` (nicht ganz, aber so ähnlich)
2. `fatal: machine stack overflow in critical region` (genau so, ohne weitere Info in Sentry)

Das erste führt zum zweiten. Der Hintergrund könnte ein Blogpost werden, die Lösung ist

- Fehlerseiten nicht dynamisch zu rendern oder zumindest die Cookies nicht zu prüfen
- `Rails.application.config.action_dispatch,cookies_serializer = :hybrid`