### PR TITLE
Kalender-Feeds für Gruppen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 *  Gruppen verfügen nun über eine einfache Mitgliederstatistik (Reiter "Statistiken" auf der Gruppe) (hitobito_kljb#4).
 *  Der Login-Status (hat kein Login, hat Login, 2FA, E-Mail versendet aber noch nicht akzeptiert) von Personen auf die man Schreibrechte hat kann jetzt als zusätzliche Spalte angezeigt werden (#1296).
 *  Sprache als Standardattribut auf Person (#1663)
+*  Anlässe, Kurse, etc. können neu getaggt werden (#1687)
+*  Es können neu Kalender-Feeds in jeder Gruppe eingerichtet werden. Damit können Anlässe, Kurse, Jahrespläne etc. einer Gruppe in einen externen Kalender (z.B. Google Kalender) eingebunden werden (#1687)
 
 ## Version 1.26
 

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -14,6 +14,7 @@ class Ability
   @@store = AbilityDsl::Store.new
 
   store.register AssignmentAbility,
+                 CalendarAbility,
                  EventAbility,
                  Event::ApplicationAbility,
                  Event::InvitationAbility,

--- a/app/abilities/calendar_ability.rb
+++ b/app/abilities/calendar_ability.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class CalendarAbility < AbilityDsl::Base
+
+  on(Calendar) do
+    permission(:layer_full).may(:manage).in_same_layer
+    permission(:layer_and_below_full).may(:manage).in_same_layer
+  end
+
+  def in_same_layer
+    user.groups.map(&:layer_group_id).include? subject.group.layer_group.id
+  end
+
+end

--- a/app/abilities/group_ability.rb
+++ b/app/abilities/group_ability.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -44,8 +44,8 @@ class GroupAbility < AbilityDsl::Base
     permission(:layer_full).may(:destroy).in_same_layer_except_permission_giving
     permission(:layer_full).may(:index_service_tokens).service_token_in_same_layer
     permission(:layer_full)
-      .may(:index_person_add_requests, :index_notes, :index_deleted_people, :show_statistics)
-      .in_same_layer
+      .may(:index_person_add_requests, :index_notes, :index_deleted_people, :show_statistics,
+           :index_calendars).in_same_layer
     permission(:layer_full)
       .may(:update, :reactivate,
            :manage_person_tags, :activate_person_add_requests, :deactivate_person_add_requests)
@@ -64,6 +64,7 @@ class GroupAbility < AbilityDsl::Base
           :manage_person_tags, :index_deleted_people).in_same_layer_or_below
     permission(:layer_and_below_full).may(:modify_superior).in_below_layers_if_active
     permission(:layer_and_below_full).may(:index_service_tokens).service_token_in_same_layer
+    permission(:layer_and_below_full).may(:index_calendars).in_same_layer
     permission(:layer_and_below_full).
       may(:activate_person_add_requests, :deactivate_person_add_requests).
       in_same_layer_if_active

--- a/app/abilities/various_ability.rb
+++ b/app/abilities/various_ability.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -39,6 +39,11 @@ class VariousAbility < AbilityDsl::Base
       class_side(:index).if_admin
       permission(:admin).may(:manage).all
     end
+  end
+
+  on(Calendar) do
+    permission(:layer_full).may(:manage).in_same_layer
+    permission(:layer_and_below_full).may(:manage).in_same_layer
   end
 
   def own

--- a/app/abilities/various_ability.rb
+++ b/app/abilities/various_ability.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -39,11 +39,6 @@ class VariousAbility < AbilityDsl::Base
       class_side(:index).if_admin
       permission(:admin).may(:manage).all
     end
-  end
-
-  on(Calendar) do
-    permission(:layer_full).may(:manage).in_same_layer
-    permission(:layer_and_below_full).may(:manage).in_same_layer
   end
 
   def own

--- a/app/controllers/calendars/feeds_controller.rb
+++ b/app/controllers/calendars/feeds_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class Calendars::FeedsController < ApplicationController
+
+  def index
+    respond_to do |format|
+      format.ics do
+        calendar = nil
+        if params[:calendar_token].present?
+          calendar = Calendar.find_by(id: params[:calendar_id], token: params[:calendar_token])
+        end
+        return head :not_found unless calendar
+        events = Calendars::Events.new(calendar).events
+        send_data Export::Ics::Events.new.generate(events), type: :ics, disposition: :inline
+      end
+    end
+  end
+
+  private
+
+  def devise_controller?
+    request.format.ics? # hence, no login required
+  end
+
+end

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class CalendarsController < CrudController
+
+  helper_method :group
+
+  self.nesting = Group
+
+  self.permitted_attrs = [:name, :description,
+                          {
+                              included_calendar_groups_attributes: [
+                                  :id, :group_id, :excluded, :with_subgroups, :event_type, :_destroy
+                              ],
+                              excluded_calendar_groups_attributes: [
+                                  :id, :group_id, :excluded, :with_subgroups, :event_type, :_destroy
+                              ],
+                          }]
+
+  decorates :group
+
+  prepend_before_action :parent
+  before_render_form :possible_tags
+
+  def feed
+    # TODO check token, find events, output them in ics format
+  end
+
+  private
+
+  alias group parent
+
+  def authorize_class
+    authorize!(:index_calendars, group)
+  end
+
+  def assign_attributes
+    super
+    if model_params
+      entry.calendar_tags = calendar_tags
+    end
+  end
+
+  def possible_tags
+    @possible_tags ||= Event.tags_on(:tags).order(:name).collect do |tag|
+      [tag.name, tag.id]
+    end
+  end
+
+  def calendar_tags
+    (
+      included_tags.map { |id| CalendarTag.new(tag_id: id, excluded: false) } +
+      excluded_tags.map { |id| CalendarTag.new(tag_id: id, excluded: true) }
+    ).compact
+  end
+
+  def included_tags
+    model_params[:included_calendar_tags_ids]&.reject(&:empty?) || []
+  end
+
+  def excluded_tags
+    model_params[:excluded_calendar_tags_ids]&.reject(&:empty?) || []
+  end
+
+end

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -26,20 +26,6 @@ class CalendarsController < CrudController
   prepend_before_action :parent
   before_render_form :possible_tags
 
-  def feed
-    respond_to do |format|
-      format.ics do
-        calendar = nil
-        if params[:token].present?
-          calendar = Calendar.find_by(id: params[:calendar_id], token: params[:token])
-        end
-        return head :not_found unless calendar
-        events = Calendars::Events.new(calendar).events
-        send_data Export::Ics::Events.new.generate(events), type: :ics, disposition: :inline
-      end
-    end
-  end
-
   def new(&block)
     assign_attributes if model_params
     entry.included_calendar_groups.build(group: group) if entry.included_calendar_groups.blank?

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -30,6 +30,12 @@ class CalendarsController < CrudController
     # TODO check token, find events, output them in ics format
   end
 
+  def new(&block)
+    assign_attributes if model_params
+    entry.included_calendar_groups.build(group: group) if entry.included_calendar_groups.blank?
+    respond_with(entry, &block)
+  end
+
   private
 
   alias group parent

--- a/app/controllers/concerns/tags.rb
+++ b/app/controllers/concerns/tags.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Tags
+  extend ActiveSupport::Concern
+
+  included do
+    before_render_show :load_grouped_tags, if: -> { html_request? }
+  end
+
+  private
+
+  def load_grouped_tags
+    @tags = collect_grouped_tags
+  end
+
+  def collect_grouped_tags
+    tags = entry.taggings.includes(:tag).order('tags.name').each_with_object({}) do |t, memo|
+      tag = t.tag
+      tag.hitobito_tooltip = t.hitobito_tooltip
+
+      memo[tag.category] ||= []
+      memo[tag.category] << tag
+    end
+    ActsAsTaggableOn::Tag.order_categorized(tags)
+  end
+end

--- a/app/controllers/event/tags_controller.rb
+++ b/app/controllers/event/tags_controller.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class Event::TagsController < ApplicationController
+
+  class_attribute :permitted_attrs
+
+  before_action :load_group
+  before_action :load_event
+
+  decorates :group, :event
+
+  respond_to :html
+
+  self.permitted_attrs = [:name]
+
+  def query
+    authorize!(:show, @event)
+    tags = []
+
+    if params.key?(:q) && params[:q].size >= 3
+      tags = available_tags(params[:q]).map { |tag| { label: tag } }
+    end
+
+    render json: tags
+  end
+
+  def create
+    authorize!(:update, @event)
+    create_tag(permitted_params[:name])
+    @tags = event_tags
+
+    respond_to do |format|
+      format.html { redirect_to group_event_path(@group, @event) }
+      format.js # create.js.haml
+    end
+  end
+
+  def destroy
+    authorize!(:manage_tags, @event)
+    @event.tag_list.remove(params[:name])
+    @event.save!
+
+    respond_to do |format|
+      format.html { redirect_to group_event_path(@group, @event) }
+      format.js # destroy.js.haml
+    end
+  end
+
+  private
+
+  def event_tags
+    @event
+      .reload
+      .tags
+      .order(:name)
+      .grouped_by_category
+  end
+
+  def create_tag(name)
+    return unless name.present?
+
+    ActsAsTaggableOn::Tagging.find_or_create_by!(
+      taggable: @event,
+      tag: ActsAsTaggableOn::Tag.find_or_create_by(name: name),
+      context: 'tags'
+    )
+  end
+
+  def permitted_params
+    params.require(:acts_as_taggable_on_tag).permit(permitted_attrs)
+  end
+
+  def available_tags(query)
+    ActsAsTaggableOn::Tag
+      .where('name LIKE ?', "%#{query}%")
+      .where.not(name: excluded_tags)
+      .order(:name)
+      .limit(10)
+      .pluck(:name)
+  end
+
+  def excluded_tags
+    []
+  end
+
+  def load_group
+    @group = Group.find(params[:group_id])
+  end
+
+  def load_event
+    @event = Event.find(params[:event_id])
+  end
+
+end

--- a/app/controllers/event/tags_controller.rb
+++ b/app/controllers/event/tags_controller.rb
@@ -78,14 +78,9 @@ class Event::TagsController < ApplicationController
   def available_tags(query)
     ActsAsTaggableOn::Tag
       .where('name LIKE ?', "%#{query}%")
-      .where.not(name: excluded_tags)
       .order(:name)
       .limit(10)
       .pluck(:name)
-  end
-
-  def excluded_tags
-    []
   end
 
   def load_group

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -9,6 +9,7 @@ class EventsController < CrudController
   include YearBasedPaging
   include AsyncDownload
   include Api::JsonPaging
+  include Tags
 
   self.nesting = Group
 
@@ -50,7 +51,6 @@ class EventsController < CrudController
 
   before_render_show :load_user_participation
   before_render_show :load_open_invitation
-  before_render_show :load_grouped_event_tags, if: -> { html_request? }
   before_render_form :load_sister_groups
   before_render_form :load_kinds
 
@@ -153,21 +153,6 @@ class EventsController < CrudController
         @open_invitation = invitation
       end
     end
-  end
-
-  def load_grouped_event_tags
-    @tags = collect_grouped_event_tags
-  end
-
-  def collect_grouped_event_tags
-    tags = entry.taggings.includes(:tag).order('tags.name').each_with_object({}) do |t, memo|
-      tag = t.tag
-      tag.hitobito_tooltip = t.hitobito_tooltip
-
-      memo[tag.category] ||= []
-      memo[tag.category] << tag
-    end
-    ActsAsTaggableOn::Tag.order_categorized(tags)
   end
 
   def render_tabular_in_background(format, name = :events_export)

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -8,6 +8,7 @@
 class PeopleController < CrudController
   include RenderPeopleExports
   include AsyncDownload
+  include Tags
 
   self.nesting = Group
 
@@ -46,7 +47,6 @@ class PeopleController < CrudController
   after_save :show_email_change_info
 
   before_render_show :load_person_add_requests, if: -> { html_request? }
-  before_render_show :load_grouped_person_tags, if: -> { html_request? }
   before_render_index :load_people_add_requests, if: -> { html_request? }
 
   helper_method :list_filter_args
@@ -146,21 +146,6 @@ class PeopleController < CrudController
       @add_requests = entry.add_requests.includes(:body, requester: { roles: :group })
       set_add_request_status_notification if show_add_request_status?
     end
-  end
-
-  def load_grouped_person_tags
-    @tags = collect_grouped_person_tags
-  end
-
-  def collect_grouped_person_tags
-    tags = entry.taggings.includes(:tag).order('tags.name').each_with_object({}) do |t, memo|
-      tag = t.tag
-      tag.hitobito_tooltip = t.hitobito_tooltip
-
-      memo[tag.category] ||= []
-      memo[tag.category] << tag
-    end
-    ActsAsTaggableOn::Tag.order_categorized(tags)
   end
 
   def show_add_request_status?

--- a/app/domain/calendars/events.rb
+++ b/app/domain/calendars/events.rb
@@ -34,15 +34,15 @@ class Calendars::Events
   private
 
   def excluded_groups_exist?
-    @excluded_calendar_groups_exist = excluded_calendar_groups.exists?
+    @excluded_groups_exist ||= excluded_calendar_groups.exists?
   end
 
   def included_tags_exist?
-    @included_calendar_tags_exist = included_calendar_tags.exists?
+    @included_tags_exist ||= included_calendar_tags.exists?
   end
 
   def excluded_tags_exist?
-    @excluded_calendar_tags_exist = excluded_calendar_tags.exists?
+    @excluded_tags_exist ||= excluded_calendar_tags.exists?
   end
 
   def groups_conditions(calendar_groups)

--- a/app/domain/calendars/events.rb
+++ b/app/domain/calendars/events.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class Calendars::Events
+
+  delegate :included_calendar_groups, :excluded_calendar_groups,
+           :included_calendar_tags, :excluded_calendar_tags,
+           :id, to: '@calendar'
+
+  attr_reader :calendar
+
+  def initialize(calendar)
+    @calendar = calendar
+  end
+
+  def events
+    # Inclusion and exclusion of events based on groups
+    query = Event.joins(:groups).distinct.where(groups_conditions(included_calendar_groups))
+    query = query.where(groups_conditions(excluded_calendar_groups).not) if excluded_groups_exist?
+
+    # Inclusion and exclusion of events based on tags
+    query = query.joins(:taggings).where(included_tags_condition) if included_tags_exist?
+    query = query.where(excluded_tags_condition) if excluded_tags_exist?
+
+    query
+  end
+
+  private
+
+  def excluded_groups_exist?
+    @excluded_calendar_groups_exist = excluded_calendar_groups.exists?
+  end
+
+  def included_tags_exist?
+    @included_calendar_tags_exist = included_calendar_tags.exists?
+  end
+
+  def excluded_tags_exist?
+    @excluded_calendar_tags_exist = excluded_calendar_tags.exists?
+  end
+
+  def groups_conditions(calendar_groups)
+    calendar_groups.map { |calendar_group| groups_condition(calendar_group) }.reduce(&:or)
+  end
+
+  def groups_condition(calendar_group)
+    hierarchy = hierarchy_condition(calendar_group)
+    return hierarchy unless calendar_group.event_type.present?
+
+    hierarchy.and(event_type_condition(calendar_group))
+  end
+
+  def hierarchy_condition(calendar_group)
+    groups = Group.arel_table
+    return groups[:id].eq(calendar_group.group.id) unless calendar_group.with_subgroups
+
+    groups[:lft].gteq(calendar_group.group.lft)
+        .and(groups[:rgt].lteq(calendar_group.group.rgt))
+  end
+
+  def event_type_condition(calendar_group)
+    events = Event.arel_table
+    event = Arel.sql("'Event'")
+    # special case for plain Events: type is NULL in the database
+    Arel::Nodes::NamedFunction.new('IFNULL', [events[:type], event]).eq(calendar_group.event_type)
+  end
+
+  def included_tags_condition
+    { taggings: { tag_id: included_calendar_tags.pluck(:tag_id) } }
+  end
+
+  def excluded_tags_condition
+    ActsAsTaggableOn::Tagging
+        .where(taggable_type: 'Event')
+        .where('taggable_id = events.id')
+        .where(tag_id: excluded_calendar_tags.pluck(:tag_id))
+        .arel.exists.not
+  end
+end

--- a/app/domain/calendars/events.rb
+++ b/app/domain/calendars/events.rb
@@ -72,14 +72,14 @@ class Calendars::Events
   end
 
   def included_tags_condition
-    { taggings: { tag_id: included_calendar_tags.pluck(:tag_id) } }
+    { taggings: { tag_id: included_calendar_tags.select(:tag_id) } }
   end
 
   def excluded_tags_condition
     ActsAsTaggableOn::Tagging
         .where(taggable_type: 'Event')
         .where('taggable_id = events.id')
-        .where(tag_id: excluded_calendar_tags.pluck(:tag_id))
+        .where(tag_id: excluded_calendar_tags.select(:tag_id))
         .arel.exists.not
   end
 end

--- a/app/domain/calendars/events.rb
+++ b/app/domain/calendars/events.rb
@@ -18,8 +18,10 @@ class Calendars::Events
   end
 
   def events
+    query = Event.includes([:dates, :translations, :contact])
+
     # Inclusion and exclusion of events based on groups
-    query = Event.joins(:groups).distinct.where(groups_conditions(included_calendar_groups))
+    query = query.joins(:groups).distinct.where(groups_conditions(included_calendar_groups))
     query = query.where(groups_conditions(excluded_calendar_groups).not) if excluded_groups_exist?
 
     # Inclusion and exclusion of events based on tags

--- a/app/helpers/calendars_helper.rb
+++ b/app/helpers/calendars_helper.rb
@@ -13,4 +13,47 @@ module CalendarsHelper
     end
   end
 
+  def format_calendar_group(calendar_group)
+    exclusion = calendar_group.excluded? ? 'excluded' : 'included'
+    subgroups = calendar_group.with_subgroups? ? '_with_subgroups' : ''
+    I18n.t(
+        "calendar_groups.explanation_#{exclusion}#{subgroups}",
+        group_name: calendar_group.group.name,
+        events: format_event_type(calendar_group.calendar.group, calendar_group.event_type)
+    )
+  end
+
+  def format_calendar_tags(calendar, excluded:)
+    exclusion = excluded ? 'excluded' : 'included'
+    tags = excluded ? calendar.excluded_calendar_tags : calendar.included_calendar_tags
+    I18n.t(
+        "calendars.tags.explanation_#{exclusion}",
+        count: tags.count,
+        tags: format_tag_list(tags),
+        events: format_event_type_all(calendar.group)
+    )
+  end
+
+  private
+
+  def format_event_type(group, event_type)
+    if event_type.blank?
+      format_event_type_all(group)
+    else
+      event_type.constantize.model_name.human(count: 2)
+    end
+  end
+
+  def format_event_type_all(group)
+    group.layer_group.event_types.map { |type| type.model_name.human(count: 2) }.to_sentence
+  end
+
+  def format_tag_list(tags)
+    word_or = I18n.t('calendars.tags.or')
+    tags.map(&:tag).pluck(:name).map { |tag| "\"#{tag}\"" }.to_sentence(
+        two_words_connector: word_or,
+        last_word_connector: word_or
+    )
+  end
+
 end

--- a/app/helpers/calendars_helper.rb
+++ b/app/helpers/calendars_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module CalendarsHelper
+
+  def event_type_options(layer)
+    layer.event_types.map do |event_type|
+      [event_type.model_name.human(count: 2), event_type.to_s]
+    end
+  end
+
+end

--- a/app/helpers/roles_helper.rb
+++ b/app/helpers/roles_helper.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -48,10 +48,10 @@ module RolesHelper
     end
   end
 
-  def group_options_with_level
+  def group_options_with_level(group_selection = @group_selection)
     options = []
     base_level = nil
-    Group.each_with_level(@group_selection) do |group, level|
+    Group.each_with_level(group_selection) do |group, level|
       base_level ||= level
       label = ('&nbsp; ' * (level - base_level)).html_safe + h(group.to_s)
       options << [label, group.id]

--- a/app/helpers/sheet/calendar.rb
+++ b/app/helpers/sheet/calendar.rb
@@ -7,6 +7,6 @@
 
 module Sheet
   class Calendar < Base
-    self.parent_sheet = Sheet::Group
+    self.parent_sheet = Sheet::GroupSetting
   end
 end

--- a/app/helpers/sheet/calendar.rb
+++ b/app/helpers/sheet/calendar.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Sheet
+  class Calendar < Base
+    self.parent_sheet = Sheet::Group
+  end
+end

--- a/app/javascript/javascripts/modules/events/event_tags.js.coffee
+++ b/app/javascript/javascripts/modules/events/event_tags.js.coffee
@@ -1,0 +1,48 @@
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+app = window.App ||= {}
+
+app.EventTags = {
+  showForm: ->
+    $('.event-tags-add-form').show();
+    $('.event-tags-add-form input#acts_as_taggable_on_tag_name').val('').focus()
+    $('.event-tag-add').hide();
+
+  hideForm: ->
+    $('.event-tags-add-form').hide();
+    $('.event-tag-add').show();
+    app.EventTags.loading(false)
+
+  loading: (flag) ->
+    $('.event-tags-add-form button').prop('disabled', flag)
+    $('.event-tags-add-form button .spinner').toggle(flag);
+
+  updateTags: (tags) ->
+    $('.event-tags').replaceWith(tags)
+    console.log('replacing with', tags)
+    app.EventTags.hideForm()
+    $('.event-tag-add').focus();
+
+  removeTag: (domEvent) ->
+    domEvent.preventDefault()
+    tagId = $(domEvent.target).parent().data('tag-id')
+    $('.event-tags').find('.event-tag').each((i, elem) ->
+      tag = $(elem)
+      if tag.data('tag-id') == tagId
+        if tag.parent().children().length == 1
+          tag.closest('.event-tags-category').remove()
+          return false
+        else
+          tag.remove()
+          return false
+    )
+}
+
+$(document).on('click', 'a.event-tag-remove', app.EventTags.removeTag)
+$(document).on('click', '.event-tag-add', app.EventTags.showForm)
+$(document).on('submit', '.event-tags-add-form', -> app.EventTags.loading(true); return true);
+$(document).on('keydown', '.event-tags-add-form input#acts_as_taggable_on_tag_name', (event) ->
+    event.keyCode == 27 && app.EventTags.hideForm(); return true)

--- a/app/javascript/stylesheets/hitobito/_main.scss
+++ b/app/javascript/stylesheets/hitobito/_main.scss
@@ -20,6 +20,7 @@
 @import "./modules/btn-group";
 @import "./modules/chip";
 @import "./modules/contactable";
+@import "./modules/event_tags";
 @import "./modules/group";
 @import "./modules/info_bar";
 @import "./modules/invoice";

--- a/app/javascript/stylesheets/hitobito/modules/_event_tags.scss
+++ b/app/javascript/stylesheets/hitobito/modules/_event_tags.scss
@@ -1,0 +1,30 @@
+.event-tags-category {
+  display: table-row;
+  margin-top: 12px;
+}
+.event-tags-category-title,
+.event-tags-category-list {
+  display: table-cell;
+  padding-bottom: 6px;
+  vertical-align: top;
+
+  &.hidden {
+    display: none;
+  }
+}
+
+.event-tags-category-title {
+  padding-bottom: 10px;
+  padding-right: 10px;
+  text-align: right;
+  padding-top: 2px;
+}
+
+.event-tags-add-form {
+  display: inline-block;
+  margin-bottom: 4px;
+
+  input[type="text"] {
+    margin-bottom: 0 !important;
+  }
+}

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class Calendar < ActiveRecord::Base
+
+  belongs_to :group
+
+  has_many :calendar_tags, inverse_of: :calendar, dependent: :destroy
+  has_many :included_calendar_tags, -> { where(excluded: false) },
+           inverse_of: :calendar, class_name: 'CalendarTag', dependent: :destroy
+  has_many :excluded_calendar_tags, -> { where(excluded: true) },
+           inverse_of: :calendar, class_name: 'CalendarTag', dependent: :destroy
+
+  has_many :included_calendar_groups, -> { where(excluded: false) },
+           inverse_of: :calendar, class_name: 'CalendarGroup', dependent: :destroy
+  has_many :excluded_calendar_groups, -> { where(excluded: true) },
+           inverse_of: :calendar, class_name: 'CalendarGroup', dependent: :destroy
+
+  accepts_nested_attributes_for :included_calendar_tags, :excluded_calendar_tags,
+                                :included_calendar_groups, :excluded_calendar_groups,
+                                allow_destroy: true
+
+  validates_by_schema except: [:token]
+  validates :included_calendar_groups, presence: true
+
+  scope :list, -> { order(:name) }
+
+  before_create :generate_token
+
+  def to_s(_format = :default)
+    name
+  end
+
+  def events(events_scope = Event.only_public_data)
+    Calendars::Events.new(self, events_scope).events
+  end
+
+  def included_calendar_tags_ids
+    included_calendar_tags.map(&:tag).pluck(:id)
+  end
+
+  def excluded_calendar_tags_ids
+    excluded_calendar_tags.map(&:tag).pluck(:id)
+  end
+
+  def path_args
+    [group, self]
+  end
+
+  private
+
+  def generate_token
+    self.token = SecureRandom.urlsafe_base64
+  end
+end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -15,9 +15,9 @@ class Calendar < ActiveRecord::Base
   has_many :excluded_calendar_tags, -> { where(excluded: true) },
            inverse_of: :calendar, class_name: 'CalendarTag', dependent: :destroy
 
-  has_many :included_calendar_groups, -> { where(excluded: false) },
+  has_many :included_calendar_groups, -> { where(excluded: false).includes([:group]) },
            inverse_of: :calendar, class_name: 'CalendarGroup', dependent: :destroy
-  has_many :excluded_calendar_groups, -> { where(excluded: true) },
+  has_many :excluded_calendar_groups, -> { where(excluded: true).includes([:group]) },
            inverse_of: :calendar, class_name: 'CalendarGroup', dependent: :destroy
 
   accepts_nested_attributes_for :included_calendar_tags, :excluded_calendar_tags,

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -35,10 +35,6 @@ class Calendar < ActiveRecord::Base
     name
   end
 
-  def events(events_scope = Event.only_public_data)
-    Calendars::Events.new(self, events_scope).events
-  end
-
   def included_calendar_tags_ids
     included_calendar_tags.map(&:tag).pluck(:id)
   end

--- a/app/models/calendar_group.rb
+++ b/app/models/calendar_group.rb
@@ -9,10 +9,16 @@ class CalendarGroup < ActiveRecord::Base
   belongs_to :calendar
   belongs_to :group
 
+  after_destroy :delete_calendar_if_no_included_groups_left
+
   scope :excluded, -> { where(excluded: true) }
   scope :included, -> { where(excluded: false) }
 
   validates :event_type, allow_blank: true, inclusion: { in: ->(entry) do
     entry.group.layer_group.event_types.map(&:to_s)
   end }
+
+  def delete_calendar_if_no_included_groups_left
+    calendar.destroy if calendar.reload.included_calendar_groups.count < 1
+  end
 end

--- a/app/models/calendar_group.rb
+++ b/app/models/calendar_group.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class CalendarGroup < ActiveRecord::Base
+  belongs_to :calendar
+  belongs_to :group
+
+  scope :excluded, -> { where(excluded: true) }
+  scope :included, -> { where(excluded: false) }
+end

--- a/app/models/calendar_group.rb
+++ b/app/models/calendar_group.rb
@@ -11,4 +11,8 @@ class CalendarGroup < ActiveRecord::Base
 
   scope :excluded, -> { where(excluded: true) }
   scope :included, -> { where(excluded: false) }
+
+  validates :event_type, allow_blank: true, inclusion: { in: ->(entry) do
+    entry.group.layer_group.event_types.map(&:to_s)
+  end }
 end

--- a/app/models/calendar_tag.rb
+++ b/app/models/calendar_tag.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class CalendarTag < ActiveRecord::Base
+  belongs_to :calendar
+  belongs_to :tag, class_name: 'ActsAsTaggableOn::Tag'
+
+  scope :excluded, -> { where(excluded: true) }
+  scope :included, -> { where(excluded: false) }
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -147,6 +147,8 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
            class_name: 'Person::AddRequest::Event',
            dependent: :destroy
 
+  acts_as_taggable
+
   ### VALIDATIONS
 
   validates_by_schema
@@ -298,6 +300,10 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
     def ensure_role_type!(type)
       return if type < Event::Role
       raise ArgumentError, "#{type} must be a subclass of Event::Role"
+    end
+
+    def tags
+      Event.tags_on(:tags).order(:name).pluck(:name)
     end
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -92,6 +92,8 @@ class Group < ActiveRecord::Base
   has_many :mailing_lists, dependent: :destroy
   has_many :subscriptions, as: :subscriber, dependent: :destroy
 
+  has_many :calendars, inverse_of: :group, dependent: :destroy
+
   has_many :notes, as: :subject, dependent: :destroy
 
   has_many :person_add_requests,

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -93,6 +93,7 @@ class Group < ActiveRecord::Base
   has_many :subscriptions, as: :subscriber, dependent: :destroy
 
   has_many :calendars, inverse_of: :group, dependent: :destroy
+  has_many :calendar_groups, inverse_of: :group, dependent: :destroy
 
   has_many :notes, as: :subject, dependent: :destroy
 

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -75,5 +75,7 @@ class EventSerializer < ApplicationSerializer
     entities :dates, item.dates, EventDateSerializer
     entities :group, item.groups.decorate, GroupSerializer
 
+    property :tags, item.tag_list
+
   end
 end

--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -91,7 +91,7 @@ class PersonSerializer < ApplicationSerializer
                    :household_key
 
     property :picture, item.picture_full_url
-    property :tags, item.tag_list.to_s if h.can?(:index_tags, item)
+    property :tags, item.tag_list if h.can?(:index_tags, item)
 
     apply_extensions(:public)
 

--- a/app/views/calendars/_actions_index.html.haml
+++ b/app/views/calendars/_actions_index.html.haml
@@ -1,0 +1,6 @@
+-#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+= button_action_add if can?(:new, @group.calendars.new)

--- a/app/views/calendars/_actions_show.html.haml
+++ b/app/views/calendars/_actions_show.html.haml
@@ -1,0 +1,9 @@
+-#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+= button_action_edit if can?(:edit, entry)
+= button_action_destroy if can?(:destroy, entry)
+
+= action_button(t('.copy_url'), '#', :copy, data: { copy_to_clipboard: group_calendar_feed_url(entry.group, entry, token: entry.token, format: :ics) })

--- a/app/views/calendars/_actions_show.html.haml
+++ b/app/views/calendars/_actions_show.html.haml
@@ -6,4 +6,4 @@
 = button_action_edit if can?(:edit, entry)
 = button_action_destroy if can?(:destroy, entry)
 
-= action_button(t('.copy_url'), '#', :copy, data: { copy_to_clipboard: group_calendar_feed_url(entry.group, entry, token: entry.token, format: :ics) })
+= action_button(t('.copy_url'), '#', :copy, data: { copy_to_clipboard: group_calendar_feed_url(entry.group, entry, calendar_token: entry.token, format: :ics) })

--- a/app/views/calendars/_attrs.html.haml
+++ b/app/views/calendars/_attrs.html.haml
@@ -1,0 +1,12 @@
+-#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+#main.row-fluid
+  %article.span8
+    = format_attr(entry, :description)
+
+    = render_extensions :attrs
+
+    -# TODO render included and excluded groups and tags

--- a/app/views/calendars/_attrs.html.haml
+++ b/app/views/calendars/_attrs.html.haml
@@ -9,4 +9,25 @@
 
     = render_extensions :attrs
 
-    -# TODO render included and excluded groups and tags
+    %h3
+      = t('.included_groups')
+
+    - entry.included_calendar_groups.each do |group|
+      %p
+        = format_calendar_group(group)
+
+    %h3
+      = t('.excluded_groups')
+
+    - entry.excluded_calendar_groups.each do |group|
+      %p
+        = format_calendar_group(group)
+
+    %h3
+      = t('.tags')
+
+    %p
+      = format_calendar_tags(entry, excluded: false)
+
+    %p
+      = format_calendar_tags(entry, excluded: true)

--- a/app/views/calendars/_form.html.haml
+++ b/app/views/calendars/_form.html.haml
@@ -1,0 +1,49 @@
+-#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+= entry_form do |f|
+  = f.labeled_input_fields(:name, :description)
+
+  = render_extensions :fields, locals: { f: f }
+
+  = f.labeled_inline_fields_for :included_calendar_groups do |g|
+    = g.hidden_field(:excluded, value: false)
+    = g.select(:group_id, group_options_with_level(group.groups_in_same_layer.to_a), {}, { style: 'margin-right: 20px' })
+    = g.label(:with_subgroups, class: 'checkbox', style: 'padding: 5px 20px 10px 20px; vertical-align: top') do
+      = g.check_box(:with_subgroups)
+      = t('.include_subgroups')
+    = g.select(:event_type, event_type_options(group.layer_group), include_blank: t('.all_event_types'))
+
+  = f.labeled_inline_fields_for :excluded_calendar_groups do |g|
+    = g.hidden_field(:excluded, value: true)
+    = g.select(:group_id, group_options_with_level(group.groups_in_same_layer.to_a), {}, { style: 'margin-right: 20px' })
+    = g.label(:with_subgroups, class: 'checkbox', style: 'padding: 5px 20px 10px 20px; vertical-align: top') do
+      = g.check_box(:with_subgroups)
+      = t('.exclude_subgroups')
+    = g.select(:event_type, event_type_options(group.layer_group), include_blank: t('.all_event_types'))
+
+  .shown
+    = f.labeled :included_calendar_tags do
+      = f.collection_select(:included_calendar_tags_ids,
+                            @possible_tags,
+                            :second,
+                            :first,
+                            { },
+                            { class: 'chosen-select',
+                              multiple: true,
+                              data: { chosen_no_results: t('global.chosen_no_results'),
+                                      placeholder: ' ' } })
+
+    .shown
+    = f.labeled :excluded_calendar_tags do
+      = f.collection_select(:excluded_calendar_tags_ids,
+                            @possible_tags,
+                            :second,
+                            :first,
+                            { },
+                            { class: 'chosen-select',
+                              multiple: true,
+                              data: { chosen_no_results: t('global.chosen_no_results'),
+                                      placeholder: ' ' } })

--- a/app/views/calendars/_list.html.haml
+++ b/app/views/calendars/_list.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-- title @group.to_s
+- title Calendar.model_name.human(count: 2)
 
 = crud_table do |t|
   - t.col(Calendar.human_attribute_name(:name)) do |calendar|

--- a/app/views/calendars/_list.html.haml
+++ b/app/views/calendars/_list.html.haml
@@ -1,0 +1,13 @@
+-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+- title @group.to_s
+
+= crud_table do |t|
+  - t.col(Calendar.human_attribute_name(:name)) do |calendar|
+    %strong
+      = link_to(calendar.name, group_calendar_path(@group, calendar.id))
+  - t.col(Calendar.human_attribute_name(:description)) do |calendar|
+    = calendar.description.to_s.truncate(60)

--- a/app/views/event/tags/_list.html.haml
+++ b/app/views/event/tags/_list.html.haml
@@ -1,0 +1,9 @@
+.event-tags
+  - if tags.present?
+    - tags.each do |category, category_tags|
+      .event-tags-category
+        .event-tags-category-title{class: tags.length == 1 && category == :other ? 'hidden' : nil}
+          = format_tag_category(category)
+        .event-tags-category-list
+          - category_tags.each do |tag|
+            = render 'event/tags/tag', tag: tag, event: @event, category: category

--- a/app/views/event/tags/_tag.html.haml
+++ b/app/views/event/tags/_tag.html.haml
@@ -1,0 +1,9 @@
+%span.chip.event-tag{data: {tag_id: tag.id}, rel: :tooltip, 'data-html': true, title: tag.hitobito_tooltip }
+  = format_tag_name(tag)
+  - if can?(:manage_tags, event)
+    = link_to icon(:times),
+              group_event_tags_path(event_id: event.id, name: tag.name),
+              method: :delete,
+              data: { tag_id: tag.id },
+              remote: true,
+              class: 'event-tag-remove'

--- a/app/views/event/tags/create.js.haml
+++ b/app/views/event/tags/create.js.haml
@@ -1,0 +1,1 @@
+App.EventTags.updateTags('#{escape_javascript(render 'event/tags/list', tags: @tags)}');

--- a/app/views/events/_attrs_primary.html.haml
+++ b/app/views/events/_attrs_primary.html.haml
@@ -31,3 +31,4 @@
   = render_extensions :attrs_primary, folder: 'events'
 
   = render 'attachments'
+  = render 'tags'

--- a/app/views/events/_tags.html.haml
+++ b/app/views/events/_tags.html.haml
@@ -1,0 +1,24 @@
+-#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+%dl.dl-horizontal
+  = labeled ActsAsTaggableOn::Tag.model_name.human(count: 2) do
+    = render 'event/tags/list', tags: @tags
+
+    - if can? :update, entry
+      %button.chip.chip-add.event-tag-add
+        = t('events.add_tag')
+        = icon(:plus)
+
+      = form_for(entry.tags.new, url: group_event_tags_path(@group, entry), remote: true,
+                     html: {class: 'event-tags-add-form', style: 'display:none'}) do |f|
+        = f.text_field(:name, placeholder: t('events.add_tag'),
+                                      data: { provide: 'entity',
+                                              url: group_event_tags_query_path(group_id: @group.id,
+                                                                               event_id: entry.id) })
+
+        %button.btn{type: :submit}
+          = t('global.ok')
+          = spinner

--- a/app/views/group_settings/_actions_index.html.haml
+++ b/app/views/group_settings/_actions_index.html.haml
@@ -5,3 +5,4 @@
 
 - if can?(:index_service_tokens, @group)
   = action_button(t('activerecord.models.service_token.other'), group_service_tokens_path(@group), :key)
+  = action_button(t('activerecord.models.service_token.other'), group_service_tokens_path(@group), :key)

--- a/app/views/group_settings/_actions_index.html.haml
+++ b/app/views/group_settings/_actions_index.html.haml
@@ -5,4 +5,4 @@
 
 - if can?(:index_service_tokens, @group)
   = action_button(t('activerecord.models.service_token.other'), group_service_tokens_path(@group), :key)
-  = action_button(t('activerecord.models.service_token.other'), group_service_tokens_path(@group), :key)
+  = action_button(Calendar.model_name.human(count: 2), group_calendars_path(@group), :'calendar-alt')

--- a/app/views/public_events/_attrs_primary.html.haml
+++ b/app/views/public_events/_attrs_primary.html.haml
@@ -29,3 +29,4 @@
   = render_present_attrs(entry, :description, :location)
 
   = render_extensions :attrs_primary, folder: 'events'
+  = render 'tags'

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -155,8 +155,8 @@ de:
         one: Auftrag
         other: Aufträge
       calendar:
-        one: Kalender
-        other: Kalender
+        one: Kalender-Feed
+        other: Kalender-Feeds
       custom_content:
         one: Text
         other: Texte

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -154,6 +154,9 @@ de:
       assignment:
         one: Auftrag
         other: Aufträge
+      calendar:
+        one: Kalender
+        other: Kalender
       custom_content:
         one: Text
         other: Texte
@@ -1032,6 +1035,14 @@ de:
         taggings_count: Anzahl
         category: Kategorie
         name: Name
+
+      calendar:
+        name: Name
+        description: Beschreibung
+        included_calendar_groups: Aus den Gruppen
+        excluded_calendar_groups: Ausgeschlossene Gruppen
+        included_calendar_tags: Nur mit Tags
+        excluded_calendar_tags: Ausgeschlossene Tags
 
   doorkeeper:
     scopes:

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -499,6 +499,7 @@ de:
     tabs:
       participants: 'Teilnehmende'
     export_enqueued: 'Export wird im Hintergrund gestartet und nach Fertigstellung heruntergeladen.'
+    add_tag: Tag hinzufügen
 
   event/applications:
     approved: 'Die Anmeldung wurde freigegeben.'

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -1737,6 +1737,14 @@ de:
     submit: Zusammenführen
     category: Kategorie
 
+  calendars:
+    actions_show:
+      copy_url: Kalender-Feed URL kopieren
+    form:
+      include_subgroups: Auch Untergruppen einschliessen
+      exclude_subgroups: Auch Untergruppen ausschliessen
+      all_event_types: Alle
+
   views:
     pagination:
       next: '>>'

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -1740,10 +1740,30 @@ de:
   calendars:
     actions_show:
       copy_url: Kalender-Feed URL kopieren
+    attrs:
+      included_groups: Eingeschlossene Gruppen
+      excluded_groups: Ausgeschlossene Gruppen
+      tags: Ein- und ausgeschlossene Tags
     form:
       include_subgroups: Auch Untergruppen einschliessen
       exclude_subgroups: Auch Untergruppen ausschliessen
       all_event_types: Alle
+    tags:
+      or: ' oder '
+      explanation_included:
+        zero: ''
+        one: 'Nur %{events} mit dem Tag %{tags} sind eingeschlossen.'
+        other: 'Nur %{events} mit einem der Tags %{tags} sind eingeschlossen.'
+      explanation_excluded:
+        zero: ''
+        one: '%{events} mit dem Tag %{tags} sind ausgeschlossen.'
+        other: '%{events} mit einem der Tags %{tags} sind ausgeschlossen.'
+
+  calendar_groups:
+    explanation_included_with_subgroups: '%{events} von %{group_name} und Untergruppen sind eingeschlossen.'
+    explanation_included: '%{events} von %{group_name} sind eingeschlossen.'
+    explanation_excluded_with_subgroups: 'Alle %{events} von %{group_name} und Untergruppen sind ausgeschlossen.'
+    explanation_excluded: 'Alle %{events} von %{group_name} sind ausgeschlossen.'
 
   views:
     pagination:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -224,6 +224,10 @@ Hitobito::Application.routes.draw do
 
           get 'qualifications' => 'qualifications#index'
           put 'qualifications' => 'qualifications#update'
+
+          post 'tags' => 'tags#create'
+          delete 'tags' => 'tags#destroy'
+          get 'tags/query' => 'tags#query'
         end
 
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -267,7 +267,7 @@ Hitobito::Application.routes.draw do
       end
 
       resources :calendars do
-        get 'feed' => 'calendars#feed'
+        get 'feed' => 'calendars/feeds#index'
       end
 
       resource :csv_imports, only: [:new, :create], controller: 'person/csv_imports' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,6 +266,10 @@ Hitobito::Application.routes.draw do
         resources :recipient_counts, controller: 'mailing_lists/recipient_counts', only: [:index]
       end
 
+      resources :calendars do
+        get 'feed' => 'calendars#feed'
+      end
+
       resource :csv_imports, only: [:new, :create], controller: 'person/csv_imports' do
         member do
           post :define_mapping

--- a/db/migrate/20220312160000_create_calendars.rb
+++ b/db/migrate/20220312160000_create_calendars.rb
@@ -1,0 +1,24 @@
+class CreateCalendars < ActiveRecord::Migration[6.1]
+  def change
+    create_table :calendars do |t|
+      t.string :name, null: false
+      t.belongs_to :group, null: false
+      t.text :description
+      t.string :token, null: false
+    end
+
+    create_table :calendar_tags do |t|
+      t.belongs_to :calendar, null: false
+      t.belongs_to :tag, null: false
+      t.boolean :excluded, default: false
+    end
+
+    create_table :calendar_groups do |t|
+      t.belongs_to :calendar, null: false
+      t.belongs_to :group, null: false
+      t.boolean :excluded, default: false
+      t.boolean :with_subgroups, default: false
+      t.string :event_type, default: nil
+    end
+  end
+end

--- a/db/migrate/20220312160000_create_calendars.rb
+++ b/db/migrate/20220312160000_create_calendars.rb
@@ -9,9 +9,12 @@ class CreateCalendars < ActiveRecord::Migration[6.1]
 
     create_table :calendar_tags do |t|
       t.belongs_to :calendar, null: false
-      t.belongs_to :tag, null: false
+      t.integer :tag_id, null: false
       t.boolean :excluded, default: false
     end
+
+    # Necessary to auto-delete calendar_tags when the corresponding tag is deleted
+    add_foreign_key :calendar_tags, :tags, on_delete: :cascade
 
     create_table :calendar_groups do |t|
       t.belongs_to :calendar, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,10 +98,10 @@ ActiveRecord::Schema.define(version: 2022_03_12_160000) do
 
   create_table "calendar_tags", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "calendar_id", null: false
-    t.bigint "tag_id", null: false
+    t.integer "tag_id", null: false
     t.boolean "excluded", default: false
     t.index ["calendar_id"], name: "index_calendar_tags_on_calendar_id"
-    t.index ["tag_id"], name: "index_calendar_tags_on_tag_id"
+    t.index ["tag_id"], name: "fk_rails_b4e7ba0100"
   end
 
   create_table "calendars", charset: "utf8mb4", force: :cascade do |t|
@@ -1010,6 +1010,7 @@ ActiveRecord::Schema.define(version: 2022_03_12_160000) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "calendar_tags", "tags", on_delete: :cascade
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_03_100050) do
+ActiveRecord::Schema.define(version: 2022_03_12_160000) do
 
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -84,6 +84,32 @@ ActiveRecord::Schema.define(version: 2022_03_03_100050) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["creator_id"], name: "index_assignments_on_creator_id"
     t.index ["person_id"], name: "index_assignments_on_person_id"
+  end
+
+  create_table "calendar_groups", charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "calendar_id", null: false
+    t.bigint "group_id", null: false
+    t.boolean "excluded", default: false
+    t.boolean "with_subgroups", default: false
+    t.string "event_type"
+    t.index ["calendar_id"], name: "index_calendar_groups_on_calendar_id"
+    t.index ["group_id"], name: "index_calendar_groups_on_group_id"
+  end
+
+  create_table "calendar_tags", charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "calendar_id", null: false
+    t.bigint "tag_id", null: false
+    t.boolean "excluded", default: false
+    t.index ["calendar_id"], name: "index_calendar_tags_on_calendar_id"
+    t.index ["tag_id"], name: "index_calendar_tags_on_tag_id"
+  end
+
+  create_table "calendars", charset: "utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "group_id", null: false
+    t.text "description"
+    t.string "token", null: false
+    t.index ["group_id"], name: "index_calendars_on_group_id"
   end
 
   create_table "cors_origins", charset: "utf8mb4", force: :cascade do |t|

--- a/spec/controllers/calendars/feeds_controller_spec.rb
+++ b/spec/controllers/calendars/feeds_controller_spec.rb
@@ -1,0 +1,50 @@
+# encoding: utf-8
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+describe Calendars::FeedsController do
+
+  let(:person) { people(:bottom_member) }
+  let(:group) { groups(:bottom_layer_one) }
+  let(:calendar_token) { 'test-token-1234asdf' }
+  let(:calendar) { Fabricate(:calendar, group: group) }
+  let!(:calendar_group) { Fabricate(:calendar_group, excluded: false, calendar: calendar, group: group) }
+  let!(:event) { Fabricate(:event, groups: [group], name: 'my test event which will appear in the feed') }
+
+  describe 'while logged in' do
+
+    before { sign_in(person) }
+
+    it 'can access token using url' do
+      get :index, params: { group_id: group.id, calendar_id: calendar.id, calendar_token: calendar.token }, format: :ics
+      expect(response).to be_successful
+      expect(response.body.scan('BEGIN:VEVENT')).to have(1).item
+      expect(response.body.scan('my test event which will appear in the feed')).to have(1).item
+    end
+
+    it 'GET#show.ics returns 404 for bad token' do
+      get :index, params: { group_id: group.id, calendar_id: calendar.id, calendar_token: 'wrong-token-IXSvkeJEHe' }, format: :ics
+      expect(response.status).to eq 404
+    end
+  end
+
+  describe 'while logged out' do
+    it 'can access token using url' do
+      get :index, params: { group_id: group.id, calendar_id: calendar.id, calendar_token: calendar.token }, format: :ics
+      expect(response).to be_successful
+      expect(response.body.scan('BEGIN:VEVENT')).to have(1).item
+      expect(response.body.scan('my test event which will appear in the feed')).to have(1).item
+    end
+
+    it 'GET#show.ics returns 404 for bad token' do
+      get :index, params: { group_id: group.id, calendar_id: calendar.id, calendar_token: 'wrong-token-IXSvkeJEHe' }, format: :ics
+      expect(response.status).to eq 404
+    end
+  end
+
+end

--- a/spec/controllers/calendars_controller_spec.rb
+++ b/spec/controllers/calendars_controller_spec.rb
@@ -1,0 +1,162 @@
+# encoding: utf-8
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+describe CalendarsController do
+
+  let(:person)   { people(:top_leader) }
+  let(:group)    { groups(:top_group) }
+  let(:calendar) { Fabricate(:calendar, group: group) }
+
+  before do
+    sign_in(person)
+    person.roles.destroy_all
+  end
+
+  context 'with layer_full or layer_and_below_full permission' do
+    before { Fabricate(Group::TopGroup::Leader.name, group: group, person: person) }
+
+    let(:tag1) { Fabricate(:tag) }
+    let(:tag2) { Fabricate(:tag) }
+    let(:tag3) { Fabricate(:tag) }
+
+    it 'GET#index renders page' do
+      get :index, params: { group_id: group.id }
+      expect(response).to be_successful
+    end
+
+    it 'GET#show renders page' do
+      get :show, params: { group_id: group.id, id: calendar.id }
+      expect(response).to be_successful
+    end
+
+    it 'POST#create creates a new calendar' do
+      expect do
+        post :create, params: {
+            group_id: group.id,
+            calendar: {
+                name: 'Test calendar',
+                description: 'Test description',
+                included_calendar_groups_attributes: [{
+                    excluded: false,
+                    group_id: group.id,
+                    # checkbox_tag creates a hidden zero input as well as a checkbox with value 1
+                    with_subgroups: [ '0', '1' ],
+                    event_type: '',
+                    _destroy: false
+                }],
+                included_calendar_tags_ids: [''],
+                excluded_calendar_tags_ids: ['']
+            }
+        }
+      end.to change { Calendar.count }.by 1
+      expect(flash[:notice]).to eq 'Kalender-Feed <i>Test calendar</i> wurde erfolgreich erstellt.'
+      expect(Calendar.last.included_calendar_groups.count).to eq 1
+      expect(Calendar.last.excluded_calendar_groups.count).to eq 0
+      expect(Calendar.last.included_calendar_tags.count).to eq 0
+      expect(Calendar.last.excluded_calendar_tags.count).to eq 0
+    end
+
+    it 'POST#create validates at least one included group' do
+      expect do
+        post :create, params: {
+            group_id: group.id,
+            calendar: {
+                name: 'Test calendar',
+                description: 'Test description',
+                included_calendar_groups_attributes: [],
+                included_calendar_tags_ids: [''],
+                excluded_calendar_tags_ids: ['']
+            }
+        }
+      end.to change { Calendar.count }.by 0
+      calendar = assigns(:calendar)
+      expect(calendar).not_to be_valid
+      expect(calendar.errors.messages[:included_calendar_groups]).to include('muss ausgefüllt werden')
+    end
+
+    it 'POST#create creates a new calendar with tags and excluded groups' do
+      expect do
+        post :create, params: {
+            group_id: group.id,
+            calendar: {
+                name: 'Test calendar',
+                description: 'Test description',
+                included_calendar_groups_attributes: [{
+                    excluded: false,
+                    group_id: group.id,
+                    # checkbox_tag creates a hidden zero input as well as a checkbox with value 1
+                    with_subgroups: [ '0', '1' ],
+                    event_type: '',
+                    _destroy: false
+                }],
+                excluded_calendar_groups_attributes: [{
+                    excluded: true,
+                    group_id: group.id,
+                    with_subgroups: [ '0' ],
+                    event_type: 'Event',
+                    _destroy: false
+                }, {
+                    excluded: true,
+                    group_id: group.id,
+                    with_subgroups: [ '0', '1' ],
+                    event_type: 'Event::Course',
+                    _destroy: false
+                }],
+                included_calendar_tags_ids: ['', tag1.id.to_s],
+                excluded_calendar_tags_ids: ['', tag2.id.to_s, tag3.id.to_s]
+            }
+        }
+      end.to change { Calendar.count }.by 1
+      expect(flash[:notice]).to eq 'Kalender-Feed <i>Test calendar</i> wurde erfolgreich erstellt.'
+      expect(Calendar.last.included_calendar_groups.count).to eq 1
+      expect(Calendar.last.excluded_calendar_groups.count).to eq 2
+      expect(Calendar.last.included_calendar_tags.count).to eq 1
+      expect(Calendar.last.excluded_calendar_tags.count).to eq 2
+    end
+  end
+
+  context 'without layer_full or layer_and_below_full permission' do
+    before { Fabricate(Group::TopGroup::Secretary.name, group: group, person: person) }
+
+    it 'GET#index denies access' do
+      expect do
+        get :index, params: { group_id: group.id }
+      end.to raise_error(CanCan::AccessDenied)
+    end
+
+    it 'GET#show denies access' do
+      expect do
+        get :show, params: { group_id: group.id, id: calendar.id }
+      end.to raise_error(CanCan::AccessDenied)
+    end
+
+    it 'POST#create denies access' do
+      expect do
+        post :create, params: {
+            group_id: group.id,
+            calendar: {
+                name: 'Test calendar',
+                description: 'Test description',
+                included_calendar_groups_attributes: [{
+                                                          excluded: false,
+                                                          group_id: group.id,
+                                                          # checkbox_tag creates a hidden zero input as well as a checkbox with value 1
+                                                          with_subgroups: [ '0', '1' ],
+                                                          event_type: '',
+                                                          _destroy: false
+                                                      }],
+                included_calendar_tags_ids: [''],
+                excluded_calendar_tags_ids: ['']
+            }
+        }
+      end.to raise_error(CanCan::AccessDenied)
+    end
+  end
+
+end

--- a/spec/domain/calendars/events_spec.rb
+++ b/spec/domain/calendars/events_spec.rb
@@ -10,13 +10,9 @@ require 'spec_helper'
 describe Calendars::Events do
 
   around(:each) do |example|
-    layer_previous, layer.class.event_types = layer.class.event_types, [Event, Event::Course]
-    subgroup_previous, subgroup.class.event_types = subgroup.class.event_types, [Event, Event::Course]
-    subsubgroup_previous, subsubgroup.class.event_types = subsubgroup.class.event_types, [Event, Event::Course]
+    subgroup_previous, subgroup.class.event_types = subgroup.class.event_types.clone, [Event, Event::Course]
     example.run
-    layer.class.event_types = layer_previous
     subgroup.class.event_types = subgroup_previous
-    subsubgroup.class.event_types = subsubgroup_previous
   end
 
   let(:layer) { groups(:bottom_layer_one) }

--- a/spec/domain/calendars/events_spec.rb
+++ b/spec/domain/calendars/events_spec.rb
@@ -1,0 +1,2032 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+describe Calendars::Events do
+
+  around(:each) do |example|
+    layer_previous, layer.class.event_types = layer.class.event_types, [Event, Event::Course]
+    subgroup_previous, subgroup.class.event_types = subgroup.class.event_types, [Event, Event::Course]
+    subsubgroup_previous, subsubgroup.class.event_types = subsubgroup.class.event_types, [Event, Event::Course]
+    example.run
+    layer.class.event_types = layer_previous
+    subgroup.class.event_types = subgroup_previous
+    subsubgroup.class.event_types = subsubgroup_previous
+  end
+
+  let(:layer) { groups(:bottom_layer_one) }
+  let(:subgroup) { groups(:bottom_group_one_one) }
+  let(:subsubgroup) { groups(:bottom_group_one_one_one) }
+
+  let(:layer_event) { Fabricate(:event, groups: [layer]) }
+  let(:layer_course) { Fabricate(:course, groups: [layer]) }
+  let(:subgroup_event) { Fabricate(:event, groups: [subgroup]) }
+  let(:subgroup_course) { Fabricate(:course, groups: [subgroup]) }
+  let(:subsubgroup_event) { Fabricate(:event, groups: [subsubgroup]) }
+  let(:subsubgroup_course) { Fabricate(:course, groups: [subsubgroup]) }
+
+  let(:calendar) { Fabricate(:calendar, group: layer) }
+
+  subject { Calendars::Events.new(calendar).events }
+
+  context 'with included calendar group' do
+    context 'layer' do
+      let!(:calendar_group) { calendar.included_calendar_groups.first.tap { |g| g.update(group: layer) } }
+
+      context 'including all event types' do
+        before { calendar_group.update(event_type: nil) }
+
+        context 'without subgroups' do
+          before { calendar_group.update(with_subgroups: false) }
+
+          it { is_expected.to include(layer_event) }
+          it { is_expected.to include(layer_course) }
+          it { is_expected.not_to include(subgroup_event) }
+          it { is_expected.not_to include(subgroup_course) }
+          it { is_expected.not_to include(subsubgroup_event) }
+          it { is_expected.not_to include(subsubgroup_course) }
+
+          context 'with excluded calendar group' do
+            let(:excluded_calendar_group) { Fabricate(:calendar_group, excluded: true, calendar: calendar) }
+            context 'layer' do
+              before { excluded_calendar_group.update(group: layer) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subgroup makes no difference' do
+              before { excluded_calendar_group.update(group: subgroup, event_type: nil, with_subgroups: true) }
+
+              it { is_expected.to include(layer_event) }
+              it { is_expected.to include(layer_course) }
+              it { is_expected.not_to include(subgroup_event) }
+              it { is_expected.not_to include(subgroup_course) }
+              it { is_expected.not_to include(subsubgroup_event) }
+              it { is_expected.not_to include(subsubgroup_course) }
+            end
+          end
+        end
+
+        context 'with subgroups' do
+          before { calendar_group.update(with_subgroups: true) }
+
+          it { is_expected.to include(layer_event) }
+          it { is_expected.to include(layer_course) }
+          it { is_expected.to include(subgroup_event) }
+          it { is_expected.to include(subgroup_course) }
+          it { is_expected.to include(subsubgroup_event) }
+          it { is_expected.to include(subsubgroup_course) }
+
+          context 'with excluded calendar group' do
+            let(:excluded_calendar_group) { Fabricate(:calendar_group, excluded: true, calendar: calendar) }
+            context 'layer' do
+              before { excluded_calendar_group.update(group: layer) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subgroup' do
+              before { excluded_calendar_group.update(group: subgroup) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+            end
+          end
+
+          context '' do
+            let(:tag_hello) { ActsAsTaggableOn::Tag.find_by(name: 'hello') }
+            let(:tag_world) { ActsAsTaggableOn::Tag.find_by(name: 'world') }
+
+            before do
+              layer_event.update!(tag_list: 'hello, world')
+              layer_course.update!(tag_list: 'foo')
+              subgroup_event.update!(tag_list: 'world, foo')
+              subgroup_course.update!(tag_list: 'hello, foo')
+              subsubgroup_event.update!(tag_list: '')
+              subsubgroup_course.update!(tag_list: 'hello')
+            end
+
+            context 'filtering by a single tag' do
+              let!(:included_tag_hello) { Fabricate(:calendar_tag, excluded: false, calendar: calendar, tag: tag_hello) }
+
+              it { is_expected.to include(layer_event) }
+              it { is_expected.not_to include(layer_course) }
+              it { is_expected.not_to include(subgroup_event) }
+              it { is_expected.to include(subgroup_course) }
+              it { is_expected.not_to include(subsubgroup_event) }
+              it { is_expected.to include(subsubgroup_course) }
+            end
+
+            context 'filtering by multiple tags includes all events containing any of the tags' do
+              let!(:included_tag_hello) { Fabricate(:calendar_tag, excluded: false, calendar: calendar, tag: tag_hello) }
+              let!(:included_tag_world) { Fabricate(:calendar_tag, excluded: false, calendar: calendar, tag: tag_world) }
+
+              it { is_expected.to include(layer_event) }
+              it { is_expected.not_to include(layer_course) }
+              it { is_expected.to include(subgroup_event) }
+              it { is_expected.to include(subgroup_course) }
+              it { is_expected.not_to include(subsubgroup_event) }
+              it { is_expected.to include(subsubgroup_course) }
+            end
+
+            context 'excluding a single tag' do
+              let!(:excluded_tag_hello) { Fabricate(:calendar_tag, excluded: true, calendar: calendar, tag: tag_hello) }
+
+              it { is_expected.not_to include(layer_event) }
+              it { is_expected.to include(layer_course) }
+              it { is_expected.to include(subgroup_event) }
+              it { is_expected.not_to include(subgroup_course) }
+              it { is_expected.to include(subsubgroup_event) }
+              it { is_expected.not_to include(subsubgroup_course) }
+            end
+
+            context 'excluding multiple tags leaves only events containing none of the tags' do
+              let!(:excluded_tag_hello) { Fabricate(:calendar_tag, excluded: true, calendar: calendar, tag: tag_hello) }
+              let!(:excluded_tag_world) { Fabricate(:calendar_tag, excluded: true, calendar: calendar, tag: tag_world) }
+
+              it { is_expected.not_to include(layer_event) }
+              it { is_expected.to include(layer_course) }
+              it { is_expected.not_to include(subgroup_event) }
+              it { is_expected.not_to include(subgroup_course) }
+              it { is_expected.to include(subsubgroup_event) }
+              it { is_expected.not_to include(subsubgroup_course) }
+            end
+
+            context 'including and excluding some tags, excluding takes precedence' do
+              let!(:included_tag_hello) { Fabricate(:calendar_tag, excluded: false, calendar: calendar, tag: tag_hello) }
+              let!(:excluded_tag_world) { Fabricate(:calendar_tag, excluded: true, calendar: calendar, tag: tag_world) }
+
+              it { is_expected.not_to include(layer_event) }
+              it { is_expected.not_to include(layer_course) }
+              it { is_expected.not_to include(subgroup_event) }
+              it { is_expected.to include(subgroup_course) }
+              it { is_expected.not_to include(subsubgroup_event) }
+              it { is_expected.to include(subsubgroup_course) }
+            end
+          end
+        end
+      end
+
+      context 'including only plain events' do
+        before { calendar_group.update(event_type: Event.name) }
+
+        context 'without subgroups' do
+          before do
+            calendar_group.update(with_subgroups: false)
+          end
+
+          it { is_expected.to include(layer_event) }
+          it { is_expected.not_to include(layer_course) }
+          it { is_expected.not_to include(subgroup_event) }
+          it { is_expected.not_to include(subgroup_course) }
+          it { is_expected.not_to include(subsubgroup_event) }
+          it { is_expected.not_to include(subsubgroup_course) }
+
+          context 'with excluded calendar group' do
+            let(:excluded_calendar_group) { Fabricate(:calendar_group, excluded: true, calendar: calendar) }
+            context 'layer' do
+              before { excluded_calendar_group.update(group: layer) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses makes no difference' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name, with_subgroups: true) }
+
+                it { is_expected.to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.not_to include(subgroup_event) }
+                it { is_expected.not_to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+            end
+
+            context 'subgroup makes no difference' do
+              before { excluded_calendar_group.update(group: subgroup, event_type: nil, with_subgroups: true) }
+
+              it { is_expected.to include(layer_event) }
+              it { is_expected.not_to include(layer_course) }
+              it { is_expected.not_to include(subgroup_event) }
+              it { is_expected.not_to include(subgroup_course) }
+              it { is_expected.not_to include(subsubgroup_event) }
+              it { is_expected.not_to include(subsubgroup_course) }
+            end
+          end
+        end
+
+        context 'with subgroups' do
+          before { calendar_group.update(with_subgroups: true) }
+
+          it { is_expected.to include(layer_event) }
+          it { is_expected.not_to include(layer_course) }
+          it { is_expected.to include(subgroup_event) }
+          it { is_expected.not_to include(subgroup_course) }
+          it { is_expected.to include(subsubgroup_event) }
+          it { is_expected.not_to include(subsubgroup_course) }
+
+          context 'with excluded calendar group' do
+            let(:excluded_calendar_group) { Fabricate(:calendar_group, excluded: true, calendar: calendar) }
+            context 'layer' do
+              before { excluded_calendar_group.update(group: layer) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subgroup' do
+              before { excluded_calendar_group.update(group: subgroup) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses makes no difference' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name, with_subgroups: true) }
+
+                it { is_expected.to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.to include(subgroup_event) }
+                it { is_expected.not_to include(subgroup_course) }
+                it { is_expected.to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+            end
+          end
+        end
+      end
+
+      context 'including only courses' do
+        before { calendar_group.update(event_type: Event::Course.name) }
+
+        context 'without subgroups' do
+          before { calendar_group.update(with_subgroups: false) }
+
+          it { is_expected.not_to include(layer_event) }
+          it { is_expected.to include(layer_course) }
+          it { is_expected.not_to include(subgroup_event) }
+          it { is_expected.not_to include(subgroup_course) }
+          it { is_expected.not_to include(subsubgroup_event) }
+          it { is_expected.not_to include(subsubgroup_course) }
+
+          context 'with excluded calendar group' do
+            let(:excluded_calendar_group) { Fabricate(:calendar_group, excluded: true, calendar: calendar) }
+            context 'layer' do
+              before { excluded_calendar_group.update(group: layer) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events makes no difference' do
+                before { excluded_calendar_group.update(event_type: Event.name, with_subgroups: true) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.to include(layer_course) }
+                it { is_expected.not_to include(subgroup_event) }
+                it { is_expected.not_to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subgroup makes no difference' do
+              before { excluded_calendar_group.update(group: subgroup, event_type: nil, with_subgroups: true) }
+
+              it { is_expected.not_to include(layer_event) }
+              it { is_expected.to include(layer_course) }
+              it { is_expected.not_to include(subgroup_event) }
+              it { is_expected.not_to include(subgroup_course) }
+              it { is_expected.not_to include(subsubgroup_event) }
+              it { is_expected.not_to include(subsubgroup_course) }
+            end
+          end
+        end
+
+        context 'with subgroups' do
+          before { calendar_group.update(with_subgroups: true) }
+
+          it { is_expected.not_to include(layer_event) }
+          it { is_expected.to include(layer_course) }
+          it { is_expected.not_to include(subgroup_event) }
+          it { is_expected.to include(subgroup_course) }
+          it { is_expected.not_to include(subsubgroup_event) }
+          it { is_expected.to include(subsubgroup_course) }
+
+          context 'with excluded calendar group' do
+            let(:excluded_calendar_group) { Fabricate(:calendar_group, excluded: true, calendar: calendar) }
+            context 'layer' do
+              before { excluded_calendar_group.update(group: layer) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subgroup' do
+              before { excluded_calendar_group.update(group: subgroup) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events makes no difference' do
+                before { excluded_calendar_group.update(event_type: Event.name, with_subgroups: true) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.to include(layer_course) }
+                it { is_expected.not_to include(subgroup_event) }
+                it { is_expected.to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.to include(subsubgroup_course) }
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'subgroup' do
+      let!(:calendar_group) { calendar.included_calendar_groups.first.tap { |g| g.update(group: subgroup) } }
+
+      context 'including all event types' do
+        before { calendar_group.update(event_type: nil) }
+
+        context 'without subsubgroups' do
+          before { calendar_group.update(with_subgroups: false) }
+
+          it { is_expected.not_to include(layer_event) }
+          it { is_expected.not_to include(layer_course) }
+          it { is_expected.to include(subgroup_event) }
+          it { is_expected.to include(subgroup_course) }
+          it { is_expected.not_to include(subsubgroup_event) }
+          it { is_expected.not_to include(subsubgroup_course) }
+
+          context 'with excluded calendar group' do
+            let(:excluded_calendar_group) { Fabricate(:calendar_group, excluded: true, calendar: calendar) }
+            context 'layer' do
+              before { excluded_calendar_group.update(group: layer) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subgroup' do
+              before { excluded_calendar_group.update(group: subgroup) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subsubgroup makes no difference' do
+              before { excluded_calendar_group.update(group: subsubgroup, event_type: nil, with_subgroups: true) }
+
+              it { is_expected.not_to include(layer_event) }
+              it { is_expected.not_to include(layer_course) }
+              it { is_expected.to include(subgroup_event) }
+              it { is_expected.to include(subgroup_course) }
+              it { is_expected.not_to include(subsubgroup_event) }
+              it { is_expected.not_to include(subsubgroup_course) }
+            end
+          end
+        end
+
+        context 'with subsubgroups' do
+          before { calendar_group.update(with_subgroups: true) }
+
+          it { is_expected.not_to include(layer_event) }
+          it { is_expected.not_to include(layer_course) }
+          it { is_expected.to include(subgroup_event) }
+          it { is_expected.to include(subgroup_course) }
+          it { is_expected.to include(subsubgroup_event) }
+          it { is_expected.to include(subsubgroup_course) }
+
+          context 'with excluded calendar group' do
+            let(:excluded_calendar_group) { Fabricate(:calendar_group, excluded: true, calendar: calendar) }
+            context 'layer' do
+              before { excluded_calendar_group.update(group: layer) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subgroup' do
+              before { excluded_calendar_group.update(group: subgroup) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subsubgroup' do
+              before { excluded_calendar_group.update(group: subsubgroup) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.to include(subgroup_event) }
+                it { is_expected.to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.to include(subgroup_event) }
+                it { is_expected.to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.to include(subsubgroup_course) }
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.to include(subgroup_event) }
+                it { is_expected.to include(subgroup_course) }
+                it { is_expected.to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+            end
+          end
+        end
+      end
+
+      context 'including only plain events' do
+        before { calendar_group.update(event_type: Event.name) }
+
+        context 'without subgroups' do
+          before do
+            calendar_group.update(with_subgroups: false)
+          end
+
+          it { is_expected.not_to include(layer_event) }
+          it { is_expected.not_to include(layer_course) }
+          it { is_expected.to include(subgroup_event) }
+          it { is_expected.not_to include(subgroup_course) }
+          it { is_expected.not_to include(subsubgroup_event) }
+          it { is_expected.not_to include(subsubgroup_course) }
+
+          context 'with excluded calendar group' do
+            let(:excluded_calendar_group) { Fabricate(:calendar_group, excluded: true, calendar: calendar) }
+            context 'layer' do
+              before { excluded_calendar_group.update(group: layer) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses makes no difference' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name, with_subgroups: true) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.to include(subgroup_event) }
+                it { is_expected.not_to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+            end
+
+            context 'subgroup' do
+              before { excluded_calendar_group.update(group: subgroup) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses makes no difference' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name, with_subgroups: true) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.to include(subgroup_event) }
+                it { is_expected.not_to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+            end
+
+            context 'subsubgroup makes no difference' do
+              before { excluded_calendar_group.update(group: subsubgroup, event_type: nil, with_subgroups: true) }
+
+              it { is_expected.not_to include(layer_event) }
+              it { is_expected.not_to include(layer_course) }
+              it { is_expected.to include(subgroup_event) }
+              it { is_expected.not_to include(subgroup_course) }
+              it { is_expected.not_to include(subsubgroup_event) }
+              it { is_expected.not_to include(subsubgroup_course) }
+            end
+          end
+        end
+
+        context 'with subgroups' do
+          before { calendar_group.update(with_subgroups: true) }
+
+          it { is_expected.not_to include(layer_event) }
+          it { is_expected.not_to include(layer_course) }
+          it { is_expected.to include(subgroup_event) }
+          it { is_expected.not_to include(subgroup_course) }
+          it { is_expected.to include(subsubgroup_event) }
+          it { is_expected.not_to include(subsubgroup_course) }
+
+          context 'with excluded calendar group' do
+            let(:excluded_calendar_group) { Fabricate(:calendar_group, excluded: true, calendar: calendar) }
+            context 'layer' do
+              before { excluded_calendar_group.update(group: layer) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses makes no difference' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name, with_subgroups: true) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.to include(subgroup_event) }
+                it { is_expected.not_to include(subgroup_course) }
+                it { is_expected.to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+            end
+
+            context 'subgroup' do
+              before { excluded_calendar_group.update(group: subgroup) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only courses makes no difference' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name, with_subgroups: true) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.to include(subgroup_event) }
+                it { is_expected.not_to include(subgroup_course) }
+                it { is_expected.to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+            end
+
+            context 'subsubgroup' do
+              before { excluded_calendar_group.update(group: subsubgroup) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.to include(subgroup_event) }
+                it { is_expected.not_to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.to include(subgroup_event) }
+                it { is_expected.not_to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.to include(subgroup_event) }
+                it { is_expected.not_to include(subgroup_course) }
+                it { is_expected.to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+            end
+          end
+        end
+      end
+
+      context 'including only courses' do
+        before { calendar_group.update(event_type: Event::Course.name) }
+
+        context 'without subgroups' do
+          before { calendar_group.update(with_subgroups: false) }
+
+          it { is_expected.not_to include(layer_event) }
+          it { is_expected.not_to include(layer_course) }
+          it { is_expected.not_to include(subgroup_event) }
+          it { is_expected.to include(subgroup_course) }
+          it { is_expected.not_to include(subsubgroup_event) }
+          it { is_expected.not_to include(subsubgroup_course) }
+
+          context 'with excluded calendar group' do
+            let(:excluded_calendar_group) { Fabricate(:calendar_group, excluded: true, calendar: calendar) }
+            context 'layer' do
+              before { excluded_calendar_group.update(group: layer) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events makes no difference' do
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.not_to include(subgroup_event) }
+                it { is_expected.to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subgroup' do
+              before { excluded_calendar_group.update(group: subgroup) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events makes no difference' do
+                before { excluded_calendar_group.update(event_type: Event.name, with_subgroups: true) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.not_to include(subgroup_event) }
+                it { is_expected.to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subsubgroup makes no difference' do
+              before { excluded_calendar_group.update(group: subsubgroup, event_type: nil, with_subgroups: true) }
+
+              it { is_expected.not_to include(layer_event) }
+              it { is_expected.not_to include(layer_course) }
+              it { is_expected.not_to include(subgroup_event) }
+              it { is_expected.to include(subgroup_course) }
+              it { is_expected.not_to include(subsubgroup_event) }
+              it { is_expected.not_to include(subsubgroup_course) }
+            end
+          end
+        end
+
+        context 'with subgroups' do
+          before { calendar_group.update(with_subgroups: true) }
+
+          it { is_expected.not_to include(layer_event) }
+          it { is_expected.not_to include(layer_course) }
+          it { is_expected.not_to include(subgroup_event) }
+          it { is_expected.to include(subgroup_course) }
+          it { is_expected.not_to include(subsubgroup_event) }
+          it { is_expected.to include(subsubgroup_course) }
+
+          context 'with excluded calendar group' do
+            let(:excluded_calendar_group) { Fabricate(:calendar_group, excluded: true, calendar: calendar) }
+            context 'layer' do
+              before { excluded_calendar_group.update(group: layer) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events makes no difference' do
+                before { excluded_calendar_group.update(event_type: Event.name, with_subgroups: true) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.not_to include(subgroup_event) }
+                it { is_expected.to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.to include(subsubgroup_course) }
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subgroup' do
+              before { excluded_calendar_group.update(group: subgroup) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+
+              context 'excluding only plain events makes no difference' do
+                before { excluded_calendar_group.update(event_type: Event.name, with_subgroups: true) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.not_to include(subgroup_event) }
+                it { is_expected.to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.to include(subsubgroup_course) }
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                context 'excluding also subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: true) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.not_to include(subsubgroup_course) }
+                end
+
+                context 'not excluding subsubgroups' do
+                  before { excluded_calendar_group.update(with_subgroups: false) }
+
+                  it { is_expected.not_to include(layer_event) }
+                  it { is_expected.not_to include(layer_course) }
+                  it { is_expected.not_to include(subgroup_event) }
+                  it { is_expected.not_to include(subgroup_course) }
+                  it { is_expected.not_to include(subsubgroup_event) }
+                  it { is_expected.to include(subsubgroup_course) }
+                end
+              end
+            end
+
+            context 'subsubgroup' do
+              before { excluded_calendar_group.update(group: subsubgroup) }
+
+              context 'excluding all event types' do
+                before { excluded_calendar_group.update(event_type: nil) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.not_to include(subgroup_event) }
+                it { is_expected.to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+
+              context 'excluding only plain events' do
+                before { excluded_calendar_group.update(event_type: Event.name) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.not_to include(subgroup_event) }
+                it { is_expected.to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.to include(subsubgroup_course) }
+              end
+
+              context 'excluding only courses' do
+                before { excluded_calendar_group.update(event_type: Event::Course.name) }
+
+                it { is_expected.not_to include(layer_event) }
+                it { is_expected.not_to include(layer_course) }
+                it { is_expected.not_to include(subgroup_event) }
+                it { is_expected.to include(subgroup_course) }
+                it { is_expected.not_to include(subsubgroup_event) }
+                it { is_expected.not_to include(subsubgroup_course) }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fabricators/calendar_fabricator.rb
+++ b/spec/fabricators/calendar_fabricator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+Fabricator(:calendar) do
+  name { Faker::Lorem.words(number: 1).first.capitalize }
+  description { Faker::Lorem.sentences }
+  group { Fabricate('Group::TopLayer') }
+  token { SecureRandom.urlsafe_base64 }
+  included_calendar_groups(count: 1, fabricator: :calendar_group_base)
+end
+
+Fabricator(:calendar_group_base, class_name: :calendar_group) do
+  group { Fabricate('Group::TopLayer') }
+  excluded { false }
+  with_subgroups { false }
+end
+
+Fabricator(:calendar_group, from: :calendar_group_base) do
+  calendar
+end
+
+Fabricator(:calendar_tag) do
+  calendar { Fabricate(:calendar) }
+  tag { Fabricate(:tag) }
+  excluded { false }
+end

--- a/spec/models/calendar_spec.rb
+++ b/spec/models/calendar_spec.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+
+#  Copyright (c) 2022, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+describe Calendar do
+
+  let(:group)    { groups(:top_group) }
+  let(:calendar) { Fabricate(:calendar, group: group) }
+
+  context 'deleting' do
+    let(:tag) { Fabricate(:tag) }
+    let(:subgroup) { group.children.create!(name: 'subgroup', type: Group::TopGroup.sti_name) }
+    let!(:calendar_group) { Fabricate(:calendar_group, excluded: false, calendar: calendar, group: subgroup) }
+    let!(:calendar_tag) { Fabricate(:calendar_tag, tag: tag, calendar: calendar, excluded: false) }
+
+    it 'deletes calendar tag when the referenced tag is destroyed' do
+      expect { tag.destroy! }.to change { CalendarTag.count }.by -1
+      expect(Calendar.find(calendar.id).name).to eq calendar.name
+    end
+
+    it 'deletes calendar group when the referenced group is destroyed' do
+      expect { subgroup.destroy! }.to change { CalendarGroup.count }.by -1
+      expect(Calendar.find(calendar.id).name).to eq calendar.name
+    end
+
+    it 'deletes calendar when the last included group is destroyed' do
+      calendar.included_calendar_groups.first.destroy!
+      expect { subgroup.destroy! }.to change { CalendarGroup.count }.by -1
+      expect { Calendar.find(calendar.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+end


### PR DESCRIPTION
* Anlässe, Kurse, etc. können neu getaggt werden
* Es können neu Kalender-Feeds in jeder Gruppe eingerichtet werden. Damit können Anlässe, Kurse, Jahrespläne etc. einer Gruppe in einen externen Kalender (z.B. Google Kalender) eingebunden werden.

Ähnlich wie Abos anhand von Rollen eine Liste von Personen zusammenstellen können, kann ein Kalender-Feed anhand von Veranstalter-Gruppen und Tags eine Liste von Anlässen, Kursen und Lagern zusammenstellen.
Jeder Kalender-Feed hat einen öffentlichen Link (mit einem calendar_token) der auch erreichbar ist, ohne eingeloggt zu sein. Dieser .ics-Link kann in Kalender-Applikationen eingebunden werden, genau wie das bereits möglich ist für alle Anlässe für die ich angemeldet bin.

https://user-images.githubusercontent.com/7566995/158043202-4caa0749-b55e-46db-a779-23dc60ed3da5.mp4

Grundannahmen:
* Fürs Auflisten, Erstellen, Bearbeiten und Löschen von Kalender-Feeds sind dieselben Berechtigungen nötig, die auch für die Verwaltung von Service Tokens nötig sind, also `:layer_full` oder `:layer_and_below_full`. Grund ist, dass die Kalender-Feed-URL beliebigen Leuten auf einen Schlag Lesezugriff auf viele Anlässe vergibt, und daher nicht leichtfertig herausgegeben werden sollte.
* Es können nur Anlässe, Kurse, etc. innerhalb desselben Layers in einen Kalender-Feed kombiniert werden. Nur auf diese hat die Layer-Leitung auch garantiert Zugriff, siehe #1214. Um die Anlässe von mehreren Layern in eine Kalender-App einzubinden, muss auf jedem dieser Layers ein eigener Kalender-Feed erstellt werden.
* Ein Reset des Kalender-Tokens ist nicht implementiert, weil es im Verdachtsfall einfach ist, einen neuen Kalender-Feed mit denselben Einstellungen zu erstellen und den alten zu löschen
* Nach Tags filtern geht nur über alle Gruppen hinweg gleichzeitig. Es ist z.B. nicht möglich, alle Events eines Layers einzuschliessen, aber nur diejenigen Events einer bestimmten Untergruppe auszuschliessen, die das Tag "geheim" haben. Es kann nur das Tag "geheim" komplett aus dem ganzen Kalender-Feed ausgeschlossen werden. Sonst würde der SQL Query und auch das User Interface zu kompliziert werden.

Entstanden am Hitobito Community Hackathon im Frühling 2022