### PR TITLE
Enable extensions for invoices form and infos, also move offset_cursor_from_top to all pdf sections

### DIFF
--- a/app/domain/export/pdf/messages/letter/section.rb
+++ b/app/domain/export/pdf/messages/letter/section.rb
@@ -15,11 +15,6 @@ class Export::Pdf::Messages::Letter
 
     private
 
-    def offset_cursor_from_top(offset)
-      position = pdf.bounds.top - (offset - Export::Pdf::Messages::Letter::MARGIN)
-      pdf.move_cursor_to position
-    end
-
     def with_settings(opts = {})
       before = opts.map { |key, _value| [key, pdf.send(key)] }
       opts.each { |key, value| pdf.send(:"#{key}=", value) }

--- a/app/domain/export/pdf/section.rb
+++ b/app/domain/export/pdf/section.rb
@@ -13,7 +13,7 @@ module Export::Pdf
     delegate :bounds, :text, :cursor, :font_size, :text_box,
              :fill_and_stroke_rectangle, :fill_color,
              :image, :group, :move_cursor_to, :float,
-             :stroke_bounds, :stamp, :create_stamp,
+             :stroke_bounds, :stamp, :create_stamp, :page,
              :bounds, :table, :cursor, :font_size, :text_box,
              :fill_and_stroke_rectangle, :fill_color, :image,
              to: :pdf
@@ -30,6 +30,11 @@ module Export::Pdf
     end
 
     private
+
+    def offset_cursor_from_top(offset)
+      position = pdf.bounds.top - (offset - page.margins[:top])
+      pdf.move_cursor_to position
+    end
 
     def bounding_box(top_left, attrs = {})
       pdf.bounding_box(top_left, attrs) do

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -26,5 +26,6 @@
   = field_set_tag do
     = f.labeled_inline_fields_for :invoice_items, 'invoice_lists/invoice_items'
 
+  = render_extensions :form, locals: { f: f }
 
   = render "invoice_lists/calculated", invoice: entry.decorate

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -20,12 +20,12 @@
   - if parent.invoice_config.with_reference? || entry.qr?
     = f.labeled_input_field :payment_purpose, rows: 2
 
+  = render_extensions :form, locals: { f: f }
+
   = field_set_tag do
     = render "invoice_lists/invoice_articles", f: f, group: parent
 
   = field_set_tag do
     = f.labeled_inline_fields_for :invoice_items, 'invoice_lists/invoice_items'
-
-  = render_extensions :form, locals: { f: f }
 
   = render "invoice_lists/calculated", invoice: entry.decorate

--- a/app/views/invoices/_infos.html.haml
+++ b/app/views/invoices/_infos.html.haml
@@ -21,4 +21,5 @@
       = labeled_attr(entry, :esr_number) if entry.with_reference?
       = labeled_attr(entry, :creator)
       = labeled_attr(entry, :vat_number) if entry.vat_number?
+      = render_extensions :infos
 

--- a/spec/domain/export/pdf/messages/letter/content_spec.rb
+++ b/spec/domain/export/pdf/messages/letter/content_spec.rb
@@ -9,14 +9,20 @@ require 'spec_helper'
 
 describe Export::Pdf::Messages::Letter::Content do
 
-  let(:options) { {} }
+  let(:options) { {
+    margin: Export::Pdf::Messages::Letter::MARGIN,
+    page_size: 'A4',
+    page_layout: :portrait,
+    compress: true
+  } }
+
   let(:top_leader) { people(:top_leader) }
   let(:recipient) do
     MessageRecipient
       .new(message: letter, person: top_leader)
   end
   let(:letter) { Message::Letter.new(body: 'simple text') }
-  let(:pdf) { Prawn::Document.new }
+  let(:pdf) { Prawn::Document.new(options) }
   let(:analyzer) { PDF::Inspector::Text.analyze(pdf.render) }
 
   subject { described_class.new(pdf, letter, options) }
@@ -24,7 +30,7 @@ describe Export::Pdf::Messages::Letter::Content do
   context "salutation" do
     it "renders body" do
       subject.render(recipient)
-      expect(text_with_position).to eq [[36, 487, "simple text"]]
+      expect(text_with_position).to eq [[71, 502, "simple text"]]
     end
 
     it "prepends salutation if set" do
@@ -32,8 +38,8 @@ describe Export::Pdf::Messages::Letter::Content do
       recipient.salutation = 'Hallo Top'
       subject.render(recipient)
       expect(text_with_position).to eq [
-        [36, 487, "Hallo Top"],
-        [36, 459, "simple text"]
+        [71, 502, "Hallo Top"],
+        [71, 474, "simple text"]
       ]
     end
 
@@ -43,8 +49,8 @@ describe Export::Pdf::Messages::Letter::Content do
       top_leader.gender = "m"
       subject.render(recipient)
       expect(text_with_position).to eq [
-        [36, 487, "Lieber Top"],
-        [36, 459, "simple text"]
+        [71, 502, "Lieber Top"],
+        [71, 474, "simple text"]
       ]
     end
 
@@ -70,7 +76,7 @@ describe Export::Pdf::Messages::Letter::Content do
       it "does not render personal salutation for letter with no salutation" do
         subject.render(recipient)
         expect(text_with_position).to eq [
-          [36, 487, 'Lorem ipsum']
+          [71, 502, 'Lorem ipsum']
         ]
       end
 
@@ -80,8 +86,8 @@ describe Export::Pdf::Messages::Letter::Content do
 
         subject.render(recipient)
         expect(text_with_position).to eq [
-          [36, 487, "Liebe*r Top, liebe*r #{housemate1.first_name}"],
-          [36, 459, 'Lorem ipsum']
+          [71, 502, "Liebe*r Top, liebe*r #{housemate1.first_name}"],
+          [71, 474, 'Lorem ipsum']
         ]
       end
 
@@ -91,8 +97,8 @@ describe Export::Pdf::Messages::Letter::Content do
 
         subject.render(recipient)
         expect(text_with_position).to eq [
-          [36, 487, 'Liebe*r Top'],
-          [36, 459, 'Lorem ipsum']
+          [71, 502, 'Liebe*r Top'],
+          [71, 474, 'Lorem ipsum']
         ]
       end
     end
@@ -112,10 +118,10 @@ describe Export::Pdf::Messages::Letter::Content do
       pdf.start_new_page
       subject.render(recipient)
       expect(text_with_position).to eq [
-        [36, 487, "Hallo Top"],
-        [36, 459, "simple text"],
-        [36, 487, "Hallo Top"],
-        [36, 459, "simple text"]
+        [71, 502, "Hallo Top"],
+        [71, 474, "simple text"],
+        [71, 502, "Hallo Top"],
+        [71, 474, "simple text"]
       ]
       expect(stamps).to be_nil
     end
@@ -126,8 +132,8 @@ describe Export::Pdf::Messages::Letter::Content do
       pdf.start_new_page
       subject.render(recipient)
       expect(text_with_position).to eq [
-        [36, 487, "Hallo Top"],
-        [36, 487, "Hallo Top"],
+        [71, 502, "Hallo Top"],
+        [71, 502, "Hallo Top"],
       ]
       expect(stamps.keys).to eq [:render_content]
     end

--- a/spec/domain/export/pdf/messages/letter/header_spec.rb
+++ b/spec/domain/export/pdf/messages/letter/header_spec.rb
@@ -8,7 +8,13 @@
 require 'spec_helper'
 
 describe Export::Pdf::Messages::Letter::Header do
-  let(:options)    { {} }
+  let(:base_options) { {
+    margin: Export::Pdf::Messages::Letter::MARGIN,
+    page_size: 'A4',
+    page_layout: :portrait,
+    compress: true
+  } }
+  let(:options) { base_options }
   let(:top_group)  { groups(:top_group) }
   let(:top_leader) { people(:top_leader) }
   let(:recipient) do
@@ -19,15 +25,15 @@ describe Export::Pdf::Messages::Letter::Header do
     Message::Letter.new(body: 'simple text', group: top_group,
                         shipping_method: 'normal', pp_post: 'CH-3030 Bern, Belpstrasse 37')
   end
-  let(:pdf)      { Prawn::Document.new }
+  let(:pdf)      { Prawn::Document.new(options) }
   let(:analyzer) { PDF::Inspector::Text.analyze(pdf.render) }
   let(:image)    { Rails.root.join('spec/fixtures/files/images/logo.png') }
   let(:shipping_info_with_position) do
     [
-      [36, 657, 'P.P.'],
-      [56, 657, ' '],
-      [145, 670, 'Post CH AG'],
-      [59, 657, 'CH-3030 Bern, Belpstrasse 37']
+      [71, 672, 'P.P.'],
+      [91, 672, ' '],
+      [180, 685, 'Post CH AG'],
+      [94, 672, 'CH-3030 Bern, Belpstrasse 37']
     ]
   end
 
@@ -36,7 +42,7 @@ describe Export::Pdf::Messages::Letter::Header do
   describe 'logo' do
 
     def expects_image(id)
-      image_options = options.merge(position: :right)
+      image_options = { position: :right }
       expect_any_instance_of(Prawn::Document)
         .to receive(:image).with(instance_of(StringIO), image_options)
     end
@@ -112,8 +118,8 @@ describe Export::Pdf::Messages::Letter::Header do
     it 'is present' do
       subject.render(recipient)
       expect(text_with_position_without_shipping_info).to eq [
-        [36, 637, 'Top Leader'],
-        [36, 609, 'Supertown']
+        [71, 652, 'Top Leader'],
+        [71, 624, 'Supertown']
       ]
     end
 
@@ -122,14 +128,14 @@ describe Export::Pdf::Messages::Letter::Header do
       subject.render(recipient)
 
       expect(text_with_position_without_shipping_info).to eq [
-        [36, 637, 'Top Leader'],
-        [36, 609, 'Supertown']
+        [71, 652, 'Top Leader'],
+        [71, 624, 'Supertown']
       ]
     end
 
     context 'stamping' do
       let(:stamps) { pdf.instance_variable_get('@stamp_dictionary_registry') }
-      let(:options) { { stamped: true } }
+      let(:options) { base_options.merge({ stamped: true }) }
 
       it 'includes only receiver address' do
         subject.render(recipient)
@@ -137,10 +143,10 @@ describe Export::Pdf::Messages::Letter::Header do
         subject.render(recipient)
         expect(stamps.keys).to eq [:render_logo_right, :render_shipping_info]
         expect(text_with_position_without_shipping_info).to eq [
-          [36, 637, 'Top Leader'],
-          [36, 609, 'Supertown'],
-          [36, 637, 'Top Leader'],
-          [36, 609, 'Supertown']
+          [71, 652, 'Top Leader'],
+          [71, 624, 'Supertown'],
+          [71, 652, 'Top Leader'],
+          [71, 624, 'Supertown']
         ]
       end
 
@@ -151,10 +157,10 @@ describe Export::Pdf::Messages::Letter::Header do
         subject.render(recipient)
         expect(stamps.keys).to eq [:render_logo_right, :render_shipping_info]
         expect(text_with_position_without_shipping_info).to eq [
-          [36, 637, 'Top Leader'],
-          [36, 609, 'Supertown'],
-          [36, 637, 'Top Leader'],
-          [36, 609, 'Supertown']
+          [71, 652, 'Top Leader'],
+          [71, 624, 'Supertown'],
+          [71, 652, 'Top Leader'],
+          [71, 624, 'Supertown']
         ]
       end
 
@@ -174,8 +180,8 @@ describe Export::Pdf::Messages::Letter::Header do
       subject.render(recipient)
 
       expect(text_with_position_without_shipping_info).to eq [
-        [36, 637, 'Top Leader'],
-        [36, 609, 'Supertown']
+        [71, 652, 'Top Leader'],
+        [71, 624, 'Supertown']
       ]
     end
 
@@ -184,8 +190,8 @@ describe Export::Pdf::Messages::Letter::Header do
       subject.render(recipient)
 
       expect(text_with_position_without_shipping_info).to eq [
-        [36, 637, 'Top Leader'],
-        [36, 609, 'Supertown']
+        [71, 652, 'Top Leader'],
+        [71, 624, 'Supertown']
       ]
     end
 
@@ -194,7 +200,7 @@ describe Export::Pdf::Messages::Letter::Header do
       subject.render(recipient)
 
       expect(text_with_position_without_shipping_info).to eq [
-        [36, 637, 'Top Leader']
+        [71, 652, 'Top Leader']
       ]
     end
 


### PR DESCRIPTION
Refs: https://github.com/hitobito/hitobito_sww/issues/57

The change to `#offset_cursor_from_top` was simply to improve the api.
Problem was, the offset calculation had to change from the constant margin `Letter::MARGIN` to `pdf.page.margins[:top]`
With this change, I then realized that our specs for letter/content & letter/header never specified a margin.
Thus we always tested these sections somewhat wrong. The positions on the actual PDF exports didn't change. The reasons for the spec adjustments are because the analyzer shows the positions in the `pdf.bounds`. And these bounds are tied to the margin.

Manual tests showed no changes however to these letter exports. Also the transformations to the positions in specs do make mathematically sense.