### PR TITLE
Start categorizing errors to make config more understandable

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -36,7 +36,7 @@ Raven.configure do |config|
     'Timeout::Error',
   ]
 
-  misbehaving_clients_errors = [
+  misbehaving_client_errors = [
     'ActionDispatch::Http::MimeNegotiation::InvalidType',
   ]
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2021-2022, Katholische Landjugendbewegung Paderborn. This file
+#  Copyright (c) 2021-2023, Katholische Landjugendbewegung Paderborn. This file
 #  is part of hitobito and licensed under the Affero General Public License
 #  version 3 or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -21,7 +21,7 @@ Raven.configure do |config|
   config.tags[:project]      = analyzer.project
   config.current_environment = analyzer.stage if ENV['SENTRY_CURRENT_ENV'].blank?
 
-  config.excluded_exceptions += [
+  setup_and_connection_errors = [
     'ActiveRecord::ConnectionNotEstablished',
     'Errno::ECONNREFUSED',
     'Errno::ECONNRESET',
@@ -34,5 +34,14 @@ Raven.configure do |config|
     'SignalException',
     'ThinkingSphinx::ConnectionError',
     'Timeout::Error',
+  ]
+
+  misbehaving_clients_errors = [
+    'ActionDispatch::Http::MimeNegotiation::InvalidType',
+  ]
+
+  config.excluded_exceptions += [
+    *setup_and_connection_errors,
+    *misbehaving_client_errors,
   ]
 end


### PR DESCRIPTION
I added an error that mostly comes from misbehaving clients and script-kiddies and took the opportunity to categorize and group things. My goal is to keep that config maintainable and a huge list of Exception without a proper explanation why they are there is not my idea of maintainable.