### PR TITLE
Link to first event group instead of parent group

### DIFF
--- a/app/views/events/_list_table.html.haml
+++ b/app/views/events/_list_table.html.haml
@@ -9,5 +9,5 @@
 
   = render_extensions(:list_columns, locals: { t: t })
 
-  - t.col(nil, class: 'center') { |e| button_action_event_apply(e, @group) }
+  - t.col(nil, class: 'center') { |e| button_action_event_apply(e, e.groups.first) }
 


### PR DESCRIPTION
Same as f0ffaa9f234fb29c7a974253c3d8a475f02724ee, but for the apply button.

Fixes https://help.puzzle.ch/#ticket/zoom/5753

Since my time for working on that ticket is limited, and since we don't run specs on branches anymore since #1935, I have to open a PR to run the specs.