### PR TITLE
Bug: Kontostelle & Konto wird nicht gespeichert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 *  Introduce new bulk mail stack
 *  Rechnungen können neu das Total ausblenden (hitobito_sww#26)
 *  Rollen können beim Erstellen und Editieren ein Start- und Enddatum gesetzt werden. Das Enddatum kann auch in der Zukunft liegen, die Rolle wird dann automatisch an diesem Datum beendet. (#1714)
+*  Die Kosten-Stelle und das Konto wird für Gruppenrechnungen korrekt gespeichert (gefixt von @maede97) (hitobito_cevi#77)
 
 ## Version 1.26
 

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -24,6 +24,8 @@ class InvoiceListsController < CrudController
       invoice_items_attributes: [
         :name,
         :description,
+        :cost_center,
+        :account,
         :unit_cost,
         :vat_rate,
         :count,


### PR DESCRIPTION
Dieser PR fixt das Problem, dass das Konto und die Kontostelle nicht gespeichert werden bei einer Sammelrechnung.
Closes https://github.com/hitobito/hitobito_cevi/issues/77