### PR TITLE
Repair Mailchimp-Sync

### DIFF
--- a/app/jobs/mailchimp_synchronization_job.rb
+++ b/app/jobs/mailchimp_synchronization_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2018-2020, Grünliberale Partei Schweiz. This file is part of
+#  Copyright (c) 2018-2023, Grünliberale Partei Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -19,7 +19,7 @@ class MailchimpSynchronizationJob < BaseJob
   end
 
   def perform
-    return unless Settings.mailchimp.enabled
+    return unless FeatureGate.enabled?('mailchimp')
 
     sync.perform
   end

--- a/app/jobs/mailchimp_synchronization_job.rb
+++ b/app/jobs/mailchimp_synchronization_job.rb
@@ -30,7 +30,7 @@ class MailchimpSynchronizationJob < BaseJob
                         mailchimp_last_synced_at: Time.zone.now)
   end
 
-  def error(job, exception)
+  def error(_job, exception)
     sync.result.exception = exception
     mailing_list.update(mailchimp_syncing: false,
                         mailchimp_result: sync.result)

--- a/app/jobs/reoccuring_mailchimp_synchronization_job.rb
+++ b/app/jobs/reoccuring_mailchimp_synchronization_job.rb
@@ -9,7 +9,7 @@ class ReoccuringMailchimpSynchronizationJob < RecurringJob
 
   run_every 24.hours
 
-  def perform
+  def perform_internal
     MailingList.mailchimp.where.not(mailchimp_syncing: true).find_each do |list|
       next if list.mailchimp_result&.state == :failed
 

--- a/app/jobs/reoccuring_mailchimp_synchronization_job.rb
+++ b/app/jobs/reoccuring_mailchimp_synchronization_job.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2018, Grünliberale Partei Schweiz. This file is part of
+#  Copyright (c) 2018-2023, Grünliberale Partei Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -11,10 +11,10 @@ class ReoccuringMailchimpSynchronizationJob < RecurringJob
 
   def perform
     MailingList.mailchimp.where.not(mailchimp_syncing: true).find_each do |list|
-      unless list.mailchimp_result&.state == :failed
-        MailchimpSynchronizationJob.new(list.id).enqueue!
-      end
+      next if list.mailchimp_result&.state == :failed
+
+      MailchimpSynchronizationJob.new(list.id).enqueue!
     end
   end
-end
 
+end

--- a/spec/jobs/mailchimp_synchronization_job_spec.rb
+++ b/spec/jobs/mailchimp_synchronization_job_spec.rb
@@ -1,6 +1,6 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2018, Grünliberale Partei Schweiz. This file is part of
+#  Copyright (c) 2018-2023, Grünliberale Partei Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -62,7 +62,7 @@ describe MailchimpSynchronizationJob do
     end
 
     it 'may be overridden via setting' do
-      expect(Settings.mailchimp).to receive(:enabled).and_return(false)
+      expect(FeatureGate).to receive(:enabled?).with('mailchimp').and_return(false)
       expect_any_instance_of(Synchronize::Mailchimp::Synchronizator).not_to receive(:perform)
       subject.enqueue!
       Delayed::Worker.new.work_off

--- a/spec/jobs/reoccuring_mailchimp_synchronization_job_spec.rb
+++ b/spec/jobs/reoccuring_mailchimp_synchronization_job_spec.rb
@@ -1,12 +1,11 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-#  Copyright (c) 2018, Grünliberale Partei Schweiz. This file is part of
+#  Copyright (c) 2018-2023, Grünliberale Partei Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
 require 'spec_helper'
-
 
 describe ReoccuringMailchimpSynchronizationJob do
   let(:group) { groups(:top_group) }
@@ -27,18 +26,18 @@ describe ReoccuringMailchimpSynchronizationJob do
 
   it 'ignores list not linked' do
     Fabricate(:mailing_list, group: group)
-    expect { subject.perform }.not_to change { Delayed::Job.count }
+    expect { subject.perform_internal }.not_to(change { Delayed::Job.count })
   end
 
   it 'ignores list with failed result' do
     create(:failed)
-    expect { subject.perform }.not_to change { Delayed::Job.count }
+    expect { subject.perform_internal }.not_to(change { Delayed::Job.count })
   end
 
-  %i[success partial unchanged].each do |state|
+  [:success, :partial, :unchanged].each do |state|
     it "enqueues job for #{state}" do
       create(state)
-      expect { subject.perform }.to change { Delayed::Job.count }.by(1)
+      expect { subject.perform_internal }.to change { Delayed::Job.count }.by(1)
     end
   end
 


### PR DESCRIPTION
After a few linting and cleanup steps, I unexpectedly found the bug. 

The perform-methods of the `ReoccuringJob` handles the rescheduling. Therefore, overwriting it prevents the rescheduling.

The current healthz-checks for the DJ pod catch this, but it would be cleaner to reschedule the job directly instead of relying on external reboots.