### PR TITLE
DJ-Setup separieren

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,12 +14,12 @@ gem 'acts-as-taggable-on'
 gem 'airbrake'
 gem 'awesome_nested_set'
 gem 'aws-sdk-s3', require: false
-gem 'caxlsx', '~>3.0.0'
 gem 'bcrypt'
 gem 'bleib', '~> 0.0.10'
 gem 'bootsnap', require: false
 gem 'cancancan'
 gem 'carrierwave'
+gem 'caxlsx', '~>3.0.0'
 gem 'cmess'
 gem 'commonmarker'
 gem 'config'

--- a/config/application.rb
+++ b/config/application.rb
@@ -94,6 +94,10 @@ module Hitobito
       end
     end
 
+    config.to_prepare do
+      ActionMailer::Base.default from: Settings.email.sender
+    end
+
     def self.sphinx_version
       @sphinx_version ||= ThinkingSphinx::Configuration.instance.controller.sphinx_version.presence ||
         ENV['RAILS_SPHINX_VERSION']

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,29 +87,6 @@ module Hitobito
       g.test_framework :rspec, fixture: true
     end
 
-    config.to_prepare do
-      ActionMailer::Base.default from: Settings.email.sender
-
-      if ActiveRecord::Base.connection.data_source_exists?('delayed_jobs')
-
-        if MailConfig.legacy?
-          MailRelayJob.new.schedule
-        else
-          MailingLists::MailRetrieverJob.new.schedule
-        end
-
-        SphinxIndexJob.new.schedule if Application.sphinx_present? && Application.sphinx_local?
-        DownloadCleanerJob.new.schedule
-        SessionsCleanerJob.new.schedule
-        WorkerHeartbeatCheckJob.new.schedule
-        ReoccuringMailchimpSynchronizationJob.new.schedule
-        Address::CheckValidityJob.new.schedule if Settings.addresses.token
-        Address::ImportJob.new.schedule if Settings.addresses.token
-        People::DuplicateLocatorJob.new.schedule
-        Payments::EbicsImportJob.new.schedule
-      end
-    end
-
     initializer :define_sphinx_indizes, before: :add_to_prepare_blocks do |app|
       # only add here to be the last one
       app.config.to_prepare do

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -15,6 +15,10 @@ task :mysql do # rubocop:disable Rails/RakeEnvironment
 end
 
 namespace :db do
+  task :migrate do # rubocop:disable Rails/RakeEnvironment This task is only extended here and has all needed preconditions set
+    Rake::Task['delayed_job:schedule'].invoke
+  end
+
   desc 'Rebuild Nested-Set'
   task rebuild_nested_set: [:environment] do
     puts 'Rebuilding nested set...'

--- a/lib/tasks/delayed_jobs.rake
+++ b/lib/tasks/delayed_jobs.rake
@@ -7,30 +7,34 @@
 
 namespace :delayed_job do
   desc 'Schedule Background-Jobs'
-  task :schedule => [:environment, :'db:abort_if_pending_migrations'] do
+  task schedule: [:environment, :'db:abort_if_pending_migrations'] do
     next if Rails.env.test?
 
-    if ActiveRecord::Base.connection.data_source_exists?('delayed_jobs')
-
-      if MailConfig.legacy?
-        MailRelayJob.new.schedule
-      else
-        MailingLists::MailRetrieverJob.new.schedule
-      end
-
-      SphinxIndexJob.new.schedule if Hitobito::Application.sphinx_present? && Hitobito::Application.sphinx_local?
-      DownloadCleanerJob.new.schedule
-      SessionsCleanerJob.new.schedule
-      WorkerHeartbeatCheckJob.new.schedule
-      ReoccuringMailchimpSynchronizationJob.new.schedule
-      Address::CheckValidityJob.new.schedule if Settings.addresses.token
-      Address::ImportJob.new.schedule if Settings.addresses.token
-      People::DuplicateLocatorJob.new.schedule
-      Payments::EbicsImportJob.new.schedule
+    if MailConfig.legacy?
+      MailRelayJob.new.schedule
+    else
+      MailingLists::MailRetrieverJob.new.schedule
     end
+
+    if Hitobito::Application.sphinx_present? && Hitobito::Application.sphinx_local?
+      SphinxIndexJob.new.schedule
+    end
+
+    DownloadCleanerJob.new.schedule
+    SessionsCleanerJob.new.schedule
+    WorkerHeartbeatCheckJob.new.schedule
+    ReoccuringMailchimpSynchronizationJob.new.schedule
+
+    if Settings.addresses.token
+      Address::CheckValidityJob.new.schedule
+      Address::ImportJob.new.schedule
+    end
+
+    People::DuplicateLocatorJob.new.schedule
+    Payments::EbicsImportJob.new.schedule
   end
 
-  task :clear => [:environment] do
+  task clear: [:environment] do
     Delayed::Job.delete_all
   end
 end

--- a/lib/tasks/delayed_jobs.rake
+++ b/lib/tasks/delayed_jobs.rake
@@ -10,8 +10,6 @@ namespace :delayed_job do
   task :schedule => [:environment, :'db:abort_if_pending_migrations'] do
     next if Rails.env.test?
 
-    ActionMailer::Base.default from: Settings.email.sender
-
     if ActiveRecord::Base.connection.data_source_exists?('delayed_jobs')
 
       if MailConfig.legacy?

--- a/lib/tasks/delayed_jobs.rake
+++ b/lib/tasks/delayed_jobs.rake
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022-2022, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+namespace :delayed_job do
+  desc 'Schedule Background-Jobs'
+  task :schedule => [:environment, :'db:abort_if_pending_migrations'] do
+    next if Rails.env.test?
+
+    ActionMailer::Base.default from: Settings.email.sender
+
+    if ActiveRecord::Base.connection.data_source_exists?('delayed_jobs')
+
+      if MailConfig.legacy?
+        MailRelayJob.new.schedule
+      else
+        MailingLists::MailRetrieverJob.new.schedule
+      end
+
+      SphinxIndexJob.new.schedule if Hitobito::Application.sphinx_present? && Hitobito::Application.sphinx_local?
+      DownloadCleanerJob.new.schedule
+      SessionsCleanerJob.new.schedule
+      WorkerHeartbeatCheckJob.new.schedule
+      ReoccuringMailchimpSynchronizationJob.new.schedule
+      Address::CheckValidityJob.new.schedule if Settings.addresses.token
+      Address::ImportJob.new.schedule if Settings.addresses.token
+      People::DuplicateLocatorJob.new.schedule
+      Payments::EbicsImportJob.new.schedule
+    end
+  end
+
+  task :clear => [:environment] do
+    Delayed::Job.delete_all
+  end
+end


### PR DESCRIPTION
Aktuell werden bei jedem Reload in der Console auch immer die Jobs neu in die DB geladen. Ich würde gerne etwas mehr Kontrolle darüber haben. Da der DJ-Setup im Kern ein DB-Setup ist, habe ich es als Folgetask an die Migrationen angehängt. Damit ist es erstmal aus dem Weg während des Entwickelns, aber vorhanden, wenn man einen Setup macht. 

Ich habe noch nicht geschaut, welche Wagons davon auch noch betroffen sind. Da der bisherigen Weg ja auch noch funktioniert, würde ich das dann bei Bedarf und Gelegenheit angehen.