### PR TITLE
Really exclude archived roles from mailing lists

### DIFF
--- a/app/domain/mailing_lists/subscribers.rb
+++ b/app/domain/mailing_lists/subscribers.rb
@@ -91,7 +91,9 @@ class MailingLists::Subscribers
       #{Group.quoted_table_name}.rgt <= sub_groups.rgt AND
       roles.type = related_role_types.role_type AND
       (roles.deleted_at IS NULL OR
-       roles.deleted_at > '#{Time.now.utc.to_s(:db)}')
+       roles.deleted_at > '#{Time.now.utc.to_s(:db)}') AND
+      (roles.archived_at IS NULL OR
+       roles.archived_at > '#{Time.now.utc.to_s(:db)}')
     SQL
 
     if subscriptions.groups.any?(&:subscription_tags)


### PR DESCRIPTION
Fixes https://github.com/hitobito/hitobito/issues/1440#issuecomment-1348178994

It is not enough to delete all subscriptions of a group while archiving, because the roles of the group might also be included in the mailing list via a subscription of a higher group. E.g. say an Abteilung has 3 child groups with the same type, and the same "Member" role. If on the Abteilung there is a mailing list including all "Member" roles in the Abteilung, then I can archive one of the child groups and deleting its subscriptions will do nothing. The actual subscription belongs to the Abteilung, so it looks something like this:
```
Subscription {
  group: Abteilung,
  role_types: ['Group::ChildGroup::Member'],
}
```

For this reason, we really have to explicitly exclude archived roles from all mailing lists.