### PR TITLE
Allow for integration of nextcloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 *  Neu kann auf einer Ebene eine Datenschutzerklärung (DSE) hinterlegt werden. Diese muss, falls vorhanden, bei der Selbstregistrierung, dem Anmelden bei einem Anlass/Kurs oder dem Hinzufügen einer Person auf einer Gruppe akzeptiert werden um fortzufahren. (#1881)
 *  Personen mit layer_full oder layer_and_below_full können neu Personen, welche in ihren Ebenen unter "Ohne Rollen" erscheinen, per globale Suchfunktion finden und anzeigen. (hitobito_sww#80)
-
+*  Anbindung an Nextcloud möglich (#1854)
 
 ## Version 1.28
 
@@ -29,7 +29,6 @@
 *  Neues Bestätigungsmail für Event Voranmeldung (hitobito_cevi#80)
 *  Einführung neue JSON:API für Personen (#1920)
 *  Neu kann in den Rechnungseinstellungen im Tab "E-Mail" der Absendername definiert werden, mit dem die Rechnungen dieser Ebene versendet werden (#1893)
-
 
 ## Version 1.27
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -10,13 +10,16 @@ class GroupsController < CrudController
   include AsyncDownload
 
   # Respective group attrs are added in corresponding instance method.
-  self.permitted_attrs = Contactable::ACCESSIBLE_ATTRS.dup + [:logo,
-                                                              :remove_logo,
-                                                              :privacy_policy_title,
-                                                              :privacy_policy,
-                                                              :remove_privacy_policy,
-                                                              :self_registration_role_type,
-                                                              :self_registration_notification_email]
+  self.permitted_attrs = Contactable::ACCESSIBLE_ATTRS.dup + [
+    :logo,
+    :nextcloud_url,
+    :privacy_policy,
+    :privacy_policy_title,
+    :remove_logo,
+    :remove_privacy_policy,
+    :self_registration_notification_email,
+    :self_registration_role_type,
+  ]
 
   # required to allow api calls
   protect_from_forgery with: :null_session, only: [:index, :show]

--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -97,14 +97,17 @@ class GroupDecorator < ApplicationDecorator
                            .pluck(:id)
   end
 
-  def nextcloud_url
-    layer_group.nextcloud_url
-  end
-
   def archived_class
     return nil unless model.archived?
 
     'is-archived'
+  end
+
+  def nextcloud_organizer
+    model
+      .hierarchy.where(layer_group_id: layer_group.id) # local_hierarchy as a scope
+      .where.not(nextcloud_url: nil) # only those with a nextcloud_url
+      .last
   end
 
   private

--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -95,6 +95,10 @@ class GroupDecorator < ApplicationDecorator
     @subgroup_ids ||= Group.where('lft >= :lft AND rgt <= :rgt',
                                   lft: group.lft, rgt: group.rgt)
                            .pluck(:id)
+  end
+
+  def nextcloud_url
+    layer_group.nextcloud_url
   end
 
   def archived_class

--- a/app/domain/feature_gate.rb
+++ b/app/domain/feature_gate.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2022, Hitobito AG. This file is part of
+# Copyright (c) 2022-2023, Hitobito AG. This file is part of
 # hitobito and licensed under the Affero General Public License version 3
 # or later. See the COPYING file at the top-level directory or at
 # https://github.com/hitobito/hitobito.
@@ -8,9 +8,23 @@
 # Restrict code-execution depending on settings-level feature-switches
 #
 # Provides the following class-level methods
-#   - assert!(feature)
-#   - if(feature) { ... }
-#   - enabled?(feature)
+#   - assert!(feature)    # raises unless the feature is active
+#   - enabled?(feature)   # answers if the feature is active
+#   - if(feature) { ... } # executes block if feature is active
+
+# In config/settings.yml any key can have a subkey "enabled" which determines
+# if a given feature is enabled. For example:
+#
+# # settings.yml
+# groups:
+#   self_registration:
+#     enabled: true
+#
+# # anywhere in the application
+# FeatureGate.if('groups.self_registration') do
+#   # Code activated if feature is configured active
+# end
+#
 class FeatureGate
   class FeatureGateError < StandardError; end
 

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -17,6 +18,11 @@ module GroupsHelper
   def format_self_registration_link(group)
     url = group_self_registration_url(group)
     link_to(url, url)
+  end
+
+  def format_nextcloud_url(group)
+    url = group.nextcloud_url
+    link_to(url, url, target: '_blank', rel: 'noopener')
   end
 
   def maybe_value(value)

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -21,7 +21,9 @@ module GroupsHelper
   end
 
   def format_nextcloud_url(group)
-    url = group.nextcloud_url
+    url = group.nextcloud_organizer&.nextcloud_url
+    return unless url
+
     link_to(url, url, target: '_blank', rel: 'noopener')
   end
 

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -11,7 +11,7 @@ module GroupsHelper
   def tab_person_add_request_label(group)
     label = t('activerecord.models.person/add_request.other')
     count = Person::AddRequest.for_layer(group).count
-    label << " (#{count})" if count > 0
+    label << " (#{count})" if count.positive?
     label.html_safe
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -63,6 +63,9 @@ class Group < ActiveRecord::Base
   class_attribute :used_attributes
   self.used_attributes = [:name, :short_name, :email, :contact_id,
                           :address, :zip_code, :town, :country, :description]
+  FeatureGate.if('groups.nextcloud') do
+    used_attributes << :nextcloud_url
+  end
 
   # Attributes that may only be modified by people from superior layers.
   class_attribute :superior_attributes

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -163,7 +163,7 @@ class Role < ActiveRecord::Base
   # If this role has contact_data permissions, set the flag on the person
   def set_contact_data_visible
     if becomes(type.constantize).permissions.include?(:contact_data)
-      person.update_column :contact_data_visible, true
+      person.update_column :contact_data_visible, true # rubocop:disable Rails/SkipsModelValidations intentional
     end
   end
 
@@ -171,20 +171,20 @@ class Role < ActiveRecord::Base
   def reset_contact_data_visible
     if permissions.include?(:contact_data) &&
        !person.roles.collect(&:permissions).flatten.include?(:contact_data)
-      person.update_column :contact_data_visible, false
+      person.update_column :contact_data_visible, false # rubocop:disable Rails/SkipsModelValidations intentional
     end
   end
 
   def set_first_primary_group
     if (deleted_at.nil? || deleted_at.future?) && person.roles.count <= 1
-      person.update_column :primary_group_id, group_id
+      person.update_column :primary_group_id, group_id # rubocop:disable Rails/SkipsModelValidations intentional
     end
   end
 
   def reset_primary_group
     if person.primary_group_id == group_id &&
         person.roles.where(group_id: group_id).count.zero?
-      person.update_column :primary_group_id, alternative_primary_group.try(:id)
+      person.update_column :primary_group_id, alternative_primary_group.try(:id) # rubocop:disable Rails/SkipsModelValidations intentional
     end
   end
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -71,9 +71,13 @@ class Role < ActiveRecord::Base
     class_attribute :nextcloud_group
     self.nextcloud_group = false
 
-    NextcloudGroup = Struct.new(:gid, :displayName) do
+    NextcloudGroup = Struct.new(:gid, :displayName) do # rubocop:disable Lint/ConstantDefinitionInBlock
       def hash
-        @gid.hash
+        gid.hash
+      end
+
+      def to_h
+        { 'gid' => gid, 'displayName' => displayName }
       end
     end
   end

--- a/app/views/groups/_attrs.html.haml
+++ b/app/views/groups/_attrs.html.haml
@@ -1,4 +1,4 @@
--#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+-#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
@@ -13,6 +13,8 @@
       = render_attrs(entry, :self_registration_link, :self_registration_notification_email)
     = render_attrs(entry, :type_name)
     = render_present_attrs(entry, *entry.used_attributes(:description))
+    - if FeatureGate.enabled?('groups.nextcloud')
+      = render_present_attrs(entry, :nextcloud_url)
     = render_extensions :attrs
     = render_present_attrs(entry, :created_info, :updated_info, :deleted_info, :archived_info) if can?(:show_details, @group)
 

--- a/app/views/groups/_attrs.html.haml
+++ b/app/views/groups/_attrs.html.haml
@@ -13,8 +13,8 @@
       = render_attrs(entry, :self_registration_link, :self_registration_notification_email)
     = render_attrs(entry, :type_name)
     = render_present_attrs(entry, *entry.used_attributes(:description))
-    - if FeatureGate.enabled?('groups.nextcloud')
-      = render_present_attrs(entry, :nextcloud_url)
+    - if entry.class.attr_used?(:nextcloud_url) && entry.nextcloud_organizer.present?
+      = render_attrs(entry, :nextcloud_url)
     = render_extensions :attrs
     = render_present_attrs(entry, :created_info, :updated_info, :deleted_info, :archived_info) if can?(:show_details, @group)
 

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,4 +1,4 @@
--#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+-#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
@@ -31,6 +31,8 @@
               class: 'span6')
         = f.help_inline(t('.hint_external_registration'))
       = f.labeled_input_fields(:self_registration_notification_email)
+    - if FeatureGate.enabled?('groups.nextcloud') && entry.layer?
+      = f.labeled_input_fields(:nextcloud_url)
 
   = render 'contactable/fields', f: f
 

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -31,7 +31,7 @@
               class: 'span6')
         = f.help_inline(t('.hint_external_registration'))
       = f.labeled_input_fields(:self_registration_notification_email)
-    - if FeatureGate.enabled?('groups.nextcloud') && entry.layer?
+    - if entry.class.attr_used?(:nextcloud_url)
       = f.labeled_input_fields(:nextcloud_url)
 
   = render 'contactable/fields', f: f

--- a/bin/single-file-update-copyright
+++ b/bin/single-file-update-copyright
@@ -20,8 +20,8 @@ fi
 # Copyright (c) 2018,
 # Copyright (c) 2018-2022,
 sed -i -r "
-  s/Copyright \(c\) (([[:digit:]]{4})(-[[:digit:]]{4})?),/Copyright \(c\) \2-$year,/g
-  s/Copyright \(c\) $year-$year,/Copyright \(c\) $year,/g
+  s/Copyright \(c\) (([[:digit:]]{4})(-[[:digit:]]{4})?),?/Copyright \(c\) \2-$year,/g
+  s/Copyright \(c\) $year-$year,?/Copyright \(c\) $year,/g
 " $file
 
 echo "$file"

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2019-2021, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2019-2023, Pfadibewegung Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -92,8 +92,11 @@ Doorkeeper.configure do
   # not in configuration, i.e. `default_scopes` or `optional_scopes`.
   # (disabled by default)
   #
+  list_of_optional_scopes = [:name, :with_roles, :openid, :api, :events, :groups, :people, :invoices, :mailing_lists]
+  FeatureGate.if('groups.nextcloud') { list_of_optional_scopes << :nextcloud }
+
   default_scopes :email
-  optional_scopes :name, :with_roles, :openid, :api, :events, :groups, :people, :invoices, :mailing_lists
+  optional_scopes *list_of_optional_scopes
 
   enforce_configured_scopes
 

--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -67,7 +67,7 @@ Doorkeeper::OpenidConnect.configure do
   # end
 
   claims do
-    claim(:email, scope: :email)     { |resource_owner| resource_owner.email }
+    claim(:email, scope: :email, response: [:user_info, :id_token]) { |resource_owner| resource_owner.email }
     claim(:first_name, scope: :name) { |resource_owner| resource_owner.first_name }
     claim(:last_name, scope: :name)  { |resource_owner| resource_owner.last_name }
     claim(:nickname, scope: :name)   { |resource_owner| resource_owner.nickname }
@@ -88,9 +88,9 @@ Doorkeeper::OpenidConnect.configure do
     end
 
     FeatureGate.if('groups.nextcloud') do
-      claim(:name, scope: :nextcloud)  { |resource_owner| resource_owner.to_s }
+      claim(:name, scope: :nextcloud, response: [:user_info, :id_token])  { |resource_owner| resource_owner.to_s }
 
-      claim(:groups, scope: :nextcloud) do |resource_owner|
+      claim(:groups, scope: :nextcloud, response: [:user_info, :id_token]) do |resource_owner|
         resource_owner.roles.includes(:group).map do |role|
           role.nextcloud_group
         end.compact

--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -88,12 +88,9 @@ Doorkeeper::OpenidConnect.configure do
     end
 
     FeatureGate.if('groups.nextcloud') do
-      claim(:name, scope: :nextcloud, response: [:user_info, :id_token])  { |resource_owner| resource_owner.to_s }
-
+      claim(:name, scope: :nextcloud, response: [:user_info, :id_token]) { |resource_owner| resource_owner.to_s }
       claim(:groups, scope: :nextcloud, response: [:user_info, :id_token]) do |resource_owner|
-        resource_owner.roles.includes(:group).map do |role|
-          role.nextcloud_group
-        end.compact
+        resource_owner.roles.map(&:nextcloud_group).uniq.compact
       end
     end
   end

--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -1,3 +1,10 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2019-2023, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
 Doorkeeper::OpenidConnect.configure do
   issuer Settings.oidc.issuer
 
@@ -77,6 +84,16 @@ Doorkeeper::OpenidConnect.configure do
           role: role.class.model_name,
           role_name: role.class.model_name.human
         }
+      end
+    end
+
+    FeatureGate.if('groups.nextcloud') do
+      claim(:name, scope: :nextcloud)  { |resource_owner| resource_owner.to_s }
+
+      claim(:groups, scope: :nextcloud) do |resource_owner|
+        resource_owner.roles.includes(:group).map do |role|
+          role.nextcloud_group
+        end.compact
       end
     end
   end

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -485,6 +485,7 @@ de:
         self_registration_role_type: Externe Registrierung
         self_registration_link: Externe Registrierung
         self_registration_notification_email: Externe Registrierung Benachrichtigungs-E-Mail
+        nextcloud_url: Link zu Nextcloud
         remove_logo: Aktuelles Gruppenlogo entfernen
         privacy_policy_title: DSE/Datenschutzerklärung Titel
         privacy_policy: DSE/Datenschutzerklärung

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -1108,7 +1108,7 @@ de:
       people: Lesen aller Personen, auf die du Zugriff hast
       invoices: Lesen aller Rechnungen, auf die du Zugriff hast
       mailing_lists: Lesen aller Abos, auf die du Zugriff hast
-      nextcloud: Lesen der eingestellten Nextcloud-Gruppen und des Anzeigenamens
+      nextcloud: Lesen deiner Nextcloud-Gruppen und deines Anzeigenamens
   errors:
     messages:
       attachments_not_allowed: "darf keine Anhänge enthalten"

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -1107,6 +1107,7 @@ de:
       people: Lesen aller Personen, auf die du Zugriff hast
       invoices: Lesen aller Rechnungen, auf die du Zugriff hast
       mailing_lists: Lesen aller Abos, auf die du Zugriff hast
+      nextcloud: Mapping der Rollen auf Nextcloud-Gruppen
   errors:
     messages:
       attachments_not_allowed: "darf keine Anhänge enthalten"

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -1108,7 +1108,7 @@ de:
       people: Lesen aller Personen, auf die du Zugriff hast
       invoices: Lesen aller Rechnungen, auf die du Zugriff hast
       mailing_lists: Lesen aller Abos, auf die du Zugriff hast
-      nextcloud: Mapping der Rollen auf Nextcloud-Gruppen
+      nextcloud: Lesen der eingestellten Nextcloud-Gruppen und des Anzeigenamens
   errors:
     messages:
       attachments_not_allowed: "darf keine Anhänge enthalten"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -232,3 +232,5 @@ groups:
     enabled: true
   statistics:
     enabled: true
+  nextcloud:
+    enabled: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -20,3 +20,7 @@ email:
   sender: "hitobito <noreply@localhost>"
   mass_recipient: "hitobito <noreply@localhost>"
   list_domain: localhost
+
+groups:
+  nextcloud:
+    enabled: true

--- a/db/migrate/20230115160409_add_nextcloud_link_to_groups.rb
+++ b/db/migrate/20230115160409_add_nextcloud_link_to_groups.rb
@@ -1,3 +1,10 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023-2023, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
 class AddNextcloudLinkToGroups < ActiveRecord::Migration[6.1]
   def change
     add_column :groups, :nextcloud_url, :string

--- a/db/migrate/20230115160409_add_nextcloud_link_to_groups.rb
+++ b/db/migrate/20230115160409_add_nextcloud_link_to_groups.rb
@@ -1,0 +1,5 @@
+class AddNextcloudLinkToGroups < ActiveRecord::Migration[6.1]
+  def change
+    add_column :groups, :nextcloud_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -411,6 +411,7 @@ ActiveRecord::Schema.define(version: 2023_01_17_131844) do
     t.string "self_registration_role_type"
     t.string "self_registration_notification_email"
     t.string "privacy_policy"
+    t.string "nextcloud_url"
     t.index ["layer_group_id"], name: "index_groups_on_layer_group_id"
     t.index ["lft", "rgt"], name: "index_groups_on_lft_and_rgt"
     t.index ["parent_id"], name: "index_groups_on_parent_id"

--- a/doc/development/08_oauth.md
+++ b/doc/development/08_oauth.md
@@ -30,7 +30,7 @@ Different external applications need different types of data about their users. 
 | `people`        | people API endpoints                      |
 | `invoices`      | invoice API endpoints                     |
 | `mailing_lists` | mailing list API endpoints                |
-| `nextcloud`     | maps roles to nextcloud-groups            |
+| `nextcloud`     | nextcloud groups based on user's roles    |
 
 The scope `with_roles` contains most of the profile information, including the fields of the name scope. Multiple scopes can be combined in a single authorization request.
 

--- a/doc/development/08_oauth.md
+++ b/doc/development/08_oauth.md
@@ -30,6 +30,7 @@ Different external applications need different types of data about their users. 
 | `people`        | people API endpoints                      |
 | `invoices`      | invoice API endpoints                     |
 | `mailing_lists` | mailing list API endpoints                |
+| `nextcloud`     | maps roles to nextcloud-groups            |
 
 The scope `with_roles` contains most of the profile information, including the fields of the name scope. Multiple scopes can be combined in a single authorization request.
 

--- a/lib/tasks/hitobito.rake
+++ b/lib/tasks/hitobito.rake
@@ -49,7 +49,7 @@ namespace :hitobito do
           ❌ OAuth not correctly configured
 
             JWT Signing Key missing.
-            This key is needed to OAuth to work.
+            This key is needed for OAuth to work.
             See doc/development/08_oauth.md for details
 
         MESSAGE

--- a/lib/tasks/hitobito.rake
+++ b/lib/tasks/hitobito.rake
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -32,6 +32,30 @@ namespace :hitobito do
            "#{c.subject_class.to_s.ljust(24)}\t" \
            "#{c.action.to_s.ljust(25)}\t" \
            "#{c.constraint}"
+    end
+  end
+
+  desc 'Check existence of needed configurations and settings'
+  task check_config: [
+    'hitobito:checks:oauth'
+  ]
+
+  namespace :checks do
+    task oauth: :environment do
+      signing_key = Settings.oidc.signing_key.join.presence
+
+      if signing_key.nil?
+        puts <<~MESSAGE
+          ❌ OAuth not correctly configured
+
+            JWT Signing Key missing.
+            This key is needed to OAuth to work.
+            See doc/development/08_oauth.md for details
+
+        MESSAGE
+      else
+        puts '✅ OAuth configured'
+      end
     end
   end
 end

--- a/spec/controllers/oauth/userinfo_controller_spec.rb
+++ b/spec/controllers/oauth/userinfo_controller_spec.rb
@@ -76,11 +76,16 @@ describe Doorkeeper::OpenidConnect::UserinfoController do
         admin_role = Fabricate(:'Group::GlobalGroup::Leader', person: user, group: temp_group)
         admin_role.class.nextcloud_group = 'Admins'
 
-        admin_role = Fabricate(:'Group::GlobalGroup::Leader', person: user, group: temp_group)
-        admin_role.class.nextcloud_group = 'Admins'
+        # second role resulting in the same mapping, intended to test deduplication
+        Fabricate(:'Group::GlobalGroup::Leader', person: user, group: temp_group)
 
         group_role = Fabricate(:'Group::GlobalGroup::Member', person: user, group: temp_group)
         group_role.class.nextcloud_group = true
+      end
+
+      after do
+        Group::GlobalGroup::Leader.nextcloud_group = false
+        Group::GlobalGroup::Member.nextcloud_group = false
       end
 
       it 'has assumptions' do

--- a/spec/controllers/oauth/userinfo_controller_spec.rb
+++ b/spec/controllers/oauth/userinfo_controller_spec.rb
@@ -76,6 +76,9 @@ describe Doorkeeper::OpenidConnect::UserinfoController do
         admin_role = Fabricate(:'Group::GlobalGroup::Leader', person: user, group: temp_group)
         admin_role.class.nextcloud_group = 'Admins'
 
+        admin_role = Fabricate(:'Group::GlobalGroup::Leader', person: user, group: temp_group)
+        admin_role.class.nextcloud_group = 'Admins'
+
         group_role = Fabricate(:'Group::GlobalGroup::Member', person: user, group: temp_group)
         group_role.class.nextcloud_group = true
       end
@@ -84,7 +87,7 @@ describe Doorkeeper::OpenidConnect::UserinfoController do
         expect(Settings.groups.nextcloud.enabled).to be true # in the test-env
 
         expect(user.to_s).to eq 'Tom Tester'
-        expect(user).to have(3).roles
+        expect(user).to have(4).roles
         expect(user.email).to eq 'top_leader@example.com'
       end
 

--- a/spec/controllers/oauth/userinfo_controller_spec.rb
+++ b/spec/controllers/oauth/userinfo_controller_spec.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2019, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -14,38 +14,93 @@ describe Doorkeeper::OpenidConnect::UserinfoController do
   let(:redirect_uri) { 'urn:ietf:wg:oauth:2.0:oob' }
 
   describe 'GET#show' do
-    let(:token) { app.access_tokens.create!(resource_owner_id: user.id, scopes: 'openid', expires_in: 2.hours) }
+    let(:token) do
+      app.access_tokens.create!(resource_owner_id: user.id,
+                                scopes: 'openid', expires_in: 2.hours)
+    end
 
     it 'shows the userinfo' do
       get :show, params: { access_token: token.token }
       expect(response.status).to eq 200
-      expect(JSON.parse(response.body)).to eq({ 'sub' => user.id.to_s })
+      expect(JSON.parse(response.body)).to eq('sub' => user.id.to_s)
     end
 
     context 'with name scope' do
-      let(:token) { app.access_tokens.create!(resource_owner_id: user.id, scopes: 'openid name', expires_in: 2.hours) }
+      let(:token) do
+        app.access_tokens.create!(resource_owner_id: user.id,
+                                  scopes: 'openid name', expires_in: 2.hours)
+      end
 
       before do
-        user.update(nickname: 'Filou', address: 'Teststrasse 7', zip_code: '8000', town: 'Zürich', country: 'CH')
+        user.update(nickname: 'Filou',
+                    address: 'Teststrasse 7', zip_code: '8000', town: 'Zürich', country: 'CH')
       end
 
       it 'shows the userinfo' do
         get :show, params: { access_token: token.token }
         expect(response.status).to eq 200
-        expect(JSON.parse(response.body)).to eq({
-          'sub' => user.id.to_s, 'first_name' => user.first_name, 'last_name' => user.last_name, 'nickname' => 'Filou',
+        expect(JSON.parse(response.body)).to eq(
+          'sub' => user.id.to_s, 'first_name' => user.first_name, 'last_name' => user.last_name,
+          'nickname' => 'Filou',
           'address' => 'Teststrasse 7', 'zip_code' => '8000', 'town' => 'Zürich', 'country' => 'CH'
-        })
+        )
       end
     end
 
     context 'with email scope' do
-      let(:token) { app.access_tokens.create!(resource_owner_id: user.id, scopes: 'openid email', expires_in: 2.hours) }
+      let(:token) do
+        app.access_tokens.create!(resource_owner_id: user.id,
+                                  scopes: 'openid email', expires_in: 2.hours)
+      end
 
       it 'shows the userinfo' do
         get :show, params: { access_token: token.token }
         expect(response.status).to eq 200
-        expect(JSON.parse(response.body)).to eq({ 'sub' => user.id.to_s, 'email' => user.email })
+        expect(JSON.parse(response.body)).to eq('sub' => user.id.to_s, 'email' => user.email)
+      end
+    end
+
+    context 'with nextcloud scope' do
+      let(:token) do
+        app.access_tokens.create!(
+          resource_owner_id: user.id,
+          scopes: 'openid email nextcloud',
+          expires_in: 2.hours
+        )
+      end
+
+      before do
+        user.update(first_name: 'Tom', last_name: 'Tester')
+
+        temp_group = Group::GlobalGroup.new(id: 1024, name: 'Test', parent: groups(:top_layer))
+        admin_role = Fabricate(:'Group::GlobalGroup::Leader', person: user, group: temp_group)
+        admin_role.class.nextcloud_group = 'Admins'
+
+        group_role = Fabricate(:'Group::GlobalGroup::Member', person: user, group: temp_group)
+        group_role.class.nextcloud_group = true
+      end
+
+      it 'has assumptions' do
+        expect(Settings.groups.nextcloud.enabled).to be true # in the test-env
+
+        expect(user.to_s).to eq 'Tom Tester'
+        expect(user).to have(3).roles
+        expect(user.email).to eq 'top_leader@example.com'
+      end
+
+      it 'shows the userinfo' do
+        get :show, params: { access_token: token.token }
+        expect(response.status).to eq 200
+
+        expect(JSON.parse(response.body)).to eq(
+          'sub' => user.id.to_s,
+          'email' => 'top_leader@example.com',
+          'name' => 'Tom Tester',
+          'groups' => [
+            { 'displayName' => 'Admins', 'gid' => 'hitobito-Admins' },
+            { 'displayName' => 'Test',   'gid' => '1024' }
+          ]
+        )
       end
     end
   end

--- a/spec/decorators/group_decorator_spec.rb
+++ b/spec/decorators/group_decorator_spec.rb
@@ -140,13 +140,14 @@ describe GroupDecorator, :draper_with_helpers do
     end
   end
 
-  it 'reads the nextcloud_url from the layer_group' do
+  it 'reads the nextcloud_url from the next organizing group in the hierarchy' do
     expect(subject.nextcloud_url).to be_nil
 
     subject.layer_group.nextcloud_url = 'http://example.org'
     subject.layer_group.save!
     subject.reload
 
-    expect(subject.nextcloud_url).to eq 'http://example.org'
+    expect(subject.nextcloud_organizer).to eq subject.layer_group
+    expect(subject.nextcloud_organizer.nextcloud_url).to eq 'http://example.org'
   end
 end

--- a/spec/decorators/group_decorator_spec.rb
+++ b/spec/decorators/group_decorator_spec.rb
@@ -46,7 +46,7 @@ describe GroupDecorator, :draper_with_helpers do
 
   describe 'selecting attributes' do
 
-    class DummyGroup < Group
+    class DummyGroup < Group # rubocop:disable Lint/ConstantDefinitionInBlock
       self.used_attributes += [:foo, :bar]
     end
 
@@ -88,11 +88,13 @@ describe GroupDecorator, :draper_with_helpers do
 
     its(:subgroup_ids) do
       should match_array(
-        [ groups(:bottom_layer_one),
+        [
+          groups(:bottom_layer_one),
           groups(:bottom_group_one_one),
           groups(:bottom_group_one_one_one),
           groups(:bottom_group_one_two)
-        ].collect(&:id))
+        ].collect(&:id)
+      )
     end
   end
 

--- a/spec/decorators/group_decorator_spec.rb
+++ b/spec/decorators/group_decorator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -138,5 +138,15 @@ describe GroupDecorator, :draper_with_helpers do
     it 'suffix display_name' do
       expect(subject.display_name).to_not end_with(' (archiviert)')
     end
+  end
+
+  it 'reads the nextcloud_url from the layer_group' do
+    expect(subject.nextcloud_url).to be_nil
+
+    subject.layer_group.nextcloud_url = 'http://example.org'
+    subject.layer_group.save!
+    subject.reload
+
+    expect(subject.nextcloud_url).to eq 'http://example.org'
   end
 end

--- a/spec/domain/export/csv/groups/list_spec.rb
+++ b/spec/domain/export/csv/groups/list_spec.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -18,49 +18,69 @@ describe Export::Tabular::Groups::List do
 
   subject { csv }
 
-   its(:headers) do
-     should == ['Id', 'Elterngruppe', 'Name', 'Kurzname', 'Gruppentyp', 'Haupt-E-Mail', 'Adresse', 'PLZ', 'Ort', 'Land', 'Geändert', 'Ebene', 'Beschreibung', 'Telefonnummern', 'Anzahl Mitglieder', 'Social Media']
-   end
+  its(:headers) do
+    should == [
+      'Id',
+      'Elterngruppe',
+      'Name',
+      'Kurzname',
+      'Gruppentyp',
+      'Haupt-E-Mail',
+      'Adresse',
+      'PLZ',
+      'Ort',
+      'Land',
+      'Geändert',
+      'Ebene',
+      'Beschreibung',
+      'Link zu Nextcloud',
+      'Telefonnummern',
+      'Anzahl Mitglieder',
+      'Social Media'
+    ]
+  end
 
-   it 'has 4 items' do
-     expect(subject.size).to eq(4)
-   end
+  it 'has 4 items' do
+    expect(subject.size).to eq(4)
+  end
 
-   context 'first row with contact' do
+  context 'first row with contact' do
 
-     let(:contact) { people(:bottom_member) }
+    let(:contact) { people(:bottom_member) }
 
-     subject { csv[0] }
+    subject { csv[0] }
 
-     its(['Id']) { should == group.id.to_s }
-     its(['Elterngruppe']) { should == group.parent_id.to_s }
-     its(['Name']) { should == group.name }
-     its(['Kurzname']) { should == group.short_name }
-     its(['Gruppentyp']) { should == 'Bottom Layer' }
-     its(['Haupt-E-Mail']) { should == group.email }
-     its(['Adresse']) { should == contact.address }
-     its(['PLZ']) { should == contact.zip_code.to_s }
-     its(['Ort']) { should == contact.town }
-     its(['Land']) { should == contact.country_label }
-     its(['Ebene']) { should == group.id.to_s }
-     its(['Geändert']) { should == "#{I18n.l(group.updated_at.to_date)} #{I18n.l(group.updated_at, format: :time)}" }
-     its(['Anzahl Mitglieder']) { should == '1' }
-     its(['Telefonnummern']) { should == '' }
-     its(['Social Media']) { should == '' }
-   end
+    its(['Id']) { should == group.id.to_s }
+    its(['Elterngruppe']) { should == group.parent_id.to_s }
+    its(['Name']) { should == group.name }
+    its(['Kurzname']) { should == group.short_name }
+    its(['Gruppentyp']) { should == 'Bottom Layer' }
+    its(['Haupt-E-Mail']) { should == group.email }
+    its(['Adresse']) { should == contact.address }
+    its(['PLZ']) { should == contact.zip_code.to_s }
+    its(['Ort']) { should == contact.town }
+    its(['Land']) { should == contact.country_label }
+    its(['Ebene']) { should == group.id.to_s }
+    its(['Geändert']) do
+      should == "#{I18n.l(group.updated_at.to_date)} #{I18n.l(group.updated_at, format: :time)}"
+    end
+    its(['Anzahl Mitglieder']) { should == '1' }
+    its(['Telefonnummern']) { should == '' }
+    its(['Social Media']) { should == '' }
+  end
 
-   context 'second row' do
+  context 'second row' do
 
-     let(:second_group) { groups(:bottom_group_one_one) }
+    let(:second_group) { groups(:bottom_group_one_one) }
 
-     subject { csv[1] }
+    subject { csv[1] }
 
-     its(['Elterngruppe']) { should == group.id.to_s }
-     its(['Ebene']) { should == group.id.to_s }
-     its(['Haupt-E-Mail']) { should == second_group.email }
-     its(['Adresse']) { should == second_group.address }
-     its(['PLZ']) { should == second_group.zip_code.to_s }
-     its(['Ort']) { should == second_group.town }
-     its(['Land']) { should == second_group.country_label }
-   end
+    its(['Elterngruppe']) { should == group.id.to_s }
+    its(['Ebene']) { should == group.id.to_s }
+    its(['Haupt-E-Mail']) { should == second_group.email }
+    its(['Adresse']) { should == second_group.address }
+    its(['PLZ']) { should == second_group.zip_code.to_s }
+    its(['Ort']) { should == second_group.town }
+    its(['Land']) { should == second_group.country_label }
+  end
 end

--- a/spec/features/oauth_workflow_spec.rb
+++ b/spec/features/oauth_workflow_spec.rb
@@ -15,7 +15,7 @@ describe 'OauthWorkflow' do
     click_link 'Erstellen'
     fill_in 'Name', with: 'MyApp'
     fill_in 'Redirect URI', with: 'urn:ietf:wg:oauth:2.0:oob'
-    check 'name'
+    check 'name', id: 'oauth_application_scope_name'
     check 'email'
     within('.btn-toolbar.bottom') do
       click_button 'Speichern'

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -658,5 +658,10 @@ describe Group do
 
       expect(subject.nextcloud_url).to eql 'https://example.org'
     end
+
+    it 'has the nextcloud_url' do
+      expect(described_class.used_attributes).to include(:nextcloud_url)
+      expect(subject.used_attributes).to include(:nextcloud_url)
+    end
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -645,6 +645,18 @@ describe Group do
 
         expect(archived_group.reload.deleted_at).to_not be_nil
       end
+    end
+  end
+
+  context 'integrates with nextcloud, it' do
+    subject { groups(:top_layer) }
+
+    it 'has a nextcloud_url' do
+      subject.nextcloud_url = 'https://example.org'
+      subject.save!
+      subject.reload
+
+      expect(subject.nextcloud_url).to eql 'https://example.org'
     end
   end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -415,6 +415,10 @@ describe Role do
       r
     end
 
+    after do
+      subject.class.nextcloud_group = false
+    end
+
     it 'have assumptions' do
       expect(Settings.groups.nextcloud.enabled).to be true # in the test-env
     end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -328,20 +328,32 @@ describe Role do
       subject { person.roles.without_deleted }
 
       it 'lists roles with future deleted_at' do
-        Fabricate(Group::BottomLayer::Leader.name.to_s, label: 'foo',
-                  person: person, group: groups(:bottom_layer_one))
-        marked_for_termination = Fabricate(Group::BottomLayer::Member.name.to_s, label: 'Bar', created_at: Time.zone.yesterday, deleted_at: Time.zone.tomorrow,
-                                           person: person, group: groups(:bottom_layer_one))
+        Fabricate(Group::BottomLayer::Leader.name.to_s,
+                  label: 'foo',
+                  person: person,
+                  group: groups(:bottom_layer_one))
+        marked_for_termination = Fabricate(Group::BottomLayer::Member.name.to_s,
+                                           label: 'Bar',
+                                           created_at: Time.zone.yesterday,
+                                           deleted_at: Time.zone.tomorrow,
+                                           person: person,
+                                           group: groups(:bottom_layer_one))
 
         expect(subject.count).to eq(2)
         expect(subject).to include(marked_for_termination)
       end
 
       it 'does not list roles with past deleted_at' do
-        Fabricate(Group::BottomLayer::Leader.name.to_s, label: 'foo',
-                  person: person, group: groups(:bottom_layer_one))
-        Fabricate(Group::BottomLayer::Member.name.to_s, label: 'Bar', created_at: 5.days.ago, deleted_at: 3.days.ago,
-                                           person: person, group: groups(:bottom_layer_one))
+        Fabricate(Group::BottomLayer::Leader.name.to_s,
+                  label: 'foo',
+                  person: person,
+                  group: groups(:bottom_layer_one))
+        Fabricate(Group::BottomLayer::Member.name.to_s,
+                  label: 'Bar',
+                  created_at: 5.days.ago,
+                  deleted_at: 3.days.ago,
+                  person: person,
+                  group: groups(:bottom_layer_one))
 
         expect(subject.count).to eq(1)
       end
@@ -351,15 +363,22 @@ describe Role do
       subject { person.roles.only_deleted }
 
       it 'does not list roles with future deleted_at' do
-        Fabricate(Group::BottomLayer::Member.name.to_s, label: 'Bar', created_at: Time.zone.yesterday, deleted_at: Time.zone.tomorrow,
-                  person: person, group: groups(:bottom_layer_one))
+        Fabricate(Group::BottomLayer::Member.name.to_s,
+                  label: 'Bar',
+                  created_at: Time.zone.yesterday,
+                  deleted_at: Time.zone.tomorrow,
+                  person: person,
+                  group: groups(:bottom_layer_one))
 
         expect(subject.count).to eq(0)
       end
 
       it 'does not list roles with no deleted_at' do
-        Fabricate(Group::BottomLayer::Member.name.to_s, label: 'Bar', created_at: Time.zone.yesterday,
-                  person: person, group: groups(:bottom_layer_one))
+        Fabricate(Group::BottomLayer::Member.name.to_s,
+                  label: 'Bar',
+                  created_at: Time.zone.yesterday,
+                  person: person,
+                  group: groups(:bottom_layer_one))
 
         expect(subject.count).to eq(0)
       end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -439,7 +439,10 @@ describe Role do
       end
 
       it 'does not return any nextcloud groups' do
-        expect(subject.nextcloud_group).to eq('gid' => 'hitobito-Admins', 'displayName' => 'Admins')
+        expect(subject.nextcloud_group.to_h).to eq(
+          'gid' => 'hitobito-Admins',
+          'displayName' => 'Admins'
+        )
       end
     end
 
@@ -454,7 +457,10 @@ describe Role do
       end
 
       it 'does not return any nextcloud groups' do
-        expect(subject.nextcloud_group).to eq('gid' => '1024', 'displayName' => 'Test')
+        expect(subject.nextcloud_group.to_h).to eq(
+          'gid' => '1024',
+          'displayName' => 'Test'
+        )
       end
     end
 
@@ -476,7 +482,10 @@ describe Role do
       end
 
       it 'delegates to the other group' do
-        expect(subject.nextcloud_group).to eq('gid' => '1234', 'displayName' => 'TestGruppe')
+        expect(subject.nextcloud_group.to_h).to eq(
+          'gid' => '1234',
+          'displayName' => 'TestGruppe'
+        )
       end
     end
 
@@ -495,7 +504,7 @@ describe Role do
       end
 
       it 'delegates to the Proc' do
-        expect(subject.nextcloud_group).to eq(
+        expect(subject.nextcloud_group.to_h).to eq(
           'gid' => 'Group::BottomLayer::Leader',
           'displayName' => 'Role'
         )


### PR DESCRIPTION
Everything is hidden behind the FeatureGate `groups.nextcloud`. This is disabled by default.

Once activated, you can

- add a nextcloud-url to any layer-group and have it displayed on every group in the layer
- use a nextcloud-scope for oauth-apps. This allows to pass user information and a list of groups to nextcloud to provision users there.
- configure roles to either map to a fixed groupname or a dynamic group, depending on the group you have the role on.

Apart from that, I added a rake-task to determine the correct configuration quicker. The idea is to have checks for everything that requires extra-steps to be configured, collected in `rake hitobito:check_config`.

Closes #1854 