### PR TITLE
Adding UTF8 BOM to CSV-Exports

### DIFF
--- a/app/domain/export/csv/generator.rb
+++ b/app/domain/export/csv/generator.rb
@@ -10,6 +10,8 @@ require 'csv'
 module Export
   module Csv
 
+    UTF8_BOM = "\xEF\xBB\xBF"
+
     def self.export(exportable)
       Generator.new(exportable).call
     end
@@ -43,6 +45,10 @@ module Export
       # well, has some success-potential to handle UTF-8
       def convert(data)
         if Settings.csv.encoding.present?
+          # trick excel into reading UTF8 by providing a "BOM"
+          if Settings.csv.encoding == "UTF-8"
+            data = UTF8_BOM + data
+          end
           data.encode(Settings.csv.encoding, undef: :replace, invalid: :replace)
         else
           data

--- a/app/domain/export/csv/generator.rb
+++ b/app/domain/export/csv/generator.rb
@@ -41,9 +41,10 @@ module Export
         end
       end
 
+      # Allow different encodings (e.g. ISO-8859-1), configurable in the settings file.
+      # Using the BOM header helps M$ excel to recognize utf8 files.
       def convert(data)
         if Settings.csv.utf8_bom.present?
-          # trick excel into reading UTF8 by providing a "BOM" header
           data = UTF8_BOM + data
         end
         if Settings.csv.encoding.present?

--- a/app/domain/export/csv/generator.rb
+++ b/app/domain/export/csv/generator.rb
@@ -41,14 +41,12 @@ module Export
         end
       end
 
-      # convert to ISO-8859-1 (configurable, though) for Excel which is...,
-      # well, has some success-potential to handle UTF-8
       def convert(data)
+        if Settings.csv.utf8_bom.present?
+          # trick excel into reading UTF8 by providing a "BOM" header
+          data = UTF8_BOM + data
+        end
         if Settings.csv.encoding.present?
-          # trick excel into reading UTF8 by providing a "BOM"
-          if Settings.csv.encoding == "UTF-8"
-            data = UTF8_BOM + data
-          end
           data.encode(Settings.csv.encoding, undef: :replace, invalid: :replace)
         else
           data


### PR DESCRIPTION
Adding an UTF8 BOM allows MS Excel to read UTF-8 correctly whithout changing the charset manually.

The BOM is only added if the settings.yml file explicitly specifies to use UTF8 for csv exports.