### PR TITLE
Dropdown only visible if permission to do action

### DIFF
--- a/app/domain/group/mover.rb
+++ b/app/domain/group/mover.rb
@@ -35,7 +35,7 @@ class Group::Mover
   end
 
   def matching_childgroup?(candidate)
-    candidate.possible_children.include?(group.class)
+    candidate.possible_children.include?(Draper.undecorate(group).class)
   end
 
 end

--- a/app/helpers/dropdown/base.rb
+++ b/app/helpers/dropdown/base.rb
@@ -27,7 +27,7 @@ module Dropdown
     def to_s
       template.button_group do
         render_dropdown_button +
-        render_items
+        (render_items if has_items?)
       end
     end
 
@@ -49,16 +49,21 @@ module Dropdown
 
     private
 
+    def has_items?
+      @items.present?
+    end
+
     def render_dropdown_button
-      safe_join([
-        label_with_link,
-        content_tag(:a,
+      dropdown_element = content_tag(:a,
                     class: "dropdown-toggle #{button_class}",
                     href: '#',
                     data: { toggle: 'dropdown' }) do
-          safe_join([label_without_link,
-                     content_tag(:b, '', class: 'caret')].compact, ' ')
-        end
+                      safe_join([label_without_link,
+                                content_tag(:b, '', class: 'caret')].compact, ' ')
+                    end
+      safe_join([
+        label_with_link,
+        has_items? ? dropdown_element : nil
       ].compact, ' ')
     end
 


### PR DESCRIPTION
The drop-down menu for modifying a group was visible even though the user did not have permission for any of these actions. Now it is visible only if the user has the permission.