### PR TITLE
Rescue and log Error manually to avoid failing whole job

### DIFF
--- a/app/jobs/payments/ebics_import_job.rb
+++ b/app/jobs/payments/ebics_import_job.rb
@@ -10,6 +10,8 @@ class Payments::EbicsImportJob < RecurringJob
   def perform_internal
     payment_provider_configs.find_each do |provider_config|
       Payments::EbicsImport.new(provider_config).run
+    rescue StandardError => e
+      error(self, e, payment_provider_config: provider_config)
     end
   end
 

--- a/spec/fixtures/payment_provider_configs.yml
+++ b/spec/fixtures/payment_provider_configs.yml
@@ -25,3 +25,7 @@
 postfinance:
   payment_provider: 'postfinance'
   invoice_config: bottom_layer_one
+
+ubs:
+  payment_provider: 'ubs'
+  invoice_config: bottom_layer_one


### PR DESCRIPTION
Wenn aktuell eine von den config's failed (was durchaus realistisch ist, siehe: https://sentry.puzzle.ch/pitc/hitobito-backend/issues/48813/?query=is%3Aunresolved) failed der ganze Job