### PR TITLE
Make spec Jahresumbruch-safe

### DIFF
--- a/spec/fixtures/invoices.yml
+++ b/spec/fixtures/invoices.yml
@@ -65,7 +65,7 @@ sent:
   sequence_number: <%= ActiveRecord::FixtureSet.identify(:bottom_layer_one) %>-3
   esr_number: '00 00376 80338 90000 00000 00036'
   reference: 000037680338900000000000036
-  issued_at: <%= 20.days.ago.to_date %>
+  issued_at: <%= Time.zone.today %>
   sent_at: <%= 10.days.ago.to_date %>
   due_at: <%= 20.days.from_now.to_date %>
   account_number: <%= ActiveRecord::FixtureSet.identify(:bottom_layer_one) %>-3


### PR DESCRIPTION
Since the year pagination goes by issued_at, it is important that it is in the current year