### PR TITLE
Extract wagon name from github context

### DIFF
--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -58,6 +58,11 @@ jobs:
         run: |
           echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
 
+      - name: 'Extract wagon name'
+        run: |
+          repository=${{github.repository}}
+          echo "WAGON_NAME=${repository##*/}" >> $GITHUB_ENV
+
       - name: 'Choose branch for dependencies'
         run: |
           echo "BRANCH_NAME: $BRANCH_NAME"
@@ -103,10 +108,10 @@ jobs:
           ref: '${{ env.HITOBITO_BRANCH }}'
           path: ${{ inputs.wagon_dependency_repository }}
 
-      - name: Checkout ${{ inputs.wagon_repository }}
+      - name: Checkout ${{ env.WAGON_NAME }}
         uses: actions/checkout@v2
         with:
-          path: ${{ inputs.wagon_repository }}
+          path: ${{ env.WAGON_NAME }}
 
       - name: 'Create cache key'
         run: cp Gemfile.lock Gemfile.lock.backup
@@ -128,7 +133,7 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          path: ${{ inputs.wagon_repository }}/vendor/bundle
+          path: ${{ env.WAGON_NAME }}/vendor/bundle
           key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
           restore-keys: |
             ${{ runner.os }}-ruby-bundle-


### PR DESCRIPTION
Closes #1642 

Der GH Actions Trigger `schedule` hat keine payload. Wir benötigten diese Payload bisher aber, um den Wagon Namen (der getestet wird) herauszufinden. Im `github` context gibt es leider auch kein spezifisches Attribut für den Repository-Namen, daher muss das per bash script kurz raus gefiltert werden.
Damit sollten dann die cron CI's wieder laufen. Beispiele, welche mit diesem angepassten Workflow liefen:
- https://github.com/hitobito/hitobito_tenants/runs/5478514117?check_suite_focus=true
- https://github.com/hitobito/hitobito_sww/runs/5476757896?check_suite_focus=true