### PR TITLE
Fix totp drift

### DIFF
--- a/app/domain/people/one_time_password.rb
+++ b/app/domain/people/one_time_password.rb
@@ -27,7 +27,8 @@ class People::OneTimePassword
   end
 
   def verify(token)
-    authenticator.verify(token)
+    drift = Settings.people.totp_drift
+    authenticator.verify(token, drift_ahead: drift, drift_behind: drift)
   end
 
   private

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -141,6 +141,7 @@ people:
   # either name or role
   default_sort: name
   abos: true
+  totp_drift: 15
 
 event:
   attachments:

--- a/spec/domain/people/one_time_password_spec.rb
+++ b/spec/domain/people/one_time_password_spec.rb
@@ -43,5 +43,61 @@ describe People::OneTimePassword do
 
       expect(subject.verify(totp_authenticator.now)).to_not be_nil
     end
+
+    it 'returns timestamp if input token is not expired' do
+      @secret = generate_token
+
+      current_time = Time.now
+      travel_to Time.new(current_time.year, current_time.month, current_time.day, current_time.hour, current_time.min, 2)
+      current_token = totp_authenticator.now
+
+      travel 5.seconds
+      expect(subject.verify(current_token)).to_not be_nil
+
+    end
+
+    it 'returns timestamp if input token is expired since less than 15s' do
+      @secret = generate_token
+
+      current_time = Time.now
+      travel_to Time.new(current_time.year, current_time.month, current_time.day, current_time.hour, current_time.min, 2)
+      current_token = totp_authenticator.now
+      
+      travel 35.seconds
+      expect(subject.verify(current_token)).to_not be_nil
+    end
+
+    it 'returns timestamp if input token will be valid in less than 15s' do
+      @secret = generate_token
+
+      current_time = Time.now
+      travel_to Time.new(current_time.year, current_time.month, current_time.day, current_time.hour, current_time.min, 2)
+      current_token = totp_authenticator.now
+      
+      travel -5.seconds
+      expect(subject.verify(current_token)).to_not be_nil
+    end
+
+    it 'returns nil if input token expired more than 15s ago' do
+      @secret = generate_token
+
+      current_time = Time.now
+      travel_to Time.new(current_time.year, current_time.month, current_time.day, current_time.hour, current_time.min, 2)
+      current_token = totp_authenticator.now
+      
+      travel -50.seconds
+      expect(subject.verify(current_token)).to eq(nil)
+    end
+
+    it 'returns nil if input token will be valid in 15s or more' do
+      @secret = generate_token
+
+      current_time = Time.now
+      travel_to Time.new(current_time.year, current_time.month, current_time.day, current_time.hour, current_time.min, 2)
+      current_token = totp_authenticator.now
+      
+      travel -25.seconds
+      expect(subject.verify(current_token)).to eq(nil)
+    end
   end
 end


### PR DESCRIPTION
Resolves #1830 

Die library erlaub auch ein `drift_ahead` (https://rubydoc.info/github/mdp/rotp/master/ROTP%2FTOTP:verify). Daraus schliesse ich, dass die drift parameter nur das jeweilige ende es slots verschieben und nicht den ganzen slot.

Der Code akzeptiert einen Time-Drift von maximal +/- 15 Sekunden. Das RFC zum TOTP spricht von bis zu 60s Verschiebung… (6.  Resynchronization, https://www.ietf.org/rfc/rfc6238.txt). Ich denke das sollte aber reichen um das Problem zu umgehen.