### PR TITLE
Klarere Flash Message bei E-Mail-Verifikation

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -260,7 +260,8 @@ class PeopleController < CrudController
   def show_email_change_info
     return unless entry.show_email_change_info?
 
-    flash[:notice] = I18n.t("#{controller_name}.#{action_name}_email_must_be_confirmed")
+    flash[:notice] = I18n.t("#{controller_name}.#{action_name}_email_must_be_confirmed",
+                            new_mail: entry.unconfirmed_email)
   end
 
   def index_archived

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -1430,7 +1430,7 @@ de:
     send_password_instructions_invalid_email: Die Login-Informationen wurden nicht verschickt da die hinterlegte E-Mail Adresse ungültig ist.
     years_old: (%{years} Jahre alt)
 
-    update_email_must_be_confirmed: Die geänderte E-Mail-Adresse muss noch bestätigt werden, bevor sie aktiv wird.
+    update_email_must_be_confirmed: Die geänderte E-Mail-Adresse muss noch bestätigt werden, bevor sie aktiv wird. Dazu wurde ein Bestätigungslink an %{new_mail} gesendet.
 
     tabs:
       history: Verlauf


### PR DESCRIPTION
Fixes #1994 
![Screenshot 2023-01-24 at 21-22-07 cevi db - Tony Bozsik _ Necessitatibus](https://user-images.githubusercontent.com/7566995/214401216-48800690-58b4-4400-b6c4-30d32bfe669c.png)
