### PR TITLE
Upgrade prometheus exporter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -421,7 +421,8 @@ GEM
       prawn-table
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    prometheus_exporter (0.5.0)
+    prometheus_exporter (2.0.8)
+      webrick
     protective (0.2.0)
       activerecord
     pry (0.14.1)

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -19,5 +19,4 @@ if !Rails.env.test? && ENV['PROMETHEUS_EXPORTER_HOST']
 
   # This reports delayed job info
   PrometheusExporter::Instrumentation::DelayedJob.register_plugin
-
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -42,6 +42,7 @@ plugin :tmp_restart
 if ENV['PROMETHEUS_EXPORTER_HOST']
   after_worker_boot do
     require 'prometheus_exporter/instrumentation'
+
     PrometheusExporter::Instrumentation::Puma.start
   end
 


### PR DESCRIPTION
In order to get more metrics in our updated dashboards, we need to update the exporter gem. The config did not need changes.