### PR TITLE
Add technical role class to OAuth profile endpoint

### DIFF
--- a/app/controllers/oauth/profiles_controller.rb
+++ b/app/controllers/oauth/profiles_controller.rb
@@ -49,6 +49,7 @@ module Oauth
           group_id: role.group_id,
           group_name: role.group.name,
           role_name: role.class.model_name.human,
+          role_class: role.class.name
           permissions: role.class.permissions
         }
       end

--- a/app/controllers/oauth/profiles_controller.rb
+++ b/app/controllers/oauth/profiles_controller.rb
@@ -49,7 +49,7 @@ module Oauth
           group_id: role.group_id,
           group_name: role.group.name,
           role_name: role.class.model_name.human,
-          role_class: role.class.name
+          role_class: role.class.name,
           permissions: role.class.permissions
         }
       end


### PR DESCRIPTION
This is to make matching between profile endpoint and API easier:
https://github.com/hitobito/hitobito/blob/master/app/serializers/role_serializer.rb#L35