### PR TITLE
Email verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Hitobito Changelog
 
-## Unreleased
-* Jede Person kann jetzt Zwei-Faktor-Authentifizierung mit einer TOTP-App aktivieren. Für einzelne Rollen kann die Zwei-Faktor-Authentifizierung obligatorisch gemacht werden.
-
 ## Version 1.26
 
 * Anlässe: Die Kontaktperson wird auf Wunsch per E-Mail über neue Anmeldungen benachrichtigt. Die Benachrichtigung wird auf dem Anlass aktiviert (#1540).
+* Jede Person kann jetzt Zwei-Faktor-Authentifizierung mit einer TOTP-App aktivieren. Für einzelne Rollen kann die Zwei-Faktor-Authentifizierung obligatorisch gemacht werden.
+* Die Haupt-Mailadresse von Personen mit Login muss neu bestätigt werden nachdem sie geändert wurde (#957).
 
 ## Version 1.26
 

--- a/app/controllers/devise/hitobito/passwords_controller.rb
+++ b/app/controllers/devise/hitobito/passwords_controller.rb
@@ -32,6 +32,8 @@ class Devise::Hitobito::PasswordsController < Devise::PasswordsController
     confirmable_email = resource.pending_reconfirmation? ?
                             resource.unconfirmed_email : resource.email
 
+    return false if confirmable_email.blank? || resource.reset_password_sent_to.blank?
+
     # We may only confirm the email address which the reset password email was sent to.
     # If the email has been changed since sending the password reset email,
     # this would be an attack vector: An attacker could...

--- a/app/controllers/devise/hitobito/passwords_controller.rb
+++ b/app/controllers/devise/hitobito/passwords_controller.rb
@@ -29,13 +29,16 @@ class Devise::Hitobito::PasswordsController < Devise::PasswordsController
   def should_confirm_email?(resource)
     return false if resource.errors.present?
 
+    confirmable_email = resource.pending_reconfirmation? ?
+                            resource.unconfirmed_email.presence : resource.email
+
     # We may only confirm the email address which the reset password email was sent to.
     # If the email has been changed since sending the password reset email,
     # this would be an attack vector: An attacker could...
     # 1. request a password reset email to their owned address, but not click it yet
     # 2. change their email or have it changed to some address they don't own and can't confirm
     # 3. click the password reset link -> their new email address would mistakenly get confirmed
-    return false if resource.reset_password_sent_to != resource.email
+    return false if resource.reset_password_sent_to != confirmable_email
 
     true
   end

--- a/app/controllers/devise/hitobito/passwords_controller.rb
+++ b/app/controllers/devise/hitobito/passwords_controller.rb
@@ -5,11 +5,7 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
-require_dependency Devise::Engine.root.
-                                  join('app', 'controllers', 'devise', 'passwords_controller').
-                                  to_s
-
-class Devise::PasswordsController < DeviseController
+class Devise::Hitobito::PasswordsController < Devise::PasswordsController
 
   def successfully_sent?(resource)
     if resource.login?
@@ -20,3 +16,4 @@ class Devise::PasswordsController < DeviseController
   end
 
 end
+

--- a/app/controllers/devise/hitobito/passwords_controller.rb
+++ b/app/controllers/devise/hitobito/passwords_controller.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -13,6 +13,31 @@ class Devise::Hitobito::PasswordsController < Devise::PasswordsController
     else
       flash[:alert] = I18n.translate('devise.failure.signin_not_allowed')
     end
+  end
+
+  def update
+    super do |resource|
+      if should_confirm_email?(resource)
+        resource.reset_password_sent_to = nil
+        resource.confirm
+      end
+    end
+  end
+
+  private
+
+  def should_confirm_email?(resource)
+    return false if resource.errors.present?
+
+    # We may only confirm the email address which the reset password email was sent to.
+    # If the email has been changed since sending the password reset email,
+    # this would be an attack vector: An attacker could...
+    # 1. request a password reset email to their owned address, but not click it yet
+    # 2. change their email or have it changed to some address they don't own and can't confirm
+    # 3. click the password reset link -> their new email address would mistakenly get confirmed
+    return false if resource.reset_password_sent_to != resource.email
+
+    true
   end
 
 end

--- a/app/controllers/devise/hitobito/passwords_controller.rb
+++ b/app/controllers/devise/hitobito/passwords_controller.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.

--- a/app/controllers/devise/hitobito/passwords_controller.rb
+++ b/app/controllers/devise/hitobito/passwords_controller.rb
@@ -30,7 +30,7 @@ class Devise::Hitobito::PasswordsController < Devise::PasswordsController
     return false if resource.errors.present?
 
     confirmable_email = resource.pending_reconfirmation? ?
-                            resource.unconfirmed_email.presence : resource.email
+                            resource.unconfirmed_email : resource.email
 
     # We may only confirm the email address which the reset password email was sent to.
     # If the email has been changed since sending the password reset email,

--- a/app/controllers/devise/hitobito/registrations_controller.rb
+++ b/app/controllers/devise/hitobito/registrations_controller.rb
@@ -5,11 +5,7 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
-require_dependency Devise::Engine.root.
-                                  join('app', 'controllers', 'devise', 'registrations_controller').
-                                  to_s
-
-class Devise::RegistrationsController < DeviseController
+class Devise::Hitobito::RegistrationsController < Devise::RegistrationsController
 
   before_action :authorize_update_password, only: [:edit, :update]
   before_action :has_old_password, only: [:edit, :update]

--- a/app/controllers/devise/hitobito/sessions_controller.rb
+++ b/app/controllers/devise/hitobito/sessions_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -19,36 +19,29 @@ class Devise::Hitobito::SessionsController < Devise::SessionsController
                 if: :two_factor_authentication_pending?,
                 only: [:new]
 
-  module Json
-    def create
-      super do |resource|
-        return init_two_factor_auth(resource) if second_factor_required?(resource)
+  def create
+    super do |resource|
+      return init_two_factor_auth(resource) if second_factor_required?(resource)
 
-        if request.format == :json
-          resource.generate_authentication_token! unless resource.authentication_token?
-          render json: UserSerializer.new(resource, controller: self)
-          return
-        end
-      end
-    end
-
-    def second_factor_required?(resource)
-      resource.is_a?(Person) && resource.second_factor_required?
-    end
-  end
-
-  module OauthSigninLayout
-    private
-
-    def devise_layout
-      if params['oauth'] == 'true'
-        'oauth'
-      else
-        'application'
+      if request.format == :json
+        resource.generate_authentication_token! unless resource.authentication_token?
+        render json: UserSerializer.new(resource, controller: self)
+        return
       end
     end
   end
 
-  prepend Json
-  prepend OauthSigninLayout
+  private
+
+  def second_factor_required?(resource)
+    resource.is_a?(Person) && resource.second_factor_required?
+  end
+
+  def devise_layout
+    if params['oauth'] == 'true'
+      'oauth'
+    else
+      'application'
+    end
+  end
 end

--- a/app/controllers/devise/hitobito/sessions_controller.rb
+++ b/app/controllers/devise/hitobito/sessions_controller.rb
@@ -5,11 +5,7 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
-require_dependency Devise::Engine.root
-                                 .join('app', 'controllers', 'devise', 'sessions_controller')
-                                 .to_s
-
-class Devise::SessionsController < DeviseController
+class Devise::Hitobito::SessionsController < Devise::SessionsController
   layout :devise_layout
   include ::TwoFactor
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -39,6 +39,7 @@ class PeopleController < CrudController
 
   before_save :validate_household
   after_save :persist_household
+  after_save :show_email_change_info
 
   before_render_show :load_person_add_requests, if: -> { html_request? }
   before_render_show :load_grouped_person_tags, if: -> { html_request? }
@@ -263,6 +264,12 @@ class PeopleController < CrudController
     else
       { alert: I18n.t("#{controller_name}.#{action_name}_invalid_email") }
     end
+  end
+
+  def show_email_change_info
+    return unless entry.show_email_change_info?
+
+    flash[:notice] = I18n.t("#{controller_name}.#{action_name}_email_must_be_confirmed")
   end
 
 end

--- a/app/javascript/stylesheets/hitobito/_form.scss
+++ b/app/javascript/stylesheets/hitobito/_form.scss
@@ -627,3 +627,7 @@ input.switcher {
     }
   }
 }
+
+.hide-last:last-child {
+  display: none;
+}

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -75,9 +75,10 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
     :current_sign_in_at, :current_sign_in_ip, :encrypted_password, :id,
     :last_label_format_id, :failed_attempts, :last_sign_in_at, :last_sign_in_ip,
     :locked_at, :remember_created_at, :reset_password_token, :unlock_token,
-    :reset_password_sent_at, :sign_in_count, :updated_at, :updater_id,
+    :reset_password_sent_at, :reset_password_sent_to, :sign_in_count, :updated_at, :updater_id,
     :show_global_label_formats, :household_key, :event_feed_token, :family_key,
-    :two_factor_authentication, :encrypted_two_fa_secret
+    :two_factor_authentication, :encrypted_two_fa_secret,
+    :confirmation_token, :confirmed_at, :confirmation_sent_at, :unconfirmed_email
   ]
 
   FILTER_ATTRS = [ # rubocop:disable Style/MutableConstant meant to be extended in wagons

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -95,7 +95,8 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
          :rememberable,
          :trackable,
          :timeoutable,
-         :validatable
+         :validatable,
+         :confirmable
 
   include Groups
   include Contactable

--- a/app/models/person/devise_overrides.rb
+++ b/app/models/person/devise_overrides.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
@@ -7,7 +7,8 @@
 
 module Person::DeviseOverrides
 
-  def send_reset_password_instructions # from lib/devise/models/recoverable.rb
+  # from lib/devise/models/recoverable.rb
+  def send_reset_password_instructions
     persisted? && super
   end
 
@@ -42,7 +43,7 @@ module Person::DeviseOverrides
   end
 
   def set_reset_password_token
-    self.reset_password_sent_to = self.email
+    self.reset_password_sent_to = email
     super
   end
 

--- a/app/models/person/devise_overrides.rb
+++ b/app/models/person/devise_overrides.rb
@@ -38,13 +38,7 @@ module Person::DeviseOverrides
   end
 
   def generate_reset_password_token!
-    raw, enc = Devise.token_generator.generate(self.class, :reset_password_token)
-
-    self.reset_password_token   = enc
-    self.reset_password_sent_at = Time.now.utc
-    save!(validate: false)
-
-    raw
+    set_reset_password_token.tap { save!(validate: false) }
   end
 
   def generate_authentication_token!

--- a/app/models/person/devise_overrides.rb
+++ b/app/models/person/devise_overrides.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -39,6 +39,11 @@ module Person::DeviseOverrides
 
   def generate_reset_password_token!
     set_reset_password_token.tap { save!(validate: false) }
+  end
+
+  def set_reset_password_token
+    self.reset_password_sent_to = self.email
+    super
   end
 
   def generate_authentication_token!

--- a/app/models/person/devise_overrides.rb
+++ b/app/models/person/devise_overrides.rb
@@ -11,6 +11,27 @@ module Person::DeviseOverrides
     persisted? && super
   end
 
+  def confirmation_required?
+    password? && super
+  end
+
+  def reconfirmation_required?
+    password? && super
+  end
+
+  def postpone_email_change?
+    password? && super
+  end
+
+  def postpone_email_change_until_confirmation_and_regenerate_confirmation_token
+    super
+    @show_email_change_info = true
+  end
+
+  def show_email_change_info?
+    @show_email_change_info.present?
+  end
+
   def clear_reset_password_token!
     clear_reset_password_token
     save(validate: false)

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,0 +1,12 @@
+%h2= t('.resend_confirmation_instructions')
+
+= standard_form(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+  = render "shared/error_messages", errors: resource.errors
+
+  %div.field
+    = f.labeled_input_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email)
+
+  = f.indented(submit_button(f, t('.submit')))
+
+  = f.indented do
+    = render "devise/shared/links"

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -1,0 +1,8 @@
+%p= t('.body.greeting', name: @resource.full_name)
+
+%p= t('.body.information_html')
+
+%p= link_to t('.body.link_text', email: @email), confirmation_url(@resource, confirmation_token: @token)
+
+%br
+%p= t('.body.footer')

--- a/app/views/devise/sessions/_form.html.haml
+++ b/app/views/devise/sessions/_form.html.haml
@@ -11,4 +11,7 @@
   = f.labeled_input_field(:password)
   = f.labeled_boolean_field(:remember_me)
   = f.indented(submit_button(f, t('.sign_in')))
-  = f.indented(link_to t('layouts.unauthorized.forgot_password'), new_person_password_path)
+  = f.indented do
+    = link_to t('layouts.unauthorized.forgot_password'), new_person_password_path
+    |
+    = link_to t('layouts.unauthorized.need_confirmation_email'), new_person_confirmation_path

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,0 +1,25 @@
+- if controller_name != 'sessions'
+  = link_to t('devise.sessions.new.sign_in'), new_session_path(resource_name)
+  %span.hide-last
+    |
+-# if devise_mapping.registerable? && controller_name != 'registrations'
+  = link_to "Sign up", new_registration_path(resource_name)
+  %span.hide-last
+    |
+- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+  = link_to t('layouts.unauthorized.forgot_password'), new_password_path(resource_name)
+  %span.hide-last
+    |
+- if devise_mapping.confirmable? && controller_name != 'confirmations'
+  = link_to t('layouts.unauthorized.need_confirmation_email'), new_confirmation_path(resource_name)
+  %span.hide-last
+    |
+-# if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
+  %span.hide-last
+    |
+-# if devise_mapping.omniauthable?
+  - resource_class.omniauth_providers.each do |provider|
+    %span
+      |
+    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post

--- a/app/views/layouts/oauth.html.haml
+++ b/app/views/layouts/oauth.html.haml
@@ -50,11 +50,11 @@
                 %br/
               = app_version_links
 
-              = link_to t('layouts.application.source_code'), 'https://github.com/hitobito', target: '_blank'
-              = t('layouts.application.available_under_license')
+              = link_to t('layouts.footer.source_code'), 'https://github.com/hitobito', target: '_blank'
+              = t('layouts.footer.available_under_license')
               = link_to 'GNU Affero General Public License', 'http://www.gnu.org/licenses/agpl-3.0.html', target: '_blank'
               %br/
-              = t('layouts.application.developed_by')
+              = t('layouts.footer.developed_by')
               = link_to 'Hitobito', 'http://hitobito.ch', target: '_blank'
               2012 -
               = Time.zone.now.year

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -145,7 +145,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = false
+  config.reconfirmable = true
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [ :email ]

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -226,14 +226,6 @@ de:
       send_instructions: 'Du erhältst in wenigen Minuten eine E-Mail, mit der Du Deine E-Mail-Adresse bestätigen kannst.'
       send_paranoid_instructions: 'Falls Deine E-Mail-Adresse in unserer Datenbank existiert erhältst Du in wenigen Minuten eine E-Mail mit der Du sie bestätigen kannst.'
       confirmed: 'Vielen Dank für die Bestätigung deiner E-Mail-Adresse. Du kannst dich jetzt anmelden.'
-    registrations:
-      signed_up: 'Du hast dich erfolgreich registriert.'
-      signed_up_but_unconfirmed: 'Du hast Dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account noch nicht bestätigt ist. Du erhältst in Kürze eine E-Mail mit der Anleitung, wie Du Deinen Account freischalten kannst.'
-      signed_up_but_inactive: 'Du hast dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account inaktiv ist.'
-      signed_up_but_locked: 'Du hast dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account gesperrt ist.'
-      updated: 'Dein Passwort wurde aktualisiert.'
-      update_needs_confirmation: "Deine Daten wurden aktualisiert, aber Du musst Deine neue E-Mail-Adresse bestätigen. Du erhälsts in wenigen Minuten eine E-Mail, mit der Du die Änderung Deiner E-Mail-Adresse abschließen kannst."
-      destroyed: 'Dein Account wurde gelöscht.'
     unlocks:
       send_instructions: 'Du erhältst in wenigen Minuten eine E-Mail mit der Anleitung, wie Du Deinen Account entsperren können.'
       unlocked: 'Dein Account wurde erfolgreich entsperrt.'
@@ -242,6 +234,14 @@ de:
       success: 'Du hast Dich erfolgreich mit Deinem %{kind}-Account angemeldet.'
       failure: 'Du konntest nicht Deinem %{kind}-Account angemeldet werden, weil "%{reason}".'
     registrations:
+      signed_up: 'Du hast dich erfolgreich registriert.'
+      signed_up_but_unconfirmed: 'Du hast Dich erfolgreich registriert. Du erhältst in Kürze eine E-Mail mit der Anleitung, wie Du Deinen Account freischalten kannst.'
+      signed_up_but_inactive: 'Du hast dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account inaktiv ist.'
+      signed_up_but_locked: 'Du hast dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account gesperrt ist.'
+      signed_up_but_no_email: 'Du hast dich erfolgreich registriert. Wir konnten Dich nicht anmelden, da du keine Mailadresse angegeben hast.'
+      updated: 'Dein Passwort wurde aktualisiert.'
+      update_needs_confirmation: "Deine Daten wurden aktualisiert, aber Du musst Deine neue E-Mail-Adresse bestätigen. Du erhältst in wenigen Minuten eine E-Mail, mit der Du die Änderung Deiner E-Mail-Adresse abschließen kannst."
+      destroyed: 'Dein Account wurde gelöscht.'
       edit:
         change_password: "Passwort ändern"
         set_password: "Passwort setzen"

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -250,11 +250,11 @@ de:
 
     mailer:
       confirmation_instructions:
-        subject: 'Anleitung zur Bestätigung Deines Accounts'
+        subject: 'Anleitung zur Bestätigung Deiner E-Mail-Adresse'
         body:
           greeting: 'Hallo %{name}!'
           information_html: 'Du kannst deine E-Mail-Adresse mit dem folgenden Link bestätigen:'
-          link_text: 'Mailadresse %{email} bestätigen'
+          link_text: '%{email} bestätigen'
           footer: 'Diese E-Mail wurde von Hitobito gesendet'
       reset_password_instructions:
         subject: 'Anleitung für das Setzen Deines Passworts'
@@ -1324,6 +1324,8 @@ de:
     send_password_instructions: Login Informationen wurden verschickt.
     send_password_instructions_invalid_email: Die Login-Informationen wurden nicht verschickt da die hinterlegte E-Mail Adresse ungültig ist.
     years_old: (%{years} Jahre alt)
+
+    update_email_must_be_confirmed: Die geänderte E-Mail-Adresse muss noch bestätigt werden, bevor sie aktiv wird.
 
     tabs:
       history: Verlauf

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -220,9 +220,9 @@ de:
       new:
         reset_password_button: 'Passwort zurücksetzen'
     confirmations:
-      send_instructions: 'Du erhältst in wenigen Minuten eine E-Mail, mit der Du Deine Registrierung bestätigen kannst.'
-      send_paranoid_instructions: 'Falls Deine E-Mail-Adresse in unserer Datenbank existiert erhältst Du in wenigen Minuten eine E-Mail mit der Du Deine Registrierung bestätigen kannst.'
-      confirmed: 'Vielen Dank für Deine Registrierung. Du bist jetzt angemeldet.'
+      send_instructions: 'Du erhältst in wenigen Minuten eine E-Mail, mit der Du Deine E-Mail-Adresse bestätigen kannst.'
+      send_paranoid_instructions: 'Falls Deine E-Mail-Adresse in unserer Datenbank existiert erhältst Du in wenigen Minuten eine E-Mail mit der Du sie bestätigen kannst.'
+      confirmed: 'Vielen Dank für die Bestätigung deiner E-Mail-Adresse. Du kannst dich jetzt anmelden.'
     registrations:
       signed_up: 'Du hast dich erfolgreich registriert.'
       signed_up_but_unconfirmed: 'Du hast Dich erfolgreich registriert. Wir konnten Dich noch nicht anmelden, da Dein Account noch nicht bestätigt ist. Du erhältst in Kürze eine E-Mail mit der Anleitung, wie Du Deinen Account freischalten kannst.'
@@ -251,6 +251,11 @@ de:
     mailer:
       confirmation_instructions:
         subject: 'Anleitung zur Bestätigung Deines Accounts'
+        body:
+          greeting: 'Hallo %{name}!'
+          information_html: 'Du kannst deine E-Mail-Adresse mit dem folgenden Link bestätigen:'
+          link_text: 'Mailadresse %{email} bestätigen'
+          footer: 'Diese E-Mail wurde von Hitobito gesendet'
       reset_password_instructions:
         subject: 'Anleitung für das Setzen Deines Passworts'
       unlock_instructions:
@@ -259,7 +264,7 @@ de:
           greeting: 'Hallo %{name}!'
           information_html: 'Dein Account wurde aufgrund von zu vielen Fehlversuchen beim Login gesperrt.<br>Klicke auf den folgenden Link um Deinen Account zu entsperren:'
           link_text: 'Meinen Account entsperren'
-          footer: 'Dieses E-Mail wurde von Hitobito gesendet'
+          footer: 'Diese E-Mail wurde von Hitobito gesendet'
 
   errors:
     link_to_main: 'Hauptseite'

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -220,6 +220,9 @@ de:
       new:
         reset_password_button: 'Passwort zurücksetzen'
     confirmations:
+      new:
+        resend_confirmation_instructions: 'E-Mail-Adresse bestätigen'
+        submit: 'Bestätigungs-E-Mail senden'
       send_instructions: 'Du erhältst in wenigen Minuten eine E-Mail, mit der Du Deine E-Mail-Adresse bestätigen kannst.'
       send_paranoid_instructions: 'Falls Deine E-Mail-Adresse in unserer Datenbank existiert erhältst Du in wenigen Minuten eine E-Mail mit der Du sie bestätigen kannst.'
       confirmed: 'Vielen Dank für die Bestätigung deiner E-Mail-Adresse. Du kannst dich jetzt anmelden.'
@@ -890,6 +893,7 @@ de:
 
     unauthorized:
       forgot_password: 'Passwort vergessen?'
+      need_confirmation_email: 'Keine Bestätigungs-E-Mail bekommen?'
 
     footer:
       available_under_license: 'verfügbar unter der'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -309,7 +309,11 @@ Hitobito::Application.routes.draw do
     resources :help_texts, except: [:show]
 
     devise_for :service_tokens, only: [:sessions]
-    devise_for :people, skip: [:registrations], path: "users"
+    devise_for :people, skip: [:registrations], path: "users", controllers: {
+        passwords: 'devise/hitobito/passwords',
+        registrations: 'devise/hitobito/registrations',
+        sessions: 'devise/hitobito/sessions'
+    }
     as :person do
       get 'users/edit' => 'devise/registrations#edit', :as => 'edit_person_registration'
       put 'users' => 'devise/registrations#update', :as => 'person_registration'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -315,9 +315,9 @@ Hitobito::Application.routes.draw do
         sessions: 'devise/hitobito/sessions'
     }
     as :person do
-      get 'users/edit' => 'devise/registrations#edit', :as => 'edit_person_registration'
-      put 'users' => 'devise/registrations#update', :as => 'person_registration'
-      get 'users' => 'devise/registrations#edit' # route required for language switch
+      get 'users/edit' => 'devise/hitobito/registrations#edit', :as => 'edit_person_registration'
+      put 'users' => 'devise/hitobito/registrations#update', :as => 'person_registration'
+      get 'users' => 'devise/hitobito/registrations#edit' # route required for language switch
 
       get 'users/second_factor' => 'second_factor_authentication#new', as: 'new_users_second_factor'
       post 'users/second_factor' => 'second_factor_authentication#create', as: 'users_second_factor'

--- a/db/migrate/20211217170000_add_devise_confirmable_to_person.rb
+++ b/db/migrate/20211217170000_add_devise_confirmable_to_person.rb
@@ -1,0 +1,28 @@
+#  frozen_string_literal: true
+
+#  Copyright (c) 2021, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class AddDeviseConfirmableToPerson < ActiveRecord::Migration[6.1]
+  # Note: We can't use change, as User.update_all will fail in the down migration
+  def up
+    add_column :people, :confirmation_token, :string
+    add_column :people, :confirmed_at, :datetime
+    add_column :people, :confirmation_sent_at, :datetime
+    add_column :people, :unconfirmed_email, :string # Only if using reconfirmable
+    add_index :people, :confirmation_token, unique: true
+    Person.reset_column_information # Need for some types of updates, but not for update_all.
+    # To avoid a short time window between running the migration and updating all existing
+    # people as confirmed, do the following
+    Person.update_all confirmed_at: DateTime.now
+    # All existing user accounts should be able to log in after this.
+  end
+
+  def down
+    remove_index :people, :confirmation_token
+    remove_columns :people, :confirmation_token, :confirmed_at, :confirmation_sent_at
+    remove_columns :people, :unconfirmed_email # Only if using reconfirmable
+  end
+end

--- a/db/migrate/20220106150000_add_reset_password_sent_to_to_person.rb
+++ b/db/migrate/20220106150000_add_reset_password_sent_to_to_person.rb
@@ -1,0 +1,12 @@
+#  frozen_string_literal: true
+
+#  Copyright (c) 2021, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class AddResetPasswordSentToToPerson < ActiveRecord::Migration[6.1]
+  def change
+    add_column :people, :reset_password_sent_to, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -751,6 +751,7 @@ ActiveRecord::Schema.define(version: 2022_01_13_064557) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "reset_password_sent_to"
     t.index ["authentication_token"], name: "index_people_on_authentication_token"
     t.index ["confirmation_token"], name: "index_people_on_confirmation_token", unique: true
     t.index ["email"], name: "index_people_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -747,7 +747,12 @@ ActiveRecord::Schema.define(version: 2022_01_13_064557) do
     t.string "family_key"
     t.integer "two_factor_authentication"
     t.text "encrypted_two_fa_secret"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
     t.index ["authentication_token"], name: "index_people_on_authentication_token"
+    t.index ["confirmation_token"], name: "index_people_on_confirmation_token", unique: true
     t.index ["email"], name: "index_people_on_email", unique: true
     t.index ["event_feed_token"], name: "index_people_on_event_feed_token", unique: true
     t.index ["first_name"], name: "index_people_on_first_name"

--- a/db/seeds/root.rb
+++ b/db/seeds/root.rb
@@ -8,7 +8,8 @@
 Person.seed(:email,
   {company_name: 'Puzzle ITC',
    company: true,
-   email: Settings.root_email}
+   email: Settings.root_email,
+   confirmed_at: Time.now}
 )
 
 

--- a/db/seeds/support/person_seeder.rb
+++ b/db/seeds/support/person_seeder.rb
@@ -43,6 +43,7 @@ class PersonSeeder
     else
       attrs[:nickname] = Faker::Lorem.words(number: 1).first.capitalize
     end
+    attrs[:confirmed_at] = Time.now
 
     attrs
   end
@@ -71,7 +72,8 @@ class PersonSeeder
     first, last = name.split
     attrs = standard_attributes(first, last).merge({
       email: email,
-      encrypted_password: encrypted_password
+      encrypted_password: encrypted_password,
+      confirmed_at: Time.now
     }).reject do |key, _value|
       %i(
         address

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -35,6 +35,7 @@ describe DashboardController do
 
       it 'redirects to user home if logged in' do
         person = people(:top_leader)
+        person.confirm
         person.generate_authentication_token!
         get :index, params: { user_email: person.email, user_token: person.authentication_token }, format: :json
         is_expected.to redirect_to(group_person_path(person.groups.first, person, format: :json))

--- a/spec/controllers/devise/hitobito/passwords_controller_spec.rb
+++ b/spec/controllers/devise/hitobito/passwords_controller_spec.rb
@@ -7,7 +7,7 @@
 
 require 'spec_helper'
 
-describe Devise::PasswordsController do
+describe Devise::Hitobito::PasswordsController do
   let(:bottom_group) { groups(:bottom_group_one_one) }
 
   before do

--- a/spec/controllers/devise/hitobito/registrations_controller_spec.rb
+++ b/spec/controllers/devise/hitobito/registrations_controller_spec.rb
@@ -7,7 +7,7 @@
 
 require 'spec_helper'
 
-describe Devise::RegistrationsController do
+describe Devise::Hitobito::RegistrationsController do
   before { request.env['devise.mapping'] = Devise.mappings[:person] }
   render_views
 

--- a/spec/controllers/devise/hitobito/sessions_controller_spec.rb
+++ b/spec/controllers/devise/hitobito/sessions_controller_spec.rb
@@ -7,7 +7,7 @@
 
 require 'spec_helper'
 
-describe Devise::SessionsController do
+describe Devise::Hitobito::SessionsController do
   let(:bottom_group) { groups(:bottom_group_one_one) }
   let(:role) { Fabricate('Group::BottomGroup::Member', group: bottom_group) }
   let(:person) do

--- a/spec/controllers/groups/self_registration_controller_spec.rb
+++ b/spec/controllers/groups/self_registration_controller_spec.rb
@@ -121,7 +121,7 @@ describe Groups::SelfRegistrationController do
           expect(role.type).to eq(Group::TopGroup::Member.sti_name)
           expect(role.group).to eq(group)
 
-          is_expected.to redirect_to(edit_group_person_path(group.id, person.id))
+          is_expected.to redirect_to(new_person_session_path)
         end
       end
     end

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -341,7 +341,7 @@ describe PeopleController do
     end
 
     context 'PUT update' do
-      let(:person) { people(:bottom_member) }
+      let(:person) { people(:bottom_member).tap { |p| p.update_columns(encrypted_password: nil) } }
       let(:group) { person.groups.first }
 
       it 'as admin updates email with password' do
@@ -669,7 +669,7 @@ describe PeopleController do
       end
 
       it 'does not send instructions if e-mail invalid' do
-        person.update_attribute(:email, 'dude@domainungueltig42.ch')
+        person.update_column(:email, 'dude@domainungueltig42.ch')
 
         expect do
           post :send_password_instructions, params: { group_id: groups(:bottom_layer_one).id, id: person.id }, format: :js
@@ -800,6 +800,8 @@ describe PeopleController do
   context 'as api user' do
 
     describe 'GET #show' do
+      before { top_leader.confirm }
+
       it 'redirects when token is nil' do
         get :show, params: { group_id: group.id, id: top_leader.id, user_token: '', user_email: top_leader.email }
         is_expected.to redirect_to new_person_session_path
@@ -941,6 +943,7 @@ describe PeopleController do
   end
 
   context 'with valid oauth token' do
+    before { top_leader.confirm }
     let(:token) { instance_double('Oauth::AccessToken', acceptable?: true, accessible?: true, person: top_leader) }
 
     before do

--- a/spec/controllers/people_filters_controller_spec.rb
+++ b/spec/controllers/people_filters_controller_spec.rb
@@ -35,8 +35,7 @@ describe PeopleFiltersController do
 
       it 'translates invalid e-mail tags' do
         allow(Truemail).to receive(:valid?).and_call_original
-        user.email = 'not-an-email'
-        user.save!(validate: false)
+        user.update_columns(email: 'not-an-email')
         AdditionalEmail
           .new(contactable: user,
                email: 'mail@nodomain')

--- a/spec/decorators/paper_trail/version_decorator_spec.rb
+++ b/spec/decorators/paper_trail/version_decorator_spec.rb
@@ -78,7 +78,6 @@ describe PaperTrail::VersionDecorator, :draper_with_helpers, versioning: true do
 
       it { is_expected.to match(/<div>Ort wurde/) }
       it { is_expected.to match(/<div>PLZ wurde/) }
-      it { is_expected.to match(/<div>Haupt-E-Mail wurde/) }
     end
 
     context 'with association changes' do
@@ -200,7 +199,7 @@ describe PaperTrail::VersionDecorator, :draper_with_helpers, versioning: true do
   end
 
   def update
-    person.update!(town: 'Bern', zip_code: '3007', email: 'new@hito.example.com')
+    person.update!(town: 'Bern', zip_code: '3007')
   end
 
 end

--- a/spec/domain/contactable/email_validator_spec.rb
+++ b/spec/domain/contactable/email_validator_spec.rb
@@ -22,8 +22,7 @@ describe Contactable::EmailValidator do
   end
 
   it 'tags people with invalid primary e-mail' do
-    top_leader.email = 'not-an-email'
-    top_leader.save!(validate: false)
+    top_leader.update_columns(email: 'not-an-email')
 
     validator.validate_people
 
@@ -35,8 +34,7 @@ describe Contactable::EmailValidator do
   end
 
   it 'keeps existing invalid e-mail tag' do
-    top_leader.email = 'not-an-email'
-    top_leader.save!(validate: false)
+    top_leader.update_columns(email: 'not-an-email')
     create_invalid_additional_email(top_leader, 'not-an-email')
 
     validator.validate_people
@@ -66,8 +64,7 @@ describe Contactable::EmailValidator do
   end
 
   it 'tags people with invalid primary and additional e-mail' do
-    top_leader.email = 'not-an-email'
-    top_leader.save!(validate: false)
+    top_leader.update_columns(email: 'not-an-email')
     create_invalid_additional_email(top_leader, 'not-an-email')
 
     validator.validate_people

--- a/spec/domain/import/person_export_import_spec.rb
+++ b/spec/domain/import/person_export_import_spec.rb
@@ -43,7 +43,8 @@ describe 'export import person' do
     imported = Person.find_by_email('exporter@hitobito.example.org')
     expect(imported).not_to eq(exported)
 
-    excluded = %w(id created_at updated_at primary_group_id contact_data_visible email last_name)
+    excluded = %w(id created_at updated_at primary_group_id contact_data_visible email last_name
+                  confirmed_at)
     expect_attrs_equal(imported, exported, excluded)
 
     %w(phone_numbers social_accounts additional_emails).each do |assoc|

--- a/spec/domain/synchronize/mailchimp/client_spec.rb
+++ b/spec/domain/synchronize/mailchimp/client_spec.rb
@@ -50,7 +50,7 @@ describe Synchronize::Mailchimp::Client do
   context '#subscriber_body' do
 
     it 'strips whitespace from fields' do
-      top_leader.update(first_name: ' top ', last_name: ' leader ', email: ' top@example.com ')
+      top_leader.update_columns(first_name: ' top ', last_name: ' leader ', email: ' top@example.com ')
       body = client.subscriber_body(top_leader)
 
       expect(body[:email_address]).to eq 'top@example.com'

--- a/spec/fabricators/people_fabricator.rb
+++ b/spec/fabricators/people_fabricator.rb
@@ -14,6 +14,7 @@ Fabricator(:person) do
     last = attrs[:last_name]&.downcase&.gsub(/[^a-z]/, '')
     "#{first}.#{last}#{sequence}@hitobito.example.com"
   end
+  confirmed_at { 1.hour.ago }
 end
 
 Fabricator(:person_with_address, from: :person) do

--- a/spec/features/email_verification_spec.rb
+++ b/spec/features/email_verification_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+describe 'Email verification', js: true do
+
+  subject { page }
+  let(:group) { person.groups.first }
+  let(:password) { 'asdfasdfasdfasdf' }
+
+  context 'person without login' do
+    let(:me) { people(:top_leader) }
+    let(:person) do
+      person = people(:bottom_member)
+      person.update_columns(confirmed_at: nil, encrypted_password: nil)
+      person
+    end
+
+    before { sign_in(me) }
+
+    it 'should not require confirmation when creating with email' do
+      visit new_group_role_path(group_id: group.id)
+      click_link 'Neue Person erfassen'
+      fill_in 'role[new_person][first_name]', with: 'Test'
+      fill_in 'role[new_person][last_name]', with: 'User'
+      fill_in 'role[new_person][email]', with: 'someone@puzzle.ch'
+      first(:button, 'Speichern').click
+      is_expected.to have_text('wurde erfolgreich erstellt')
+      is_expected.to have_field('Haupt-E-Mail', with: 'someone@puzzle.ch')
+    end
+
+    it 'should not require confirmation when updating email' do
+      visit edit_group_person_path(group_id: group.id, id: person.id)
+      fill_in 'E-Mail', with: 'test@puzzle.ch'
+      expect do
+        first(:button, 'Speichern').click
+      end.to change { person.reload.email }.to('test@puzzle.ch')
+      is_expected.not_to have_text('E-Mail-Adresse muss noch bestätigt werden')
+    end
+  end
+
+  context 'person with login' do
+    let(:me) { people(:top_leader) }
+    let(:person) do
+      person = people(:bottom_member)
+      person.update_columns(confirmed_at: 1.hour.ago, encrypted_password: 'something')
+      person
+    end
+
+    before { sign_in(me) }
+
+    it 'should send confirmation email when updating email' do
+      visit edit_group_person_path(group_id: group.id, id: person.id)
+      fill_in 'E-Mail', with: 'test@puzzle.ch'
+      expect do
+        first(:button, 'Speichern').click
+      end.not_to change { person.reload.email }
+      is_expected.to have_text('E-Mail-Adresse muss noch bestätigt werden')
+    end
+  end
+
+  context 'unconfirmed person with login' do
+    let(:person) do
+      person = people(:bottom_member)
+      person.update(password: password)
+      person.update_columns(confirmed_at: nil)
+      person
+    end
+
+    it 'should prevent logging in' do
+      visit new_person_session_path
+      fill_in 'Haupt-E-Mail', with: person.email
+      fill_in 'person_password', with: password
+      click_button 'Anmelden'
+
+      is_expected.to have_text('Du musst Deinen Account bestätigen, bevor Du fortfahren kannst.')
+    end
+  end
+
+  context 'send_login' do
+    let(:me) { people(:top_leader) }
+    let(:person) do
+      person = people(:bottom_member)
+      person.update_columns(confirmed_at: nil)
+      person
+    end
+
+    it 'should auto-confirm email' do
+      link = click_send_login_button(person, me)
+      expect {
+        visit link
+        fill_in 'Neues Passwort', with: password
+        fill_in 'Neues Passwort bestätigen', with: password
+        click_button 'Passwort ändern'
+      }.to change { person.reload.confirmed_at }.from(nil)
+    end
+
+    it 'should not auto-confirm email which has changed in the meantime' do
+      link = click_send_login_button(person, me)
+      person.update(email: 'changed-email@puzzle.ch')
+      expect {
+        visit link
+        fill_in 'Neues Passwort', with: password
+        fill_in 'Neues Passwort bestätigen', with: password
+        click_button 'Passwort ändern'
+      }.not_to change { person.reload.confirmed_at }.from(nil)
+    end
+  end
+
+  context 'self-service password reset' do
+    let(:person) { people(:bottom_member) }
+
+    it 'should auto-confirm email' do
+      expect {
+        token = person.generate_reset_password_token!
+        visit edit_person_password_path(reset_password_token: token)
+        fill_in 'Neues Passwort', with: password
+        fill_in 'Neues Passwort bestätigen', with: password
+        click_button 'Passwort ändern'
+      }.to change { person.reload.confirmed_at }.from(nil)
+    end
+
+    it 'should not auto-confirm email which has changed in the meantime' do
+      expect {
+        token = person.generate_reset_password_token!
+        person.update(email: 'other-email@puzzle.ch')
+        visit edit_person_password_path(reset_password_token: token)
+        fill_in 'Neues Passwort', with: password
+        fill_in 'Neues Passwort bestätigen', with: password
+        click_button 'Passwort ändern'
+      }.not_to change { person.reload.confirmed_at }.from(nil)
+    end
+  end
+
+  context 'self-service event registration' do
+    it 'should auto-confirm email' do
+      # TODO
+    end
+
+    it 'should not auto-confirm email which has changed in the meantime' do
+      # TODO
+    end
+  end
+
+  context 'self-service group registration' do
+    it 'should auto-confirm email' do
+      # TODO
+    end
+
+    it 'should not auto-confirm email which has changed in the meantime' do
+      # TODO
+    end
+  end
+
+  def find_mail_to(email)
+    ActionMailer::Base.deliveries.find { |mail|
+      mail.to.include?(email)
+    }
+  end
+
+  def click_send_login_button(person, me)
+    Person::SendLoginJob.new(person, me).perform
+    mail = find_mail_to(person.email)
+    # Return the link sent in the mail
+    mail.body.raw_source[/href=\"https?:\/\/[^\/]+(\/[^\"]*)/,1]
+  end
+end

--- a/spec/features/email_verification_spec.rb
+++ b/spec/features/email_verification_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 #  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
-#  hitobito_cvp and licensed under the Affero General Public License version 3
+#  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
@@ -29,18 +29,18 @@ describe 'Email verification', js: true do
       click_link 'Neue Person erfassen'
       fill_in 'role[new_person][first_name]', with: 'Test'
       fill_in 'role[new_person][last_name]', with: 'User'
-      fill_in 'role[new_person][email]', with: 'someone@puzzle.ch'
+      fill_in 'role[new_person][email]', with: 'someone@example.com'
       first(:button, 'Speichern').click
       is_expected.to have_text('wurde erfolgreich erstellt')
-      is_expected.to have_field('Haupt-E-Mail', with: 'someone@puzzle.ch')
+      is_expected.to have_field('Haupt-E-Mail', with: 'someone@example.com')
     end
 
     it 'should not require confirmation when updating email' do
       visit edit_group_person_path(group_id: group.id, id: person.id)
-      fill_in 'E-Mail', with: 'test@puzzle.ch'
+      fill_in 'E-Mail', with: 'test@example.com'
       expect do
         first(:button, 'Speichern').click
-      end.to change { person.reload.email }.to('test@puzzle.ch')
+      end.to change { person.reload.email }.to('test@example.com')
       is_expected.not_to have_text('E-Mail-Adresse muss noch bestätigt werden')
     end
   end
@@ -57,7 +57,7 @@ describe 'Email verification', js: true do
 
     it 'should send confirmation email when updating email' do
       visit edit_group_person_path(group_id: group.id, id: person.id)
-      fill_in 'E-Mail', with: 'test@puzzle.ch'
+      fill_in 'E-Mail', with: 'test@example.com'
       expect do
         first(:button, 'Speichern').click
       end.not_to change { person.reload.email }
@@ -93,23 +93,23 @@ describe 'Email verification', js: true do
 
     it 'should auto-confirm email' do
       link = click_send_login_button(person, me)
-      expect {
+      expect do
         visit link
         fill_in 'Neues Passwort', with: password
         fill_in 'Neues Passwort bestätigen', with: password
         click_button 'Passwort ändern'
-      }.to change { person.reload.confirmed_at }.from(nil)
+      end.to change { person.reload.confirmed_at }.from(nil)
     end
 
     it 'should not auto-confirm email which has changed in the meantime' do
       link = click_send_login_button(person, me)
-      person.update(email: 'changed-email@puzzle.ch')
-      expect {
+      person.update!(email: 'changed-email@example.com')
+      expect do
         visit link
         fill_in 'Neues Passwort', with: password
         fill_in 'Neues Passwort bestätigen', with: password
         click_button 'Passwort ändern'
-      }.not_to change { person.reload.confirmed_at }.from(nil)
+      end.not_to change { person.reload.confirmed_at }.from(nil)
     end
   end
 
@@ -121,13 +121,13 @@ describe 'Email verification', js: true do
     end
 
     it 'should auto-confirm email' do
-      expect {
+      expect do
         token = person.generate_reset_password_token!
         visit edit_person_password_path(reset_password_token: token)
         fill_in 'Neues Passwort', with: password
         fill_in 'Neues Passwort bestätigen', with: password
         click_button 'Passwort ändern'
-      }.to change { person.reload.confirmed_at }.from(nil)
+      end.to change { person.reload.confirmed_at }.from(nil)
     end
 
     # Prevents the following scenario:
@@ -137,14 +137,14 @@ describe 'Email verification', js: true do
     # 4. The email change is effective immediately because no previous email was ever confirmed
     # 5. Attacker clicks the link from the password reset email and changes password. The new email must not be auto-confirmed.
     it 'should not auto-confirm email which has changed in the meantime' do
-      expect {
+      expect do
         token = person.generate_reset_password_token!
-        person.update(email: 'other-email@puzzle.ch')
+        person.update!(email: 'other-email@example.com')
         visit edit_person_password_path(reset_password_token: token)
         fill_in 'Neues Passwort', with: password
         fill_in 'Neues Passwort bestätigen', with: password
         click_button 'Passwort ändern'
-      }.not_to change { person.reload.confirmed_at }.from(nil)
+      end.not_to change { person.reload.confirmed_at }.from(nil)
     end
   end
 
@@ -152,43 +152,47 @@ describe 'Email verification', js: true do
     let(:person) do
       person = people(:bottom_member)
       person.confirm
-      person.update(email: 'newmail@puzzle.ch')
+      person.update!(email: 'newmail@example.com')
       person.reload
     end
 
     # Prevents the following scenario:
     # 1. Attacker has a verified email address which they control
-    # 2. Attacher changes email to an address which they don't own. Change is postponed, reconfirmation is pending
+    # 2. Attacher changes email to an address which they don't own.
+    #    Change is postponed, reconfirmation is pending
     # 3. Reconfirmation email is sent, but the attacker cannot receive it
     # 4. Attacker requests a password reset email, which is still sent to the old confirmed email
     # 5. Attacker changes password. The new email address must not be auto-confirmed.
     it 'should not auto-confirm email for security reasons' do
-      expect {
+      expect do
         token = person.generate_reset_password_token!
         visit edit_person_password_path(reset_password_token: token)
         fill_in 'Neues Passwort', with: password
         fill_in 'Neues Passwort bestätigen', with: password
         click_button 'Passwort ändern'
-      }.not_to change { person.reload.email }
+      end.not_to change { person.reload.email }
     end
 
     # Prevents the following scenario:
     # 1. Attacker has a verified email address which they control
-    # 2. Attacker changes email to an address which they own. Change is postponed, reconfirmation is pending
+    # 2. Attacker changes email to an address which they own. Change is
+    #    postponed, reconfirmation is pending
     # 3. Attacker receives confirmation email, but doesn't click the link
     # 4. Attacker requests a password reset email, which is still sent to the old confirmed email
-    # 5. Attacker changes email to an address which they don't own. Change is postponed, reconfirmation is pending
+    # 5. Attacker changes email to an address which they don't own. Change is
+    #    postponed, reconfirmation is pending
     # 6. Reconfirmation email is sent, but the attacker cannot receive it
-    # 7. Attacker clicks the link from the password reset email and changes password. The new email must not be auto-confirmed.
+    # 7. Attacker clicks the link from the password reset email and changes password.
+    #    The new email must not be auto-confirmed.
     it 'should not auto-confirm email which has changed again in the meantime' do
-      expect {
+      expect do
         token = person.generate_reset_password_token!
-        person.update(email: 'other-email@puzzle.ch')
+        person.update(email: 'other-email@example.com')
         visit edit_person_password_path(reset_password_token: token)
         fill_in 'Neues Passwort', with: password
         fill_in 'Neues Passwort bestätigen', with: password
         click_button 'Passwort ändern'
-      }.not_to change { person.reload.email }
+      end.not_to change { person.reload.email }
     end
   end
 
@@ -196,24 +200,24 @@ describe 'Email verification', js: true do
     let(:event) { events(:top_event) }
 
     before do
-      event.update(external_applications: true, )
+      event.update!(external_applications: true)
     end
 
     it 'should not confirm email' do
       visit register_group_event_path(group_id: event.groups.first.id, id: event.id)
-      first('#new_person #person_email').fill_in with: 'newguy@puzzle.ch'
+      first('#new_person #person_email').fill_in with: 'newguy@example.com'
       click_button 'Weiter'
       is_expected.to have_text 'Bitte fülle das folgende Formular aus, bevor du dich für den Anlass anmeldest.'
 
       fill_in 'Vorname', with: 'New'
       fill_in 'Nachname', with: 'Guy'
-      fill_in 'Haupt-E-Mail', with: 'newguy@puzzle.ch'
+      fill_in 'Haupt-E-Mail', with: 'newguy@example.com'
       first(:button, 'Speichern').click
       is_expected.to have_text 'Deine persönlichen Daten wurden aufgenommen.'
 
       click_button 'Anmelden'
-      is_expected.to have_text 'newguy@puzzle.ch'
-      expect(Person.find_by(email: 'newguy@puzzle.ch').confirmed?).to be_falsey
+      is_expected.to have_text 'newguy@example.com'
+      expect(Person.find_by(email: 'newguy@example.com').confirmed?).to be_falsey
     end
   end
 
@@ -228,12 +232,12 @@ describe 'Email verification', js: true do
       visit group_self_registration_path(group_id: group.id)
       fill_in 'Vorname', with: 'New'
       fill_in 'Nachname', with: 'Guy'
-      fill_in 'Haupt-E-Mail', with: 'newguy@puzzle.ch'
+      fill_in 'Haupt-E-Mail', with: 'newguy@example.com'
       first(:button, 'Speichern').click
       is_expected.to have_text 'Du hast Dich erfolgreich registriert. Du erhältst in Kürze eine E-Mail mit der Anleitung, wie Du Deinen Account freischalten kannst.'
-      expect(Person.find_by(email: 'newguy@puzzle.ch').confirmed?).to be_falsey
+      expect(Person.find_by(email: 'newguy@example.com').confirmed?).to be_falsey
 
-      mail = find_mail_to('newguy@puzzle.ch')
+      mail = find_mail_to('newguy@example.com')
       expect(mail.subject).to eq('Anleitung für das Setzen Deines Passworts')
     end
   end

--- a/spec/mailers/person/login_mailer_spec.rb
+++ b/spec/mailers/person/login_mailer_spec.rb
@@ -29,8 +29,8 @@ describe Person::LoginMailer do
 
   context 'with internationalized domain names' do
     before do
-     recipient.update!(email: 'member@exämple.com')
-     sender.update!(email: 'leader@exämple.com')
+     recipient.update_columns(email: 'member@exämple.com')
+     sender.update_columns(email: 'leader@exämple.com')
    end
 
     its(:to) { should == %w(member@xn--exmple-cua.com) }

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -578,8 +578,7 @@ describe Person do
     before { allow(Truemail).to receive(:valid?).and_call_original }
 
     before do
-      person.email = 'not-an-email'
-      person.save!(validate: false)
+      person.update_columns(email: 'not-an-email')
     end
 
     before do

--- a/spec/regressions/event/participation_contact_datas_controller_spec.rb
+++ b/spec/regressions/event/participation_contact_datas_controller_spec.rb
@@ -106,6 +106,8 @@ describe Event::ParticipationContactDatasController, type: :controller do
 
       person.reload
       expect(person.nickname).to eq('Jojo')
+
+      person.confirm
       expect(person.email).to eq('dude@example.com')
 
     end

--- a/spec/regressions/person/log_controller_spec.rb
+++ b/spec/regressions/person/log_controller_spec.rb
@@ -29,6 +29,7 @@ describe Person::LogController, type: :controller do
     it 'renders log in correct order' do
       Fabricate(:social_account, contactable: test_entry, label: 'Foo', name: 'Bar')
       test_entry.update!(town: 'Bern', zip_code: '3007', email: 'new@hito.example.com')
+      test_entry.confirm
       Fabricate(:phone_number, contactable: test_entry, label: 'Foo', number: '23425 1341 12')
       Person::AddRequest::Group.create!(
         person: test_entry,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -184,3 +184,11 @@ unless RSpec.configuration.exclusion_filter[:type] == 'feature'
 
   puts "Using chromedriver version #{Webdrivers::Chromedriver.current_version}"
 end
+
+Devise::Test::ControllerHelpers.prepend(Module.new do
+  # Make sure the email address is confirmed before logging in
+  def sign_in(resource, deprecated = nil, scope: nil, confirm: true)
+    resource.confirm if confirm
+    super(resource, deprecated, scope: scope)
+  end
+end)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,6 +89,8 @@ RSpec.configure do |config|
   config.before :all do
     # load all fixtures
     self.class.fixtures :all
+    Person.update_all(confirmed_at: Time.now)
+
     FileUtils.rm_rf(Dir.glob(AsyncDownloadFile::DIRECTORY.join('*')))
   end
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -7,8 +7,9 @@
 
 module FeatureHelpers
 
-  def sign_in(user = nil)
+  def sign_in(user = nil, confirm: true)
     user ||= people(:top_leader)
+    user.confirm if confirm
     login_as(user, scope: :person)
   end
 


### PR DESCRIPTION
Fixes #957 
Braucht noch eine Änderung am GLP Wagon: hitobito/hitobito_glp#27

Ready to review!

Ich habe auch noch den Devise Setup an den offiziellen Standard angepasst (Teil von hitobito 2.0 Security #1317), Sicherheitslücken in der self registration #1441 und einen Bug von #1564 auf dem OAuth Login Screen gefixt.