### PR TITLE
Verbesserungen für Anlassanmeldungen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 *  Anlässe: Die Kontaktperson wird auf Wunsch per E-Mail über neue Anmeldungen benachrichtigt. Die Benachrichtigung wird auf dem Anlass aktiviert (#1540).
 *  Jede Person kann jetzt Zwei-Faktor-Authentifizierung mit einer TOTP-App aktivieren. Für einzelne Rollen kann die Zwei-Faktor-Authentifizierung obligatorisch gemacht werden.
 *  Die Haupt-Mailadresse von Personen mit Login muss neu bestätigt werden nachdem sie geändert wurde (#957).
-*  Gruppen verfügen nun über eine einfache Mitgliederstatistik auf dem Reiter "Statistiken" auf der Gruppe (hitobito_kljb#4). (Nur bei Verbänden die das bisher noch nicht hatten) 
+*  Gruppen verfügen nun über eine einfache Mitgliederstatistik auf dem Reiter "Statistiken" auf der Gruppe (hitobito_kljb#4). (Nur bei Verbänden die das bisher noch nicht hatten)
 *  Der Login-Status (hat kein Login, hat Login, 2FA, E-Mail versendet aber noch nicht akzeptiert) von Personen auf die man Schreibrechte hat kann jetzt als zusätzliche Spalte angezeigt werden (#1296).
 *  Sprache als Standardattribut auf Person (#1663)
 *  Anlässe, Kurse, etc. können neu getaggt werden (#1687)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hitobito Changelog
 
+## unreleased
+
+* Anmeldungen für öffentlich sichtbare Anlässe verbessert (#1775)
+
 ## Version 1.28
 
 *  Neuer Personentab "Sicherheit", welcher Informationen und Vorgänge zu Sicherheitsmassnahmen aufzeigt und das Passwort einer Person zurücksetzen lässt (benötigt :update Permission auf Person) (#1688)

--- a/app/controllers/event/register_controller.rb
+++ b/app/controllers/event/register_controller.rb
@@ -1,9 +1,12 @@
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
 class Event::RegisterController < ApplicationController
+  include DeprecationHelper
 
   helper_method :resource, :entry, :group, :event
 
@@ -11,6 +14,7 @@ class Event::RegisterController < ApplicationController
   before_action :assert_honeypot_is_empty, only: [:check, :register]
 
   def index
+    deprecated_action # should be public_events#show
     session[:person_return_to] = show_event_path
     flash.now[:notice] = translate(:not_logged_in, event: event)
   end

--- a/app/controllers/public_events_controller.rb
+++ b/app/controllers/public_events_controller.rb
@@ -1,17 +1,23 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2015, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
 class PublicEventsController < ApplicationController
+  # show event-tags if they are provided
+  include DryCrud::RenderCallbacks
+  define_render_callbacks :show
+  include Tags
+
+  # handle authorization
   skip_authorization_check
   skip_before_action :authenticate_person!
   before_action :assert_public_access, :assert_external_application_possible
 
+  # behave like most hitobito-controllers
   helper_method :entry
-
   decorates :entry
 
   private

--- a/app/controllers/public_events_controller.rb
+++ b/app/controllers/public_events_controller.rb
@@ -20,6 +20,12 @@ class PublicEventsController < ApplicationController
   helper_method :entry
   decorates :entry
 
+  # enable login-form
+  helper_method :resource
+
+  # enable external login
+  helper_method :group, :event
+
   private
 
   def assert_external_application_possible
@@ -42,4 +48,11 @@ class PublicEventsController < ApplicationController
   def entry
     @entry ||= group.events.find(params[:id])
   end
+
+  def person
+    @person ||= Person.new
+  end
+
+  alias resource person # used by devise-form
+  alias event entry # used by check-email-form
 end

--- a/app/controllers/public_events_controller.rb
+++ b/app/controllers/public_events_controller.rb
@@ -16,15 +16,10 @@ class PublicEventsController < ApplicationController
   skip_before_action :authenticate_person!
   before_action :assert_public_access, :assert_external_application_possible
 
-  # behave like most hitobito-controllers
-  helper_method :entry
+  helper_method :entry, # behave like most hitobito-controllers
+                :resource, # enable login-form
+                :group, :event # enable external login
   decorates :entry
-
-  # enable login-form
-  helper_method :resource
-
-  # enable external login
-  helper_method :group, :event
 
   private
 

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -123,6 +123,12 @@ class EventDecorator < ApplicationDecorator
     label = to_s
     label += " (#{number})" if number?
     h.safe_join([groups.first.to_s, label], ': ')
+  end
+
+  def any_conditions_present?
+    course_kind? ||
+      (used_attributes.include?(:application_conditions) &&
+       attr_present?(self, :application_conditions))
   end
 
   private

--- a/app/helpers/deprecation_helper.rb
+++ b/app/helpers/deprecation_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022-2022, Puzzle ITC GmbH. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module DeprecationHelper
+  def deprecated_action
+    send_deprecation("#{controller_path}##{action_name} was called unexpectedly.")
+  end
+
+  private
+
+  def send_deprecation(err)
+    Raven.capture_exception(ActiveSupport::DeprecationException.new(err), logger: 'deprecation')
+  end
+end

--- a/app/helpers/format_helper.rb
+++ b/app/helpers/format_helper.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2019, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -103,13 +103,23 @@ module FormatHelper
   # Like #render_attrs, but only for attributes with a present value.
   def render_present_attrs(obj, *attrs)
     render_attrs(obj, *attrs) do |a|
-      obj.send(a).present? || obj.send(a).is_a?(FalseClass)
+      attr_present?(obj, a)
     end
   end
 
   # Renders the formatted content of the given attribute with a label.
   def labeled_attr(obj, attr)
     labeled(captionize(attr, object_class(obj)), format_attr(obj, attr))
+  end
+
+  def present_labeled_attr(obj, attr)
+    labeled_attr(obj, attr) if attr_present?(obj, attr)
+  end
+
+  def attr_present?(obj, attr)
+    return false if attr.blank?
+
+    obj.send(attr).present? || obj.send(attr).is_a?(FalseClass)
   end
 
   def format_column(type, val) # rubocop:disable Metrics/CyclomaticComplexity

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -123,7 +123,7 @@ module LayoutHelper
   def closest_group_with_logo
     return unless @group
 
-    @group.self_and_ancestors.reverse.find do |group|
+    @group.self_and_ancestors.includes([:logo_attachment]).reverse.find do |group|
       upload_exists?(group, :logo)
     end
   end

--- a/app/helpers/unauthorized_helper.rb
+++ b/app/helpers/unauthorized_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022-2022, Puzzle ITC GmbH. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module UnauthorizedHelper
+  def hide_signup_links?
+    [
+      new_person_session_path,
+      new_person_password_path,
+      new_person_confirmation_path
+    ].one? do |path|
+      current_page?(path)
+    end
+  end
+end

--- a/app/helpers/unauthorized_helper.rb
+++ b/app/helpers/unauthorized_helper.rb
@@ -10,9 +10,20 @@ module UnauthorizedHelper
     [
       new_person_session_path,
       new_person_password_path,
-      new_person_confirmation_path
-    ].one? do |path|
+      new_person_confirmation_path,
+
+      maybe_group_public_event_path
+    ].compact.any? do |path|
       current_page?(path)
     end
+  end
+
+  private
+
+  def maybe_group_public_event_path
+    parameters = request.path_parameters.keys
+    return nil unless parameters.include?(:group_id) && parameters.include?(:id)
+
+    group_public_event_path # with implied parameters from the current request
   end
 end

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -9,3 +9,6 @@
   = f.error_messages
   = f.labeled(:email) { f.input_field(:email) }
   = f.indented submit_button(f,t('.reset_password_button'))
+
+  = f.indented do
+    = link_to t('devise.sessions.new.sign_in'), new_person_session_path

--- a/app/views/event/register/index.html.haml
+++ b/app/views/event/register/index.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
--title t('.sign_in')
+- title t('.sign_in')
 
 = render 'devise/sessions/info'
 

--- a/app/views/events/_attrs_application.html.haml
+++ b/app/views/events/_attrs_application.html.haml
@@ -1,9 +1,9 @@
 = section Event::Application.model_name.human do
   %dl.dl-horizontal
     - entry.used?(:application_opening_at) do
-      = labeled_attr(entry, :application_opening_at)
+      = present_labeled_attr(entry, :application_opening_at)
     - entry.used?(:application_closing_at) do
-      = labeled_attr(entry, :application_closing_at)
+      = present_labeled_attr(entry, :application_closing_at)
     = labeled_attr(entry, :booking_info)
     - entry.used?(:external_applications) do
       = labeled(Event.human_attribute_name(:external_applications), entry.external_application_link(@group))
@@ -25,6 +25,6 @@
       = labeled(Event::Kind.human_attribute_name(:prolongations),
                 entry.kind.qualification_kinds('prolongation', 'participant').join(', '))
 
-  = render_attrs(entry, *entry.used_attributes(:signature, :signature_confirmation))
+  = render_present_attrs(entry, *entry.used_attributes(:signature, :signature_confirmation))
 
   = render_extensions 'attrs_application', folder: 'events'

--- a/app/views/events/_attrs_application.html.haml
+++ b/app/views/events/_attrs_application.html.haml
@@ -8,15 +8,18 @@
     - entry.used?(:external_applications) do
       = labeled(Event.human_attribute_name(:external_applications), entry.external_application_link(@group))
 
-  %dl.dl-horizontal
-    - entry.used?(:application_conditions) do
-      = labeled(entry.class.human_attribute_name(:application_conditions)) do
-        %p.multiline= format_event_application_conditions(entry)
+  - if entry.any_conditions_present?
+    %dl.dl-horizontal
 
-    - if entry.course_kind?
-      = labeled(Event::Kind.human_attribute_name(:minimum_age),
-                entry.kind.minimum_age? ? t('events.minimum_age_with_years', minimum_age: entry.kind.minimum_age) : '')
-      = labeled(t('events.preconditions'), grouped_qualification_kinds_string(entry.kind, 'precondition', 'participant'))
+      - entry.used?(:application_conditions) do
+        - if attr_present?(entry, :application_conditions)
+          = labeled(entry.class.human_attribute_name(:application_conditions)) do
+            %p.multiline= format_event_application_conditions(entry)
+
+      - if entry.course_kind?
+        = labeled(Event::Kind.human_attribute_name(:minimum_age),
+                  entry.kind.minimum_age? ? t('events.minimum_age_with_years', minimum_age: entry.kind.minimum_age) : '')
+        = labeled(t('events.preconditions'), grouped_qualification_kinds_string(entry.kind, 'precondition', 'participant'))
 
   - if entry.course_kind?
     %dl.dl-horizontal

--- a/app/views/events/_tags.html.haml
+++ b/app/views/events/_tags.html.haml
@@ -3,22 +3,23 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-%dl.dl-horizontal
-  = labeled ActsAsTaggableOn::Tag.model_name.human(count: 2) do
-    = render 'event/tags/list', tags: @tags
+- if @tags
+  %dl.dl-horizontal
+    = labeled ActsAsTaggableOn::Tag.model_name.human(count: 2) do
+      = render 'event/tags/list', tags: @tags
 
-    - if can? :update, entry
-      %button.chip.chip-add.event-tag-add
-        = t('events.add_tag')
-        = icon(:plus)
+      - if can? :update, entry
+        %button.chip.chip-add.event-tag-add
+          = t('events.add_tag')
+          = icon(:plus)
 
-      = form_for(entry.tags.new, url: group_event_tags_path(@group, entry), remote: true,
-                     html: {class: 'event-tags-add-form', style: 'display:none'}) do |f|
-        = f.text_field(:name, placeholder: t('events.add_tag'),
-                                      data: { provide: 'entity',
-                                              url: group_event_tags_query_path(group_id: @group.id,
-                                                                               event_id: entry.id) })
+        = form_for(entry.tags.new, url: group_event_tags_path(@group, entry), remote: true,
+                       html: {class: 'event-tags-add-form', style: 'display:none'}) do |f|
+          = f.text_field(:name, placeholder: t('events.add_tag'),
+                                        data: { provide: 'entity',
+                                                url: group_event_tags_query_path(group_id: @group.id,
+                                                                                 event_id: entry.id) })
 
-        %button.btn{type: :submit}
-          = t('global.ok')
-          = spinner
+          %button.btn{type: :submit}
+            = t('global.ok')
+            = spinner

--- a/app/views/layouts/_unauthorized.html.haml
+++ b/app/views/layouts/_unauthorized.html.haml
@@ -4,7 +4,7 @@
 -#  https://github.com/hitobito/hitobito.
 
 = render 'layouts/languages'
-- unless current_page?(new_person_session_path)
-  %a= link_to t('devise.sessions.new.sign_in'), new_person_session_path
-- unless current_page?(new_person_password_path)
-  %a= link_to t('.forgot_password'), new_person_password_path
+
+- unless hide_signup_links?
+  = link_to t('devise.sessions.new.sign_in'), new_person_session_path
+  = link_to t('.forgot_password'), new_person_password_path

--- a/app/views/layouts/_unauthorized.html.haml
+++ b/app/views/layouts/_unauthorized.html.haml
@@ -4,5 +4,7 @@
 -#  https://github.com/hitobito/hitobito.
 
 = render 'layouts/languages'
-%a= link_to t('devise.sessions.new.sign_in'), new_person_session_path
-%a= link_to t('.forgot_password'), new_person_password_path
+- unless current_page?(new_person_session_path)
+  %a= link_to t('devise.sessions.new.sign_in'), new_person_session_path
+- unless current_page?(new_person_password_path)
+  %a= link_to t('.forgot_password'), new_person_password_path

--- a/app/views/public_events/_attrs_primary.html.haml
+++ b/app/views/public_events/_attrs_primary.html.haml
@@ -1,4 +1,4 @@
--#  Copyright (c) 2012-2015, Jungwacht Blauring Schweiz. This file is part of
+-#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
@@ -7,24 +7,24 @@
   %dl.dl-horizontal
     = labeled_attr(entry, :dates_full)
     - entry.used?(:motto) do
-      = labeled_attr(entry, :motto)
+      = present_labeled_attr(entry, :motto)
     - entry.used?(:cost) do
-      = labeled_attr(entry, :cost)
+      = present_labeled_attr(entry, :cost)
 
   %dl.dl-horizontal
     - entry.used?(:kind_id) do
-      = labeled_attr(entry, :kind_id)
+      = present_labeled_attr(entry, :kind_id)
       = render_extensions :kind, folder: 'events'
 
     = render_extensions :attrs_main
 
     - entry.used?(:number) do
-      = labeled_attr(entry, :number)
+      = present_labeled_attr(entry, :number)
 
     = labeled(t('event.run_by'), entry.group_names)
 
     - entry.used?(:state) do
-      = labeled_attr(entry, :state_translated)
+      = present_labeled_attr(entry, :state_translated)
 
   = render_present_attrs(entry, :description, :location)
 

--- a/app/views/public_events/show.html.haml
+++ b/app/views/public_events/show.html.haml
@@ -5,20 +5,31 @@
 
 - title entry.to_s
 
-- content_for(:toolbar, button_action_public_event_apply(entry, @group))
+#main
+  .row-fluid
+    %article.span7
+      = render 'attrs_primary'
 
-#main.row-fluid
-  %article.span7
-    = render 'attrs_primary'
+      = render 'events/attachments'
 
-    = render 'events/attachments'
+      = render_extensions 'show_left'
 
-    = render_extensions 'show_left'
+    %aside.span5
+      = render 'events/attrs_contact'
 
-  %aside.span5
-    = render 'events/attrs_contact'
+      - if entry.participant_types.present?
+        = render 'events/attrs_application'
 
-    - if entry.participant_types.present?
-      = render 'events/attrs_application'
+      = render_extensions 'show_right'
 
-    = render_extensions 'show_right'
+  %h1
+    = t('event.register.index.sign_in')
+
+  .row-fluid
+    %article.span6
+      %h3= t('event.register.index.login')
+      = render 'devise/sessions/form'
+
+    %article.span6
+      %h3= t('event.register.index.no_login')
+      = render 'event/register/email_check'

--- a/app/views/public_events/show.html.haml
+++ b/app/views/public_events/show.html.haml
@@ -25,6 +25,8 @@
   %h1
     = t('event.register.index.sign_in')
 
+  = render 'devise/sessions/info'
+
   .row-fluid
     %article.span6
       %h3= t('event.register.index.login')

--- a/bin/wagon
+++ b/bin/wagon
@@ -168,7 +168,20 @@ case $cmd in
   completion)
     cat <<"COMPLETION"
 function __wagon_commands() {
-  echo 'activate gemfile configs test-prepare core-spec grep help git list create update-copyright overwritten-in-wagon'
+  echo '
+    activate
+    configs
+    core-spec
+    create
+    gemfile
+    git
+    grep
+    help
+    list
+    overwritten-in-wagon
+    test-prepare
+    update-copyright
+  ' | xargs
 }
 
 function __wagon_list() {

--- a/bin/wagon
+++ b/bin/wagon
@@ -160,11 +160,15 @@ case $cmd in
     popd
     ;;
 
+  overwritten-in-wagon)
+    git diff master.. --name-only app/views/ |\
+      xargs -L1 -I% find ../ -path "*/%" -a \! -regex ".*\(ose_composition\|hitobito-development\).*"
+    ;;
 
   completion)
     cat <<"COMPLETION"
 function __wagon_commands() {
-  echo 'activate gemfile configs test-prepare core-spec grep help git list create update-copyright'
+  echo 'activate gemfile configs test-prepare core-spec grep help git list create update-copyright overwritten-in-wagon'
 }
 
 function __wagon_list() {

--- a/spec/utils/imap/connector_spec.rb
+++ b/spec/utils/imap/connector_spec.rb
@@ -1,6 +1,6 @@
 #  frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Hitobito AG. This file is part of
+#  Copyright (c) 2012-2022, Hitobito AG. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -124,7 +124,7 @@ describe Imap::Connector do
       # check mail content
       expect(mail1.uid).to eq('42')
       expect(mail1.subject).to be(imap_fetch_data_1.attr['ENVELOPE'].subject)
-      expect(mail1.date).to eq(Time.zone.utc_to_local(DateTime.parse(Time.now.to_s)))
+      expect(mail1.date).to be_within(2.seconds).of(Time.zone.utc_to_local(Time.now))
       expect(mail1.sender_email).to eq('john@sender.com')
       expect(mail1.sender_name).to eq('sender')
       expect(mail1.plain_text_body).to eq('SpaceX rocks!')


### PR DESCRIPTION
Um die Anmeldungen für Anlässe zu erleichtern, wird die extra Seite zwischen Anlassinformationen und Kontaktinformationen direkt im ersten Schritt angezeigt.

Die Login-Links oben rechts können pro Seite ausgeschaltet werden, um Verwirrung zu vermeiden.

Weiterhin werden nur die eingetragenen Infos vom Anlass angezeigt und ein Darstellungsbug bei der Anzeige der vergebenen Tags behoben. 

Fixes #1775 