### PR TITLE
Improve household list performance

### DIFF
--- a/app/domain/messages/letter_dispatch.rb
+++ b/app/domain/messages/letter_dispatch.rb
@@ -47,13 +47,13 @@ module Messages
       household_list = People::HouseholdList.new(limit(people, @options[:recipient_limit]&.div(2)))
 
       # first, run a separate batch for people that are grouped in households, because that's slower
-      household_list.households_in_batches(exclude_non_households: true) do |batch|
+      household_list.only_households_in_batches do |batch|
         create_recipient_entries(batch)
         update!(success_count: success_count + batch.size)
       end
 
       # batch run for people without household
-      household_list.people_without_household.find_in_batches do |batch|
+      household_list.people_without_household_in_batches do |batch|
         count = create_recipient_entries(batch)
         update!(success_count: success_count + count)
       end


### PR DESCRIPTION
Fixes #1810
Fixes #1553

Ich habe folgende Änderungen vorgenommen, geordnet nach absteigender vermuteter Nützlichkeit für die Performance:
- Alle IDs der zu gruppierenden Personen werden zuerst in Memory geladen, und die gruppierenden SQL-Queries arbeiten dann mit `WHERE id IN (...)` statt mit den komplexen Bedingungen die von den Abo-Subscribers her kommen. Bei ca. 44'000 Personen sind das theoretisch 44'000 * 4 Bytes (integer ID) = ca. 172 kB RAM das dafür nötig ist.
- Die Personen die in Haushalten sind und Personen die in keinem Haushalt sind werden in zwei Teilqueries berechnet und via `UNION ALL` kombiniert
- ~~Die Daten werden jetzt nicht mehr während dem Batchen neu sortiert, sondern in der Reihenfolge belassen die vom `UNION ALL` her kommt (zuerst die Haushalte in absteigender Grösse, danach die haushaltlosen Personen in aufsteigender ID-Reihenfolge). Technisch gesehen ist dadurch die Implementation jetzt ein bisschen weniger korrekt als vorher: Personen die in einem Haushalt wohnen aber deren Mitbewohner*innen nicht im Abo sind, erscheinen jetzt trotzdem unter den Haushalts-Personen.~~ Diese Massnahme hat das Batching durcheinander gebracht. Die Sortierung ist zwingend nötig.
- Durch das `UNION ALL` ist der ganze Query insgesamt jetzt kein `GROUP BY` Query mehr, darum können wir fürs (bereits vorher bestehende) Cursor-basierte Batching `WHERE` statt `HAVING` verwenden
- Einige kleinere Dinge umbenannt für bessere Verständlichkeit was genau abgeht

Der Sarasani-Export kann jetzt lokal in ca. 18 Minuten generiert werden. 8 Minuten davon gehen für die Berechnung der IDs aller Personen im Sarasani-Abo drauf.

TODO:
- [x] Überprüfen ob die Tests noch laufen und allenfalls fixen
- [x] Sarasani-Export via UI statt via Rails Konsole testen
- [x] Smoke test ob die ausgespuckten Daten immer noch normal aussehen
- [x] Brief-Counter-Berechnung manuell testen
- [x] Brief-Vorschau manuell testen
- [x] Brief-Dispatch manuell testen