### PR TITLE
Take care not to circumvent existing conditions when including globally_visible events

### DIFF
--- a/app/domain/events/filter/groups.rb
+++ b/app/domain/events/filter/groups.rb
@@ -15,17 +15,16 @@ module Events::Filter
     end
 
     def to_scope
-      scope = @scope
-      scope = scope.in_hierarchy(@user) unless complete_course_list_allowed?
+      conditions = complete_course_list_allowed? ? Event.all : Event.in_hierarchy(@user)
 
       if group_ids.any?
-        scope = scope.with_group_id(group_ids_in_hierarchy)
-        scope = scope.or(globally_visible_events_outside_hierarchy) if group_ids_outside_hierarchy.any? # rubocop:disable Metrics/LineLength
+        conditions = conditions.with_group_id(group_ids_in_hierarchy)
+        conditions = conditions.or(globally_visible_events_outside_hierarchy) if group_ids_outside_hierarchy.any? # rubocop:disable Metrics/LineLength
       else
-        scope = scope.or(Event.where(globally_visible: true).distinct)
+        conditions = conditions.or(Event.where(globally_visible: true))
       end
 
-      scope
+      @scope.merge(conditions).distinct
     end
 
     def default_user_course_groups

--- a/app/domain/events/filter/groups.rb
+++ b/app/domain/events/filter/groups.rb
@@ -15,14 +15,11 @@ module Events::Filter
     end
 
     def to_scope
-      conditions = complete_course_list_allowed? ? Event.all : Event.in_hierarchy(@user)
+      conditions = complete_course_list_allowed? ?
+                     Event.all :
+                     Event.in_hierarchy(@user).or(Event.where(globally_visible: true))
 
-      if group_ids.any?
-        conditions = conditions.with_group_id(group_ids_in_hierarchy)
-        conditions = conditions.or(globally_visible_events_outside_hierarchy) if group_ids_outside_hierarchy.any? # rubocop:disable Metrics/LineLength
-      else
-        conditions = conditions.or(Event.where(globally_visible: true))
-      end
+      conditions = conditions.with_group_id(group_ids) if group_ids.any?
 
       @scope.merge(conditions).distinct
     end
@@ -35,27 +32,6 @@ module Events::Filter
 
     def complete_course_list_allowed?
       @options[:list_all_courses] == true
-    end
-
-    def globally_visible_events_outside_hierarchy
-      Event.where(id: events_in_groups(group_ids_outside_hierarchy),
-                  globally_visible: true).distinct
-    end
-
-    def group_ids_in_hierarchy
-      return group_ids if complete_course_list_allowed?
-
-      @group_ids_in_hierarchy ||= group_ids.select do |g_id|
-        @user.groups_hierarchy_ids.include? g_id.to_i
-      end
-    end
-
-    def group_ids_outside_hierarchy
-      @group_ids_outside_hierarchy ||= group_ids - group_ids_in_hierarchy
-    end
-
-    def events_in_groups(group_ids)
-      Event.with_group_id(group_ids).pluck(:id)
     end
 
     def group_ids

--- a/spec/domain/events/filter/groups_spec.rb
+++ b/spec/domain/events/filter/groups_spec.rb
@@ -38,22 +38,21 @@ describe Events::Filter::Groups do
     end
   end
 
-  context 'generally, it' do
+  context 'when not allowed to list all courses, it' do
     let(:non_hierarchy_group_ids) { [groups(:bottom_layer_one).id, groups(:bottom_group_one_one).id] }
     let!(:non_hierarchy_event_ids) do
       event_1 = Fabricate(:event, groups: [Group.find(non_hierarchy_group_ids.first)])
       event_2 = Fabricate(:event, groups: [Group.find(non_hierarchy_group_ids.last)])
       [event_1.id, event_2.id]
     end
+    let(:options) { { list_all_courses: false } }
 
     let(:params) { { filter: { group_ids: person.groups.pluck(:id) + non_hierarchy_group_ids } } }
 
-    it 'produces a scope that includes globally_visible' do
+    it 'produces a scope that does not includes globally_visible' do
       expect(where_condition).to match('`events`.`globally_visible`')
 
-      expect(where_condition).to include(
-        "OR `events`.`id` IN (#{non_hierarchy_event_ids.join(', ')}) AND `events`.`globally_visible` = TRUE"
-      )
+      expect(where_condition).to include("OR `events`.`globally_visible` = TRUE")
     end
 
     context 'has assumptions' do


### PR DESCRIPTION
Fixes #1861 

Previously, the `OR` circumvented the `type='Event::Course'` condition as soon as an event was globally visible, leading to server errors when trying to display globally visible camps and events in the course list.


Notice in the examples below that the parantheses right after `WHERE` are gone now.
We are now correctly using separate `WHERE (...) AND (...) AND (... OR ...)` conditions,
rather than wrongly `WHERE (... AND ... AND ... OR ...)`

### For bottom members (`complete_course_list == false`)
Query before this PR:
```sql
WHERE (`events`.`type` = 'Event::Course' AND
       (event_dates.start_at <= '2023-09-28' AND event_dates.finish_at >= '2022-09-28' OR
        event_dates.start_at <= '2023-09-28' AND event_dates.start_at >= '2022-09-28') AND
       `events`.`state` IN ('created', 'confirmed', 'application_open', 'application_closed', 'assignment_closed', 'closed') AND
       `groups`.`id` IN (1, 74, 83, 92, 307, 308)
       -- the OR ignores all other conditions for globally visible events...
       OR `events`.`globally_visible` = TRUE)
```
Query after this PR:
```sql
WHERE `events`.`type` = 'Event::Course'
  AND (event_dates.start_at <= '2023-09-28' AND event_dates.finish_at >= '2022-09-28' OR
       event_dates.start_at <= '2023-09-28' AND event_dates.start_at >= '2022-09-28')
  AND `events`.`state` IN ('created', 'confirmed', 'application_open', 'application_closed', 'assignment_closed', 'closed')
  -- the OR globally_visible only disables the hierarchy restriction now
  AND (`groups`.`id` IN (1, 74, 83, 92, 307, 308) OR `events`.`globally_visible` = TRUE)
```


### For top leaders (`complete_course_list == true`)
Query before this PR:
```sql
WHERE (`events`.`type` = 'Event::Course' AND
       (event_dates.start_at <= '2023-09-28' AND event_dates.finish_at >= '2022-09-28' OR
        event_dates.start_at <= '2023-09-28' AND event_dates.start_at >= '2022-09-28') AND
       `events`.`state` IN ('created', 'confirmed', 'application_open', 'application_closed', 'assignment_closed', 'closed')
       -- the OR ignores all other conditions for globally visible events...
       OR `events`.`globally_visible` = TRUE)
```
Query after this PR:
```sql
WHERE `events`.`type` = 'Event::Course'
  AND (event_dates.start_at <= '2023-09-28' AND event_dates.finish_at >= '2022-09-28' OR
       event_dates.start_at <= '2023-09-28' AND event_dates.start_at >= '2022-09-28')
  AND `events`.`state` IN ('created', 'confirmed', 'application_open', 'application_closed', 'assignment_closed', 'closed')
  -- no OR globally_visible is needed at all for this case
```

