### PR TITLE
Allow person-search to include group

### DIFF
--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -40,7 +40,7 @@ module Searchable
     # Concat the word clauses with AND.
     def search_conditions
       if search_support? && search_param.present?
-        search_condition(*self.class.search_tables_and_fields)
+        search_condition(*self.search_tables_and_fields)
       end
     end
 
@@ -48,6 +48,17 @@ module Searchable
       SearchStrategies::SqlConditionBuilder.new(search_param, fields).search_conditions
     end
 
+    # All search columns divided in table and field names.
+    def search_tables_and_fields
+      @search_tables_and_fields ||= search_columns.map do |f|
+        if f.to_s.include?('.')
+          f.to_s
+        else
+          "#{model_class.table_name}.#{f}"
+        end
+      end
+    end
+    
     # Returns true if this controller has searchable columns.
     def search_support?
       search_columns.present?
@@ -60,22 +71,10 @@ module Searchable
     def search_key
       :q
     end
-  end
-
-  # Class methods for Searchable.
-  module ClassMethods
-
-    # All search columns divided in table and field names.
-    def search_tables_and_fields
-      @search_tables_and_fields ||= search_columns.map do |f|
-        if f.to_s.include?('.')
-          f
-        else
-          "#{model_class.table_name}.#{f}"
-        end
-      end
+    
+    def search_columns
+      # by default, use the static class attribute (backwards compatibility)
+      @search_columns ||= self.class.search_columns
     end
-
   end
-
 end

--- a/app/controllers/person/query_controller.rb
+++ b/app/controllers/person/query_controller.rb
@@ -28,7 +28,9 @@ class Person::QueryController < ApplicationController
     
     json = if include_groups?
       people.collect do |p|
-        group = p.groups.find { |g| search_param_split.any? { |s| g.name.downcase.include? s.downcase } }
+        group = p.groups.find do |g|
+          search_param_split.any? { |s| g.name.downcase.include? s.downcase }
+        end
 
         p.public_send(serializer, group: group)
       end
@@ -55,7 +57,7 @@ class Person::QueryController < ApplicationController
 
   include Searchable
 
-  # override default search_columns to dynamically update them based on current request
+  # dynamically update search_columns based on current request
   def search_columns
     columns = [:first_name, :last_name, :company_name, :nickname, :town]
     if include_groups?

--- a/app/controllers/person/query_controller.rb
+++ b/app/controllers/person/query_controller.rb
@@ -25,20 +25,8 @@ class Person::QueryController < ApplicationController
       end
       people = decorate(people)
     end
-    
-    json = if include_groups?
-      people.collect do |p|
-        group = p.groups.find do |g|
-          search_param_split.any? { |s| g.name.downcase.include? s.downcase }
-        end
-
-        p.public_send(serializer, group: group)
-      end
-    else
-      people.collect { |p| p.public_send(serializer) }
-    end
-    
-    render json: json
+        
+    render json: serialize_people(people)
   end
 
   private
@@ -53,6 +41,21 @@ class Person::QueryController < ApplicationController
 
   def authorize_action
     authorize!(:query, Person)
+  end
+  
+  # serialize people and include matched group if present
+  def serialize_people(people)
+    if include_groups?
+      people.collect do |p|
+        group = p.groups.find do |g|
+          search_param_split.any? { |s| g.name.downcase.include? s.downcase }
+        end
+
+        p.public_send(serializer, group: group)
+      end
+    else
+      people.collect { |p| p.public_send(serializer) }
+    end
   end
 
   include Searchable

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -11,8 +11,8 @@ class PersonDecorator < ApplicationDecorator
 
   include ContactableDecorator
 
-  def as_typeahead
-    { id: id, label: h.h(full_label) }
+  def as_typeahead(group: nil)
+    { id: id, label: h.h(full_label(group: group)) }
   end
 
   def as_quicksearch
@@ -23,13 +23,14 @@ class PersonDecorator < ApplicationDecorator
     { id: id, label: h.h(name_with_address) }
   end
 
-  def full_label
+  def full_label(group: nil)
     label = to_s
     label << ", #{town}" if town?
     if company?
       name = full_name
       label << " (#{name})" if name.present?
     else
+      label << ", #{group.name}" if group
       label << " (#{birthday.year})" if birthday
     end
     label


### PR DESCRIPTION
Fixes #1675

- Groups are only shown in the dropdown if they are matched
- Groups are only searched when 2 or more search terms are entered to avoid people searching for just a group
- Searchable now allows you to customize the search_columns per request by overriding search_columns. Backwards compatibility is assured.

### Things to consider/discuss:
- [x] formatting of person in dropdown (currently the group is just added after a comma, before the year number if present)
- [ ] info/hint that searching for groups is allowed as mentioned in the issue
- [ ] privacy implications
- [ ] current approach to prevent people from searching just for a group. If Nünenen is a group, the following still works to find people from Nünenen
  - "Nün nün"
  - "Nün e"
  - etc.
- [ ] this feature allows people to figure out groups of people they only know by name by searching for the name and a common single letter like e or a. This satisfies the min 3 chars, min 2 terms requirements to search for groups. Alternatives like requiring every term to be min 2 chars could potentially allow for less data exposure.
- [ ] terrible complexity in search of matching group (in memory, not sql). tolerable?
- [ ] logged warnings about eager loading?


### Todo
- [ ] automated tests
- [ ] check if other wagons used Searchable and if so check that they still work after this rework