### PR TITLE
Fix invoices filter by nesting all in the same form tag

### DIFF
--- a/app/javascript/stylesheets/hitobito/modules/_invoice.scss
+++ b/app/javascript/stylesheets/hitobito/modules/_invoice.scss
@@ -94,6 +94,10 @@
   margin-bottom: 0;
 }
 
+.invoices-daterange-filter {
+  margin-top: -2rem;
+}
+
 .invoices-filter + div + div {
   margin-top: 20px;
 }

--- a/app/views/invoices/_filter.html.haml
+++ b/app/views/invoices/_filter.html.haml
@@ -14,8 +14,8 @@
     - if params[:state].blank? || params[:state] == 'reminded'
       = direct_filter_select(:due_since, invoice_due_since_options, t('.due_since'))
 
-  .pull-right
-    = form_tag(nil, { method: :get, class: 'form-inline-search', role: 'search', remote: true, data: { spin: true } }) do |f|
-      = direct_filter_date(:from, t('.from'), value: params[:from] || "1.1.#{@year || Time.zone.today.year}", data: { submit: true })
-      = direct_filter_date(:to, t('.to'), value: params[:to] || "31.12.#{@year || Time.zone.today.year}", data: { submit: true })
+    %div
+      .pull-right.invoices-daterange-filter
+        = direct_filter_date(:from, t('.from'), value: params[:from] || "1.1.#{@year || Time.zone.today.year}", data: { submit: true })
+        = direct_filter_date(:to, t('.to'), value: params[:to] || "31.12.#{@year || Time.zone.today.year}", data: { submit: true })
 - params[:q] = nil # Reset param so quicksearch filter does not get populated


### PR DESCRIPTION
Before, there were two forms for the filter
Meaning when selecting a daterange and then changing the other filter, it removes the daterange filter