### PR TITLE
Add valid or reactivateable precondition to event kind qualification kind

### DIFF
--- a/app/domain/event/precondition_checker.rb
+++ b/app/domain/event/precondition_checker.rb
@@ -82,12 +82,6 @@ class Event::PreconditionChecker
     course.kind.qualification_kinds('precondition', 'participant')
   end
 
-  def reactivateable?(qualification_kind_id)
-    person_qualifications.
-      select { |q| q.qualification_kind_id == qualification_kind_id }.
-      any? { |qualification| qualification.reactivateable?(course.start_date) }
-  end
-
   def valid_qualification?(qualification_kind_id, validity)
     scope = case validity.to_sym
     when :valid

--- a/app/javascript/javascripts/modules/event_kind_preconditions.js.coffee
+++ b/app/javascript/javascripts/modules/event_kind_preconditions.js.coffee
@@ -49,7 +49,9 @@ app.EventKindPreconditions = {
   buildValidityFields: (grouping) ->
     validId = 'event_kind_precondition_qualification_kinds_' + grouping + '_valid'
     validOrExpiredId = 'event_kind_precondition_qualification_kinds_' + grouping + '_valid_or_expired'
-    '<label class="precondition-validity radio" for="' + validId + '">' + $('#precondition_summary').data('validity-valid') + '<input id="' + validId + '" name="event_kind[precondition_qualification_kinds][' + grouping + '][validity]" type="radio" value="valid" /></label>' + 
+    validOrReactivatableId = 'event_kind_precondition_qualification_kinds_' + grouping + '_valid_or_reactivatable'
+    '<label class="precondition-validity radio" for="' + validId + '">' + $('#precondition_summary').data('validity-valid') + '<input id="' + validId + '" name="event_kind[precondition_qualification_kinds][' + grouping + '][validity]" type="radio" value="valid" /></label>' +
+    '<label class="precondition-validity radio" for="' + validOrReactivatableId + '">' + $('#precondition_summary').data('validity-valid-or-reactivateable') + '<input id="' + validOrReactivatableId + '" name="event_kind[precondition_qualification_kinds][' + grouping + '][validity]" type="radio" value="valid_or_reactivatable" checked="checked" /></label>' + 
     '<label class="precondition-validity radio" for="' + validOrExpiredId + '">' + $('#precondition_summary').data('validity-valid-or-expired') + '<input id="' + validOrExpiredId + '" name="event_kind[precondition_qualification_kinds][' + grouping + '][validity]" type="radio" value="valid_or_expired" checked="checked" /></label>'
 
 

--- a/app/models/event/kind_qualification_kind.rb
+++ b/app/models/event/kind_qualification_kind.rb
@@ -59,6 +59,6 @@ class Event::KindQualificationKind < ActiveRecord::Base
   validates :category, inclusion: { in: CATEGORIES }
   validates :role, inclusion: { in: ROLES }
 
-  i18n_enum :validity, %w(valid valid_or_expired)
+  i18n_enum :validity, %w(valid valid_or_expired valid_or_reactivatable)
 
 end

--- a/app/views/event/kinds/_precondition_fields.html.haml
+++ b/app/views/event/kinds/_precondition_fields.html.haml
@@ -5,7 +5,8 @@
                                data: { and: t('event.kinds.qualifications.and'),
                                  or: t('event.kinds.qualifications.or'),
                                  validity_valid: t('activerecord.attributes.event/kind_qualification_kinds.validities.valid'),
-                                 validity_valid_or_expired: t('activerecord.attributes.event/kind_qualification_kinds.validities.valid_or_expired') } }
+                                 validity_valid_or_reactivatable: t('activerecord.attributes.event/kind_qualification_kinds.validities.valid_or_reactivatable'),
+                                 validity_valid_or_expired: t('activerecord.attributes.event/kind_qualification_kinds.validities.valid_or_expired')} }
     - entry.grouped_qualification_kind_ids_and_validity('precondition', 'participant').each_with_index do |ids, index|
       .precondition-grouping
         - ids.each do |id|
@@ -19,6 +20,9 @@
         %label.radio.precondition-validity{for: "event_kind_precondition_qualification_kinds_#{index}_validity_valid"}
           = t('activerecord.attributes.event/kind_qualification_kinds.validities.valid')
           = radio_button_tag("event_kind[precondition_qualification_kinds][#{index}][validity]", 'valid', ids.first.last == 'valid')
+        %label.radio.precondition-validity{for: "event_kind_precondition_qualification_kinds_#{index}_validity_valid_or_reactivatable"}
+          = radio_button_tag("event_kind[precondition_qualification_kinds][#{index}][validity]", 'valid_or_reactivatable', ids.first.last == 'valid_or_reactivatable')
+          = t('activerecord.attributes.event/kind_qualification_kinds.validities.valid_or_reactivatable')
         %label.radio.precondition-validity{for: "event_kind_precondition_qualification_kinds_#{index}_validity_valid_or_expired"}
           = radio_button_tag("event_kind[precondition_qualification_kinds][#{index}][validity]", 'valid_or_expired', ids.first.last == 'valid_or_expired')
           = t('activerecord.attributes.event/kind_qualification_kinds.validities.valid_or_expired')

--- a/app/views/event/participations/_precondition_warnings.html.haml
+++ b/app/views/event/participations/_precondition_warnings.html.haml
@@ -1,8 +1,8 @@
--#  Copyright (c) 2012-2015, Pfadibewegung Schweiz. This file is part of
+-#  Copyright (c) 2012-2022, Pfadibewegung Schweiz. This file is part of
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
 - if @precondition_warnings.present?
   .alert.alert-warning
-    %p.multiline= @precondition_warnings.flatten.join("\n")
+    %p.multiline= sanitize(@precondition_warnings.flatten.join("\n"), tags: %w(b))

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -589,6 +589,7 @@ de:
         validities:
           valid: Muss gültig sein
           valid_or_expired: Muss gültig oder weggefallen sein
+          valid_or_reactivatable: Muss gültig oder reaktivierbar sein
 
       event/invitation:
         participation_type: Teilnahmerolle

--- a/spec/domain/event/precondition_checker_spec.rb
+++ b/spec/domain/event/precondition_checker_spec.rb
@@ -62,12 +62,13 @@ describe Event::PreconditionChecker do
     let(:sl) { qualification_kinds(:sl) }
     let(:qualifications) { person.qualifications }
 
-    describe 'with valid validity' do
+    describe 'with validity valid' do
       before do
         course.kind.event_kind_qualification_kinds.create!(qualification_kind_id: sl.id,
                                                            category: 'precondition',
                                                            role: 'participant',
                                                            validity: :valid)
+        sl.update!(reactivateable: 100)
       end
 
 

--- a/spec/domain/event/precondition_checker_spec.rb
+++ b/spec/domain/event/precondition_checker_spec.rb
@@ -68,7 +68,6 @@ describe Event::PreconditionChecker do
                                                            category: 'precondition',
                                                            role: 'participant',
                                                            validity: :valid)
-        sl.update!(reactivateable: 100)
       end
 
 
@@ -82,8 +81,136 @@ describe Event::PreconditionChecker do
         its(:valid?) { should be_falsey }
 
         context "'super lead kind' reactivateable in range" do
-          before { sl.update_attribute(:reactivateable, Date.today.year - expired_date.year) }
+          before { sl.update_attribute(:reactivateable, 2) }
+          before { qualifications.first.update_attribute(:finish_at, course_start_at - sl.reactivateable.years) }
+          its(:valid?) { should be_falsey }
+        end
+
+        context "'super lead kind' reactivateable outside range" do
+          before { sl.update_attribute(:reactivateable, 2) }
+          before { qualifications.first.update_attribute(:finish_at, course_start_at - sl.reactivateable.years - 1) }
+          its(:valid?) { should be_falsey }
+        end
+      end
+
+      context "person with valid 'super lead'" do
+        before { qualifications << Fabricate(:qualification, qualification_kind: sl, start_at: valid_date) }
+        its(:valid?) { should be_truthy }
+        its(:errors_text) { should == [] }
+      end
+
+      context "person with expired and valid 'super lead'" do
+        before do
+          qualifications << Fabricate(:qualification, qualification_kind: sl, start_at: expired_date)
+          qualifications << Fabricate(:qualification, qualification_kind: sl, start_at: valid_date)
+        end
+        its(:valid?) { should be_truthy }
+        its(:errors_text) { should == [] }
+      end
+
+      context "person with unlimited 'super lead'" do
+        before do
+          sl.update_attribute(:validity, nil)
+          qualifications << Fabricate(:qualification, qualification_kind: sl, start_at: course_start_at - 1.day)
+        end
+
+        its(:valid?) { should be_truthy }
+      end
+
+      context 'multiple preconditions' do
+        let(:gl) { qualification_kinds(:gl) }
+
+        before do
+          course.kind.event_kind_qualification_kinds.create!(qualification_kind_id: gl.id,
+                                                             category: 'precondition',
+                                                             role: 'participant',
+                                                             validity: :valid)
+        end
+
+        its('errors_text.last') { should =~ /Qualifikationen fehlen: Super Lead, Group Lead/ }
+
+        context 'missing only one' do
+          before { qualifications << Fabricate(:qualification, qualification_kind: sl, start_at: valid_date) }
+
+          its(:valid?) { should be_falsey }
+          its('errors_text.last') { should =~ /Qualifikationen fehlen: Group Lead/ }
+        end
+
+        context 'with both present' do
+          before do
+            qualifications << Fabricate(:qualification, qualification_kind: gl, start_at: course_start_at - gl.validity.years)
+            qualifications << Fabricate(:qualification, qualification_kind: sl, start_at: valid_date)
+          end
+
           its(:valid?) { should be_truthy }
+        end
+
+        context 'in multiple groups' do
+          let(:ql) { qualification_kinds(:ql) }
+
+          before do
+            course.kind.event_kind_qualification_kinds.create!(qualification_kind_id: ql.id,
+                                                               category: 'precondition',
+                                                               role: 'participant',
+                                                               grouping: 1,
+                                                               validity: :valid)
+          end
+
+          its('errors_text.last') { should =~ /Erforderliche Qualifikationen fehlen/ }
+
+          context 'missing only one in a grouping' do
+            before { qualifications << Fabricate(:qualification, qualification_kind: sl, start_at: valid_date) }
+
+            its(:valid?) { should be_falsey }
+            its('errors_text.last') { should =~ /Erforderliche Qualifikationen fehlen/ }
+          end
+
+          context 'with both in grouping nil' do
+            before do
+              qualifications << Fabricate(:qualification, qualification_kind: gl, start_at: course_start_at - gl.validity.years)
+              qualifications << Fabricate(:qualification, qualification_kind: sl, start_at: valid_date)
+            end
+
+            its(:valid?) { should be_truthy }
+          end
+
+          context 'with the single one in grouping 1' do
+            before { qualifications << Fabricate(:qualification, qualification_kind: ql, start_at: valid_date) }
+
+            its(:valid?) { should be_truthy }
+          end
+        end
+      end
+    end
+
+    describe 'with validity valid_or_reactivatable' do
+      before do
+        course.kind.event_kind_qualification_kinds.create!(qualification_kind_id: sl.id,
+                                                           category: 'precondition',
+                                                           role: 'participant',
+                                                           validity: :valid_or_reactivatable)
+      end
+
+
+      context "person without 'super lead'" do
+        its(:valid?) { should be_falsey }
+        its('errors_text.last') { should =~ /Qualifikationen fehlen: Super Lead/ }
+      end
+
+      context "person with expired 'super lead'" do
+        before { qualifications << Fabricate(:qualification, qualification_kind: sl, start_at: expired_date) }
+        its(:valid?) { should be_falsey }
+
+        context "'super lead kind' reactivateable in range" do
+          before { sl.update_attribute(:reactivateable, 2) }
+          before { qualifications.first.update_attribute(:finish_at, course_start_at - sl.reactivateable.years) }
+          its(:valid?) { should be_truthy }
+        end
+
+        context "'super lead kind' reactivateable outside range" do
+          before { sl.update_attribute(:reactivateable, 2) }
+          before { qualifications.first.update_attribute(:finish_at, course_start_at - sl.reactivateable.years - 1) }
+          its(:valid?) { should be_falsey }
         end
       end
 
@@ -196,7 +323,14 @@ describe Event::PreconditionChecker do
         its(:valid?) { should be_truthy }
 
         context "'super lead kind' reactivateable in range" do
-          before { sl.update_attribute(:reactivateable, Date.today.year - expired_date.year) }
+          before { sl.update_attribute(:reactivateable, 2) }
+          before { qualifications.first.update_attribute(:finish_at, course_start_at - sl.reactivateable.years) }
+          its(:valid?) { should be_truthy }
+        end
+
+        context "'super lead kind' reactivateable outside range" do
+          before { sl.update_attribute(:reactivateable, 2) }
+          before { qualifications.first.update_attribute(:finish_at, course_start_at - sl.reactivateable.years - 1) }
           its(:valid?) { should be_truthy }
         end
       end

--- a/spec/domain/event/precondition_checker_spec.rb
+++ b/spec/domain/event/precondition_checker_spec.rb
@@ -328,7 +328,7 @@ describe Event::PreconditionChecker do
           its(:valid?) { should be_truthy }
         end
 
-        context "'super lead kind' reactivateable outside range" do
+        context "'super lead kind' reactivateable outside range is still valid, because the course kind accepts it" do
           before { sl.update_attribute(:reactivateable, 2) }
           before { qualifications.first.update_attribute(:finish_at, course_start_at - sl.reactivateable.years - 1) }
           its(:valid?) { should be_truthy }


### PR DESCRIPTION
Closes: #1870 

Nach Absprache mit @ThomasEllenberger haben wir uns dazu entschieden eine weitere Option "Muss gültig oder reaktivierbar sein" einzufügen.

Somit sind die Vorbedingungen so:
- "Muss gültig sein": Muss Qualifikation haben welche nicht abgelaufen ist. Reaktivierbarkeit spielt keine Rolle
- "Muss gültig oder reaktivierbar sein": Muss Qualifikation haben. Wenn abgelaufen, muss sie in der Reaktivierbarkeitsperiode sein.
- "Muss gültig oder abgelaufen sein": Muss Qualifikation haben. Darf abgelaufen sein. Reaktivierbarkeit spielt keine Rolle.

