### PR TITLE
Disallow empty person searches

### DIFF
--- a/app/controllers/concerns/searchable.rb
+++ b/app/controllers/concerns/searchable.rb
@@ -29,7 +29,7 @@ module Searchable
     def search_param
       return '' unless params.key?(search_key)
 
-      params[search_key].to_s
+      params[search_key].to_s.strip
     end
 
     # Enhance the list entries with an optional search criteria


### PR DESCRIPTION
Before this PR you could search for people in the add person dialogs with just spaces (returns any 10 rows). This probably applies to every controller implementing search via the Searchable module because the parameter from the frontend doesn't have whitespace stripped. This PR fixes this by simply removing leading and trailing whitespace before further processing it.

### Todo
- Do the automated tests still pass?
- Test more potentially affected places (I tested "Person hinzufügen" for Kurse and Lager in the pbs wagon).