### PR TITLE
PERSON: Daten via API... add ability to show details

### DIFF
--- a/app/abilities/token_ability.rb
+++ b/app/abilities/token_ability.rb
@@ -47,6 +47,11 @@ class TokenAbility
         Ability.new(token.dynamic_user).can?(:show_full, p)
     end
 
+    can :show_details, [Person, PersonDecorator] do |p|
+      Role.where(person: p, group: groups).present? &&
+        Ability.new(token.dynamic_user).can?(:show_details, p)
+    end
+
     can :index_people, Group do |g|
       groups.include?(g)
     end

--- a/spec/controllers/person_duplicates/ignore_controller_spec.rb
+++ b/spec/controllers/person_duplicates/ignore_controller_spec.rb
@@ -27,7 +27,7 @@ describe PersonDuplicates::IgnoreController do
       it 'is not possible to access confirm dialog without write permission on at least one person' do
         sign_in(people(:top_leader))
 
-        expect { post :new, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id } }.to raise_error(CanCan::AccessDenied)
+        expect(post :new, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id }).to have_http_status(403)
 
         expect(duplicate_entry.reload.ignore).to eq(false)
       end
@@ -35,7 +35,7 @@ describe PersonDuplicates::IgnoreController do
       it 'is not possible access confirm dialog  without permission to manage person duplicates' do
         sign_in(people(:bottom_member))
 
-        expect { post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id } }.to raise_error(CanCan::AccessDenied)
+        expect(post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id }).to have_http_status(403)
 
         expect(duplicate_entry.reload.ignore).to eq(false)
       end
@@ -56,7 +56,7 @@ describe PersonDuplicates::IgnoreController do
       it 'is not possible to ignore without write permission on at least one person' do
         sign_in(people(:top_leader))
 
-        expect { post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id } }.to raise_error(CanCan::AccessDenied)
+        expect(post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id }).to have_http_status(403)
 
         expect(duplicate_entry.reload.ignore).to eq(false)
       end
@@ -64,7 +64,7 @@ describe PersonDuplicates::IgnoreController do
       it 'is not possible to ignore without permission to manage person duplicates' do
         sign_in(people(:bottom_member))
 
-        expect { post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id } }.to raise_error(CanCan::AccessDenied)
+        expect(post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id }).to have_http_status(403)
 
         expect(duplicate_entry.reload.ignore).to eq(false)
       end

--- a/spec/controllers/person_duplicates/merge_controller_spec.rb
+++ b/spec/controllers/person_duplicates/merge_controller_spec.rb
@@ -26,13 +26,13 @@ describe PersonDuplicates::MergeController do
       it 'is not possible to access merge form dialog without write permission on at least one person' do
         sign_in(people(:top_leader))
 
-        expect { post :new, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id } }.to raise_error(CanCan::AccessDenied)
+        expect(post :new, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id }).to have_http_status(403)
       end
 
       it 'is not possible access merge form dialog without permission to manage person duplicates' do
         sign_in(people(:bottom_member))
 
-        expect { post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id } }.to raise_error(CanCan::AccessDenied)
+        expect(post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id }).to have_http_status(403)
       end
     end
 
@@ -52,7 +52,7 @@ describe PersonDuplicates::MergeController do
       it 'is not possible to merge without write permission on at least one person' do
         sign_in(people(:top_leader))
 
-        expect { post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id, person_duplicate: { dst_person: 'person_2' } } }.to raise_error(CanCan::AccessDenied)
+        expect(post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id, person_duplicate: { dst_person: 'person_2' } }).to have_http_status(403)
 
         expect(PersonDuplicate.where(id: duplicate_entry.id)).to exist
         expect(Person.where(id: person_1.id)).to exist
@@ -62,7 +62,7 @@ describe PersonDuplicates::MergeController do
       it 'is not possible to merge without permission to manage person duplicates' do
         sign_in(people(:bottom_member))
 
-        expect { post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id, person_duplicate: { dst_person: 'person_2' } } }.to raise_error(CanCan::AccessDenied)
+        expect(post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id, person_duplicate: { dst_person: 'person_2' } }).to have_http_status(403)
 
         expect(PersonDuplicate.where(id: duplicate_entry.id)).to exist
         expect(Person.where(id: person_1.id)).to exist


### PR DESCRIPTION
Possible fix for issue: [PERSON: Daten via API vs JSON+Token inkonsistent #1460 ](https://github.com/hitobito/hitobito/issues/1460)
Adds the ability to show all details of a person when using the api-key.

Fixes #1460
Fixes hitobito/hitobito_pbs#193