### PR TITLE
Do not run when the PR is opened/reopened, just on push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,12 @@ on:
     paths-ignore:
       - 'doc/**'
       - '**.md'
+    branches:
+      - 'master'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,6 @@ on:
     paths-ignore:
       - 'doc/**'
       - '**.md'
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-      - '**.md'
 
 jobs:
   build:


### PR DESCRIPTION
We are only interested to run against code-changes. If this happens to a Branch that ist part of a PR or not is not relevant. Furthermore, the push-trigger was there all the time, so the 'PR has opened'-trigger is redundant and most of the time late.