### PR TITLE
Allow group as invoice list receiver

### DIFF
--- a/app/helpers/dropdown/invoice_new.rb
+++ b/app/helpers/dropdown/invoice_new.rb
@@ -7,13 +7,13 @@
 
 module Dropdown
   class InvoiceNew < Base
-    def initialize(template, people: [], mailing_list: nil, filter: nil)
+    def initialize(template, people: [], mailing_list: nil, filter: nil, group: nil)
       super(template, label, :plus)
       @people = people
+      @group = group
       @mailing_list = mailing_list
-      @filter = filter
-      if @filter.is_a?(ActionController::Parameters)
-        @filter = filter.to_unsafe_h.slice(:group_id, :range, :filters)
+      if filter.is_a?(ActionController::Parameters)
+        @filter = filter.to_unsafe_h.slice(:range, :filters).compact.presence
       end
       init_items
     end
@@ -46,7 +46,12 @@ module Dropdown
       elsif @filter
         template.new_group_invoice_list_path(
           finance_group,
-          filter: @filter, invoice_list: { recipient_ids: '' }
+          filter: @filter.merge(group_id: @group.id), invoice_list: { recipient_ids: '' }
+        )
+      elsif @group
+        template.new_group_invoice_list_path(
+          finance_group,
+          invoice_list: { receiver_id: @group.id, receiver_type: @group.class.base_class }
         )
       elsif @people.one?
         template.new_group_invoice_path(

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -51,10 +51,11 @@ module InvoicesHelper
     end
   end
 
-  def invoice_button(people: [], mailing_list: nil, filter: nil)
+  def invoice_button(people: [], mailing_list: nil, filter: nil, group: nil)
     Dropdown::InvoiceNew.new(self, {
       people: people,
       mailing_list: mailing_list,
+      group: group,
       filter: filter
     }).button_or_dropdown
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -240,6 +240,10 @@ class Group < ActiveRecord::Base
               .include?(self_registration_role_type.constantize)
   end
 
+  def path_args
+    [self]
+  end
+
   private
 
   def layer_person_duplicates

--- a/app/models/invoice_list.rb
+++ b/app/models/invoice_list.rb
@@ -43,7 +43,7 @@ class InvoiceList < ActiveRecord::Base
   has_many :invoices, dependent: :destroy
 
   attr_accessor :recipient_ids, :invoice
-  validates :receiver_type, inclusion: %w(MailingList), allow_blank: true
+  validates :receiver_type, inclusion: %w(MailingList Group), allow_blank: true
 
   scope :list, -> { order(:created_at) }
 

--- a/app/models/mailing_list.rb
+++ b/app/models/mailing_list.rb
@@ -138,6 +138,10 @@ class MailingList < ActiveRecord::Base
     Synchronize::Mailchimp::Client.new(self)
   end
 
+  def path_args
+    [group, self]
+  end
+
   private
 
   def assert_mail_name_is_not_protected

--- a/app/views/invoice_lists/_list.html.haml
+++ b/app/views/invoice_lists/_list.html.haml
@@ -7,6 +7,6 @@
     = content_tag(:strong) do
       = link_to(item.title, group_invoice_list_invoices_path(item.group, item))
   - t.col(t.sort_header(:receiver)) do |item|
-    = link_to(item.receiver_label, [item.group, item.receiver]) if item.receiver
+    = link_to(item.receiver_label, item.receiver.path_args) if item.receiver
 
   - t.sortable_attrs(:recipients_total, :recipients_paid, :amount_total, :amount_paid)

--- a/app/views/people/_actions_index.html.haml
+++ b/app/views/people/_actions_index.html.haml
@@ -6,7 +6,7 @@
   = action_button(t('.add_person'), new_group_role_path(@group), :plus)
 
 - if can?(:create_invoices_from_list, @group)
-  = invoice_button(filter: list_filter_args.merge(group_id: @group.id))
+  = invoice_button(filter: list_filter_args, group: @group)
 
 - if can?(:new, @group.roles.new)
   = action_button(t('.import_list'), new_group_csv_imports_path, :upload)

--- a/spec/controllers/invoice_lists_controller_spec.rb
+++ b/spec/controllers/invoice_lists_controller_spec.rb
@@ -207,7 +207,7 @@ describe InvoiceListsController do
       expect(Invoice.find_by(title: 'current_user').creator).to eq(person)
     end
 
-    it 'POST#create for receiver redirects to invoice_lists page' do
+    it 'POST#create for mailing list receiver redirects to invoice_lists page' do
       Subscription.create!(mailing_list: list, subscriber: groups(:top_group), role_types: [Group::TopGroup::Leader])
       expect do
         post :create, params: { group_id: group.id, invoice_list: { receiver_id: list.id, receiver_type: list.class, invoice: invoice_attrs.merge(title: 'test') } }
@@ -215,6 +215,15 @@ describe InvoiceListsController do
       expect(assigns(:invoice_list).receiver).to eq list
       expect(response).to redirect_to group_invoice_lists_path(group)
     end
+
+    it 'POST#create for group receiver redirects to invoice_lists page' do
+      expect do
+        post :create, params: { group_id: group.id, invoice_list: { receiver_id: group.id, receiver_type: group.class.base_class, invoice: invoice_attrs.merge(title: 'test') } }
+      end.to change { group.invoices.count }.by(1)
+      expect(assigns(:invoice_list).receiver).to eq group
+      expect(response).to redirect_to group_invoice_lists_path(group)
+    end
+
 
     it 'POST#create an invoice in background' do
       stub_const("InvoiceListsController::LIMIT_CREATE", 2)

--- a/spec/models/invoice_list_spec.rb
+++ b/spec/models/invoice_list_spec.rb
@@ -28,12 +28,14 @@ describe InvoiceList do
     expect(subject.first_recipient).to eq person
   end
 
-  it 'only accepts mailing list as receiver' do
+  it 'accepts mailing list as receiver' do
     subject.attributes = { title: :test, receiver: list }
     expect(subject).to be_valid
+  end
 
+  it 'accepts group as receiver' do
     subject.attributes = { title: :test, receiver: group }
-    expect(subject).not_to be_valid
+    expect(subject).to be_valid
   end
 
   it '#update_paid updates payment informations' do


### PR DESCRIPTION
closes: https://github.com/hitobito/hitobito_svse/issues/62
Problem was, when using the async BatchCreate, the recipient_ids would be lost due to it not being persisted in the database.
Meaning:
1. Click dropdown button, sets recipient_ids to `group.people.pluck(:id)`
2. Save invoice list entry
3. Realize there's too many recipients, thus extracting it into Job and pass `invoice_list.id`
4. Job finds invoice_list by id. Loses recipient_ids due to it not being persisted

Since we already use the receiver relation for mailing_lists i thought this would be the easiest and most in tune with the given structure. Any ideas why this wasn't done like this before?