### PR TITLE
Invoice lists: display all invoices by default and make ends of range inclusive

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -6,7 +6,6 @@
 #  https://github.com/hitobito/hitobito.
 
 class InvoicesController < CrudController
-  include YearBasedPaging
   include Api::JsonPaging
   include RenderMessagesExports
   include AsyncDownload
@@ -37,7 +36,7 @@ class InvoicesController < CrudController
                             :_destroy
                           ]]
 
-  before_render_index :year  # sets ivar used in view
+  before_render_index :year_from
 
   helper_method :group, :invoice_list
 
@@ -157,7 +156,7 @@ class InvoicesController < CrudController
     scope = scope.includes(:recipient).references(:recipient)
     scope = scope.standalone if parent.is_a?(Group)
     scope = scope.page(params[:page]).per(50) unless params[:ids]
-    Invoice::Filter.new(params.reverse_merge(year: year)).apply(scope)
+    Invoice::Filter.new(params).apply(scope)
   end
 
   def payment_attrs
@@ -193,6 +192,12 @@ class InvoicesController < CrudController
 
   def update_invoice_list_total
     entry.invoice_list&.update_total
+  end
+  
+  def year_from
+    if invoice_list
+      @year_from ||= invoice_list.created_at.year
+    end
   end
 
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -121,7 +121,8 @@ class Invoice < ActiveRecord::Base
       condition = OrCondition.new
       condition.or('issued_at >= :from AND issued_at <= :to', from: from, to: to)
       condition.or('issued_at IS NULL AND ' \
-                   'invoices.created_at >= :from AND invoices.created_at <= :to', from: from, to: to)
+                   'invoices.created_at >= :from AND invoices.created_at <= :to',
+                   from: from, to: to)
       where(condition.to_a)
     end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -119,9 +119,9 @@ class Invoice < ActiveRecord::Base
       to = Date.parse(to) if to.is_a? String
 
       condition = OrCondition.new
-      condition.or('issued_at > :from AND issued_at < :to', from: from, to: to)
+      condition.or('issued_at >= :from AND issued_at <= :to', from: from, to: to)
       condition.or('issued_at IS NULL AND ' \
-                   'invoices.created_at > :from AND invoices.created_at < :to', from: from, to: to)
+                   'invoices.created_at >= :from AND invoices.created_at <= :to', from: from, to: to)
       where(condition.to_a)
     end
 

--- a/app/views/invoices/_filter.html.haml
+++ b/app/views/invoices/_filter.html.haml
@@ -16,6 +16,6 @@
 
     %div
       .pull-right.invoices-daterange-filter
-        = direct_filter_date(:from, t('.from'), value: params[:from] || "1.1.#{@year || Time.zone.today.year}", data: { submit: true })
-        = direct_filter_date(:to, t('.to'), value: params[:to] || "31.12.#{@year || Time.zone.today.year}", data: { submit: true })
+        = direct_filter_date(:from, t('.from'), value: params[:from] || "1.1.#{@year_from || Time.zone.today.year}", data: { submit: true })
+        = direct_filter_date(:to, t('.to'), value: params[:to] || "31.12.#{Time.zone.today.year}", data: { submit: true })
 - params[:q] = nil # Reset param so quicksearch filter does not get populated


### PR DESCRIPTION
Behaviour before: Invoice lists have the current year (excluding first and last day) preselect, so when looking at old invoice lists, the list is empty and the fact that the end days are not including is surprising.

Behaviour after: Invoice lists by default show invoices starting at the beginning of the year when the list was created, to the end of the current year. The first and last day of the range is included in both the default range and when a different range is chosen by the user.

Tests: A few tests failed in my local run, but they don't look related to this change.