### PR TITLE
Course filter without deleted groups

### DIFF
--- a/app/models/group/types.rb
+++ b/app/models/group/types.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
@@ -59,7 +59,7 @@ module Group::Types
     unless layer_id == layer_group_id
       self_and_descendants.
         where(layer_group_id: layer_group_id).
-        update_all(layer_group_id: layer_id)
+        update_all(layer_group_id: layer_id) # rubocop:disable Rails/SkipsModelValidations intentionally update only one attribute
       self.layer_group_id = layer_id
     end
   end
@@ -125,6 +125,7 @@ module Group::Types
     def find_group_type!(sti_name)
       type = all_types.detect { |t| t.sti_name == sti_name }
       raise ActiveRecord::RecordNotFound, "No group '#{sti_name}' found" if type.nil?
+
       type
     end
 
@@ -132,6 +133,7 @@ module Group::Types
     def find_role_type!(sti_name)
       type = role_types.detect { |t| t.sti_name == sti_name }
       raise ActiveRecord::RecordNotFound, "No role '#{sti_name}' found" if type.nil?
+
       type
     end
 

--- a/app/models/group/types.rb
+++ b/app/models/group/types.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -117,6 +117,7 @@ module Group::Types
     # All groups that may offer courses
     def course_offerers
       where(type: course_types.map(&:sti_name)).
+        without_deleted.
         order(:parent_id, :name)
     end
 


### PR DESCRIPTION
Admist the cloud of Rubocop-Fixes lies a small change. "Thou shalt not include deleted groups in thy course listing" said a voice. As the fog was pushed away by the growing sunlight, it became apparent that a programmer tried to be funny. 

All there was, was a subtle oversight and a small fix. Well, that, and the sincere hope that this PR is deemed worthy to be merged.

And with hopeful eyes the programmer looked towards the reviewer...