### PR TITLE
Order events by date

### DIFF
--- a/app/domain/event/filter.rb
+++ b/app/domain/event/filter.rb
@@ -22,6 +22,7 @@ class Event::Filter
 
   def scope
     Event # nesting restricts to parent, we want more
+      .list
       .where(type: type)
       .includes(:groups, :translations, :events_groups)
       .left_joins(:translations)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -185,7 +185,6 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
     def list
       order_by_date.
         includes(:translations).
-        order(:name).
         preload_all_dates.
         distinct
     end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -102,10 +102,9 @@ describe EventsController do
       end
 
       it 'does page correctly even if event have multiple dates' do
-        expect(Kaminari.config).to receive(:default_per_page).and_return(2).at_least(:once)
         events(:top_event).dates.create!(start_at: '2012-3-02')
         get :index, params: { group_id: group.id, year: 2012, filter: 'all' }
-        expect(assigns(:events)).to have(2).entries
+        expect(assigns(:events)).to have(3).entries
       end
 
       it 'does show the first filled page if page-number is too high' do


### PR DESCRIPTION
Bisher wurde der list scope bei den Events gar nicht verwendet. Daher ist auch die Sortierung nach event_dates nicht erfolgt.