### PR TITLE
Download der Einladungsliste

### DIFF
--- a/app/abilities/event/invitation_ability.rb
+++ b/app/abilities/event/invitation_ability.rb
@@ -10,16 +10,16 @@ class Event::InvitationAbility < AbilityDsl::Base
 
   on(Event::Invitation) do
     permission(:group_full).
-      may(:new, :create, :edit).
+      may(:new, :create, :destroy).
       in_same_group_and_invitations_supported
     permission(:group_and_below_full).
-      may(:new, :create, :edit).
+      may(:new, :create, :destroy).
       in_same_group_or_below_and_invitations_supported
     permission(:layer_full).
-      may(:new, :create, :edit).
+      may(:new, :create, :destroy).
       in_same_layer_and_invitations_supported
     permission(:layer_and_below_full).
-      may(:new, :create, :edit).
+      may(:new, :create, :destroy).
       in_same_layer_or_below_and_invitations_supported
 
     permission(:any).may(:decline).own_invitation

--- a/app/abilities/event/invitation_ability.rb
+++ b/app/abilities/event/invitation_ability.rb
@@ -17,10 +17,10 @@ class Event::InvitationAbility < AbilityDsl::Base
       in_same_group_or_below_and_invitations_supported
     permission(:layer_full).
       may(:new, :create, :edit).
-      in_same_group_and_invitations_supported
+      in_same_layer_and_invitations_supported
     permission(:layer_and_below_full).
       may(:new, :create, :edit).
-      in_same_group_or_below_and_invitations_supported
+      in_same_layer_or_below_and_invitations_supported
 
     permission(:any).may(:decline).own_invitation
   end

--- a/app/controllers/event/invitations_controller.rb
+++ b/app/controllers/event/invitations_controller.rb
@@ -10,6 +10,9 @@ class Event::InvitationsController < CrudController
 
   self.nesting = [Group, Event]
 
+  # TODO: open / accepted is not distinguished yet
+  self.sort_mappings = { 'status': ['declined_at'] }
+
   decorates :group, :event
 
   prepend_before_action :parent, :group
@@ -29,9 +32,14 @@ class Event::InvitationsController < CrudController
   end
 
   def set_success_notice
-    msg = I18n.t('event_invitations.create.flash.success',
-                 recipient_name: entry.person.full_name,
-                 participation_type: entry.participation_type.constantize.model_name.human)
+    if action_name.to_s == 'create'
+      msg = I18n.t('event_invitations.create.flash.success',
+                   recipient_name: entry.person.full_name,
+                   participation_type: entry.participation_type.constantize.model_name.human)
+    elsif action_name.to_s == 'destroy'
+      msg = I18n.t('event_invitations.destroy.flash.success',
+                   recipient_name: entry.person.full_name)
+    end
 
     flash[:notice] = msg
   end

--- a/app/controllers/event/invitations_controller.rb
+++ b/app/controllers/event/invitations_controller.rb
@@ -70,7 +70,11 @@ class Event::InvitationsController < CrudController
 
   def render_tabular(format)
     exporter = Export::Tabular::Invitations::List
-    send_data exporter.export(format, entries), type: format
+    send_data exporter.export(format, entries, ability), type: format
+  end
+
+  def ability
+    @ability ||= Ability.new(Person.find(current_user.id))
   end
 
   class << self

--- a/app/controllers/event/invitations_controller.rb
+++ b/app/controllers/event/invitations_controller.rb
@@ -17,8 +17,21 @@ class Event::InvitationsController < CrudController
 
   prepend_before_action :parent, :group
 
+
+  ## def index: respond_to 
+  ## see hitobito/app/controllers/events_controller.rb
+  ## + job
+  ## + ..
+
   def create
     super(location: group_event_invitations_path(@group, @event))
+  end
+
+  def index
+    respond_to do |format|
+      format.html { super }
+      format.csv  { render_tabular_in_background(:csv) }
+    end 
   end
 
   private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -50,7 +50,7 @@ class EventsController < CrudController
   prepend_before_action :parent
 
   before_render_show :load_user_participation
-  before_render_show :load_open_invitation
+  before_render_show :load_my_invitation
   before_render_form :load_sister_groups
   before_render_form :load_kinds
 
@@ -146,11 +146,11 @@ class EventsController < CrudController
     end
   end
 
-  def load_open_invitation
+  def load_my_invitation
     if current_user
       invitation = current_user.event_invitations.find_by(event_id: entry.id)
-      if invitation.present? && invitation.open?
-        @open_invitation = invitation
+      if invitation.present?
+          @my_invitation = invitation
       end
     end
   end

--- a/app/domain/export/tabular/base.rb
+++ b/app/domain/export/tabular/base.rb
@@ -14,7 +14,7 @@ module Export::Tabular
     self.row_class = Export::Tabular::Row
     self.auto_filter = true
 
-    attr_reader :list
+    attr_reader :list, :ability
 
     class << self
       def export(format, *args)
@@ -40,8 +40,9 @@ module Export::Tabular
       end
     end
 
-    def initialize(list)
+    def initialize(list, abilitiy = nil)
       @list = list
+      @ability = abilitiy
     end
 
     # The list of all attributes exported to the csv/xlsx.
@@ -95,7 +96,11 @@ module Export::Tabular
     end
 
     def row_for(entry, format = nil)
-      row_class.new(entry, format)
+      row = row_class.new(entry, format)
+      if ability
+        row.set_ability(ability)
+      end
+      return row
     end
 
   end

--- a/app/domain/export/tabular/base.rb
+++ b/app/domain/export/tabular/base.rb
@@ -97,9 +97,9 @@ module Export::Tabular
 
     def row_for(entry, format = nil)
       row = row_class.new(entry, format)
-      if ability
-        row.set_ability(ability)
-      end
+      # see comment in Export::Tabular::Row for explanation
+      # why this is not included in `new()`
+      row.ability = ability
       return row
     end
 

--- a/app/domain/export/tabular/invitations/list.rb
+++ b/app/domain/export/tabular/invitations/list.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2014-2023, Carbon. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Export::Tabular::Invitations
+  class List < Export::Tabular::Base
+
+    self.model_class = Event::Invitation
+    self.row_class = Export::Tabular::Invitations::Row
+
+    def attributes
+      attrs = [:person, :mail, :participation_type, :status, :declined_at, :created_at]
+    end
+
+  end
+end
+

--- a/app/domain/export/tabular/invitations/row.rb
+++ b/app/domain/export/tabular/invitations/row.rb
@@ -13,9 +13,7 @@ module Export::Tabular::Invitations
     end
 
     def mail
-      #todo: can does not exist here
-      #entry.person.email if can?(:show, entry.person)
-      entry.person.email
+      entry.person.email if can?(:show, entry.person)
     end
 
     def participation_type
@@ -33,6 +31,13 @@ module Export::Tabular::Invitations
     def created_at
       entry.created_at
     end
+
+    private
+
+    def can?(*args)
+      ability.can?(*args)
+    end
+
   end
 end
 

--- a/app/domain/export/tabular/invitations/row.rb
+++ b/app/domain/export/tabular/invitations/row.rb
@@ -32,12 +32,6 @@ module Export::Tabular::Invitations
       entry.created_at
     end
 
-    private
-
-    def can?(*args)
-      ability.can?(*args)
-    end
-
   end
 end
 

--- a/app/domain/export/tabular/invitations/row.rb
+++ b/app/domain/export/tabular/invitations/row.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023-2023, Carbon. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Export::Tabular::Invitations
+  class Row < Export::Tabular::Row
+
+    def person
+      entry.person
+    end
+
+    def mail
+      #todo: can does not exist here
+      #entry.person.email if can?(:show, entry.person)
+      entry.person.email
+    end
+
+    def participation_type
+      entry.participation_type.constantize.model_name.human
+    end
+
+    def status
+      I18n.t("activerecord.attributes.event/invitation.statuses.#{entry.status}")
+    end
+
+    def declined_at
+      entry.declined_at
+    end
+
+    def created_at
+      entry.created_at
+    end
+  end
+end
+

--- a/app/domain/export/tabular/row.rb
+++ b/app/domain/export/tabular/row.rb
@@ -17,11 +17,15 @@ module Export::Tabular
     class_attribute :dynamic_attributes
     self.dynamic_attributes = {}
 
-    attr_reader :entry, :format
+    attr_reader :entry, :format, :ability
 
-    def initialize(entry, format = nil)
+    def initialize(entry, format = nil, ability = nil)
       @entry = entry
       @format = format
+    end
+
+    def set_ability(ability)
+      @ability = ability
     end
 
     def fetch(attr)

--- a/app/domain/export/tabular/row.rb
+++ b/app/domain/export/tabular/row.rb
@@ -17,14 +17,18 @@ module Export::Tabular
     class_attribute :dynamic_attributes
     self.dynamic_attributes = {}
 
-    attr_reader :entry, :format, :ability
+    attr_reader :entry, :format
+
+    # setter is needed as some child-classes redefine the
+    # `initialize`-methode with only two parameters.
+    # Due to this, generic calls (i.e. from Export::Tabular::Base)
+    # can not set ability when initializing
+    # todo: refactor all child-classes to new interface
+    attr_accessor :ability
 
     def initialize(entry, format = nil, ability = nil)
       @entry = entry
       @format = format
-    end
-
-    def set_ability(ability)
       @ability = ability
     end
 
@@ -33,6 +37,13 @@ module Export::Tabular
     end
 
     private
+
+    def can?(*args)
+      if not ability
+        raise "Ability not initialized yet."
+      end
+      ability.can?(*args)
+    end
 
     def value_for(attr)
       if dynamic_attribute?(attr.to_s)

--- a/app/helpers/dropdown/event/role_add.rb
+++ b/app/helpers/dropdown/event/role_add.rb
@@ -12,7 +12,7 @@ module Dropdown
 
       attr_reader :group, :event, :person
 
-      def initialize(template, group, event, person = nil, path_method = :new_group_event_role_path)
+      def initialize(template, group, event, person = nil, path_method = :new_group_event_role_path, include_restricted = false)
         label = translate("add_to_#{event.klass.name.underscore}",
                           default: full_translation_key(:add))
         super(template, label, :plus)
@@ -20,20 +20,35 @@ module Dropdown
         @event = event
         @person = person
         @path_method = path_method
-        init_items
+        if include_restricted
+          init_all_items
+        else
+          init_items
+        end
       end
 
       private
 
       def init_items
         event.role_types.reject(&:restricted?).each do |type|
-          event_role_attrs = { type: type.sti_name }
-          event_role_attrs[:person_id] = person.id if person
-
-          link = template.send(@path_method, group, event, event_role: event_role_attrs)
-          add_item(type.label, link)
+          init_item type
         end
       end
+
+      def init_all_items
+        event.role_types.each do |type|
+          init_item type
+        end
+      end
+
+      def init_item(type)
+        event_role_attrs = { type: type.sti_name }
+        event_role_attrs[:person_id] = person.id if person
+
+        link = template.send(@path_method, group, event, event_role: event_role_attrs)
+        add_item(type.label, link)
+      end
+
     end
   end
 end

--- a/app/jobs/export/invitation_export_job.rb
+++ b/app/jobs/export/invitation_export_job.rb
@@ -1,0 +1,30 @@
+# encoding: utf-8
+
+#  Copyright (c) 2023, Cevi Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class Export::InvitationsExportJob < Export::ExportBaseJob
+
+  self.parameters = PARAMETERS + [:event_id]
+
+  def initialize(user_id, event_id, options)
+    super(:csv, user_id, options)
+    @exporter = Export::Tabular::Invitations::List
+    @event_id = event_id
+  end
+
+  private
+
+  def entries
+    event.invitations
+         .without_deleted
+         .order(:lft)
+  end
+
+  def group
+    @event ||= Event.find(@event_id)
+  end
+end
+

--- a/app/jobs/export/invitations_export_job.rb
+++ b/app/jobs/export/invitations_export_job.rb
@@ -9,10 +9,10 @@ class Export::InvitationsExportJob < Export::ExportBaseJob
 
   self.parameters = PARAMETERS + [:event_id]
 
-  def initialize(user_id, event_id, options)
-    super(:csv, user_id, options)
-    @exporter = Export::Tabular::Invitations::List
+  def initialize(format, user_id, event_id, options)
+    super(format, user_id, options)
     @event_id = event_id
+    @exporter = Export::Tabular::Invitations::List
   end
 
   private

--- a/app/models/event/invitation.rb
+++ b/app/models/event/invitation.rb
@@ -25,6 +25,10 @@ class Event::Invitation < ActiveRecord::Base
   belongs_to :event
   belongs_to :person
 
+  validates_by_schema
+  validates :person_id,
+    uniqueness: { scope: :event_id , message: -> (s, _) { I18n.t("event_invitations.invalid_existing_person", model_name: s.event.model_name.human) }}
+
   def status
     if related_participation.present?
       :accepted

--- a/app/views/event/invitations/_actions_index.html.haml
+++ b/app/views/event/invitations/_actions_index.html.haml
@@ -4,4 +4,4 @@
 -#  https://github.com/hitobito/hitobito.
 
 - if can?(:new, model_class)
-  = Dropdown::Event::RoleAdd.new(self, @group, @event, nil, :new_group_event_invitation_path)
+  = Dropdown::Event::RoleAdd.new(self, @group, @event, nil, :new_group_event_invitation_path, include_restricted: true)

--- a/app/views/event/invitations/_actions_index.html.haml
+++ b/app/views/event/invitations/_actions_index.html.haml
@@ -5,3 +5,6 @@
 
 - if can?(:new, model_class)
   = Dropdown::Event::RoleAdd.new(self, @group, @event, nil, :new_group_event_invitation_path, include_restricted: true)
+
+= action_button("Download", group_event_invitations_path(@group, @event, format: :csv), :download)
+

--- a/app/views/event/invitations/_form.html.haml
+++ b/app/views/event/invitations/_form.html.haml
@@ -3,8 +3,11 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-= entry_form(entry, submit_label: t('global.button.save')) do |f|
+= entry_form(entry, submit_label: t('global.button.save'), buttons_top: false) do |f|
 
   = f.labeled_person_field(:person)
   = f.hidden_field(:event_id)
   = f.hidden_field(:participation_type, value: params[:event_role]['type'])
+
+%p
+  =t("events.invitations.description", model_name: entry.event.model_name.human)

--- a/app/views/event/invitations/_form.html.haml
+++ b/app/views/event/invitations/_form.html.haml
@@ -8,6 +8,7 @@
   = f.labeled_person_field(:person)
   = f.hidden_field(:event_id)
   = f.hidden_field(:participation_type, value: params[:event_role]['type'])
+  = hidden_field_tag("event_role[type]", params[:event_role]['type'])
 
 %p
   =t("events.invitations.description", model_name: entry.event.model_name.human)

--- a/app/views/event/invitations/_list.html.haml
+++ b/app/views/event/invitations/_list.html.haml
@@ -11,3 +11,4 @@
     = invitation.participation_type.constantize.model_name.human
   - t.sortable_attr(:status)
   - t.sortable_attrs :declined_at, :created_at
+  - add_table_actions(t)

--- a/app/views/event/invitations/_list.html.haml
+++ b/app/views/event/invitations/_list.html.haml
@@ -5,7 +5,9 @@
 
 = crud_table do |t|
   - t.sortable_attr(:person)
+  - t.col(Person.human_attribute_name(:email)) do |invitation|
+    = mail_to invitation.person.email
   - t.col(Event::Invitation.human_attribute_name(:participation_type)) do |invitation|
-    %strong
-      = invitation.participation_type.constantize.model_name.human
-  - t.sortable_attrs :status, :declined_at, :created_at
+    = invitation.participation_type.constantize.model_name.human
+  - t.sortable_attr(:status)
+  - t.sortable_attrs :declined_at, :created_at

--- a/app/views/event/invitations/_list.html.haml
+++ b/app/views/event/invitations/_list.html.haml
@@ -6,7 +6,7 @@
 = crud_table do |t|
   - t.sortable_attr(:person)
   - t.col(Person.human_attribute_name(:email)) do |invitation|
-    = mail_to invitation.person.email
+    - mail_to invitation.person.email if can?(:show, invitation.person)
   - t.col(Event::Invitation.human_attribute_name(:participation_type)) do |invitation|
     = invitation.participation_type.constantize.model_name.human
   - t.sortable_attr(:status)

--- a/app/views/events/_actions_show.html.haml
+++ b/app/views/events/_actions_show.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-- if !@user_participation && !@open_invitation && event_user_application_possible?(entry)
+- if !@user_participation && @my_invitation.try(:status) != :accepted && event_user_application_possible?(entry)
   = Dropdown::Event::ParticipantAdd.for_user(self, @group, entry, current_user)
 = button_action_edit if can?(:update, entry)
 = button_action_destroy if can?(:destroy, entry)

--- a/app/views/events/_actions_show.html.haml
+++ b/app/views/events/_actions_show.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-- if !@user_participation && @my_invitation.try(:status) != :accepted && event_user_application_possible?(entry)
+- if !@user_participation && @my_invitation.try(:status) != :open && event_user_application_possible?(entry)
   = Dropdown::Event::ParticipantAdd.for_user(self, @group, entry, current_user)
 = button_action_edit if can?(:update, entry)
 = button_action_destroy if can?(:destroy, entry)

--- a/app/views/events/_attrs.html.haml
+++ b/app/views/events/_attrs.html.haml
@@ -5,8 +5,10 @@
 
 - if @user_participation
   = render 'banner_participating'
-- elsif @open_invitation && event_user_application_possible?(entry)
+- elsif @my_invitation.try(:status) == :open && event_user_application_possible?(entry)
   = render 'banner_open_invitation'
+- elsif @my_invitation.try(:status) == :declined
+  = render 'banner_declined_invitation'
 
 #main.row-fluid
   %article.span7

--- a/app/views/events/_banner_declined_invitation.html.haml
+++ b/app/views/events/_banner_declined_invitation.html.haml
@@ -1,0 +1,7 @@
+-#  Copyright (c) 2021, CEVI ZH SH GL. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+.alert.alert-warning
+  = t('.explanation')

--- a/app/views/events/_banner_open_invitation.html.haml
+++ b/app/views/events/_banner_open_invitation.html.haml
@@ -6,9 +6,9 @@
 .alert.alert-warning
   = t('.explanation')
   .d-inline-block.offset-sm-1
-    = form_with method: :post, url: decline_group_event_invitation_path(@group, entry, @open_invitation), class: 'no-margin' do |f|
+    = form_with method: :post, url: decline_group_event_invitation_path(@group, entry, @my_invitation), class: 'no-margin' do |f|
       .btn-group
-        = link_to(contact_data_group_event_participations_path(@group, entry, event_role: { type: @open_invitation.participation_type }), class: 'btn', role: 'button') do
+        = link_to(contact_data_group_event_participations_path(@group, entry, event_role: { type: @my_invitation.participation_type }), class: 'btn', role: 'button') do
           = icon(:check)
           = t('.buttons.accept') 
         = button_tag type: :submit , class: 'btn' do

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -1563,6 +1563,9 @@ de:
     decline:
       flash:
         success: Einladung wurde abgelehnt.
+    destroy:
+      flash:
+        success: 'Einladung für %{recipient_name} wurde gelöscht.'
 
   people_filters:
     form:

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -1559,6 +1559,7 @@ de:
     create:
       flash:
         success: 'Einladung für %{recipient_name} als %{participation_type} wurde erstellt.'
+    invalid_existing_person: "wurde bereits zu diesem %{model_name} eingeladen."
     decline:
       flash:
         success: Einladung wurde abgelehnt.

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -487,6 +487,8 @@ de:
       buttons:
         accept: Anmelden
         decline: Abmelden
+    banner_declined_invitation:
+      explanation: Du wurdest zu diesem Anlass eingeladen und hast dich abgemeldet.
     default_description_link:
       insert_general_information: Standardbeschreibung einsetzen
     form:

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -525,6 +525,8 @@ de:
       participants: 'Teilnehmende'
     export_enqueued: 'Export wird im Hintergrund gestartet und nach Fertigstellung heruntergeladen.'
     add_tag: Tag hinzufügen
+    invitations:
+      description: 'Eingeladene Personen können sich via %{model_name}-Seite für den %{model_name} an- oder abmelden. Sie erhalten kein automatisches Mail.'
 
   event/applications:
     approved: 'Die Anmeldung wurde freigegeben.'

--- a/spec/controllers/event/invitations_controller_spec.rb
+++ b/spec/controllers/event/invitations_controller_spec.rb
@@ -11,29 +11,33 @@ describe Event::InvitationsController do
 
   before { sign_in(people(:top_leader)) }
 
-  let(:group) { groups(:top_group) }
+  test_groups = [ :top_group, :top_layer ]
   let(:course) { Fabricate(:course, groups: [group], priorization: true) }
   let(:bottom_member) { people(:bottom_member) }
   let(:invitation_params) { { person_id: bottom_member.id,
                               participation_type: 'Event::Role::Participant' } }
+  test_groups.each do |symbol|
 
-  context 'POST create' do
-    it 'creates invitation' do
-      expect do
+    context 'POST create' do
+      let(:group) { groups(symbol) }
+
+      it 'creates invitation' do
+        expect do
+          post :create, params: { group_id: group.id, event_id: course.id, event_invitation: invitation_params }
+        end.to change { Event::Invitation.count }.by(1)
+
+        expect(Event::Invitation.where(invitation_params)).to exist
+      end
+
+      it 'redirects to index path' do
         post :create, params: { group_id: group.id, event_id: course.id, event_invitation: invitation_params }
-      end.to change { Event::Invitation.count }.by(1)
+        expect(response).to redirect_to(group_event_invitations_path(group, course))
+      end
 
-      expect(Event::Invitation.where(invitation_params)).to exist
-    end
-
-    it 'redirects to index path' do
-      post :create, params: { group_id: group.id, event_id: course.id, event_invitation: invitation_params }
-      expect(response).to redirect_to(group_event_invitations_path(group, course))
-    end
-
-    it 'adds notice flash' do
-      post :create, params: { group_id: group.id, event_id: course.id, event_invitation: invitation_params }
-      expect(flash[:notice]).to eq('Einladung für Bottom Member als Teilnehmer/-in wurde erstellt.')
+      it 'adds notice flash' do
+        post :create, params: { group_id: group.id, event_id: course.id, event_invitation: invitation_params }
+        expect(flash[:notice]).to eq('Einladung für Bottom Member als Teilnehmer/-in wurde erstellt.')
+      end
     end
   end
 end


### PR DESCRIPTION
Vereinfacht diverse Tätigkeiten:
* Sortieren der Einladungen nach Status
* Kopieren der E-Mail für die Einladung oder eine Erinnerung
* Mitnehmen an Veranstaltung ;-)
* Kopieren der "Abgemeldet" Liste für Protokolle u.ä.

offenes Punkte (vgl. mit ` todo` markierte kommentare):
* Die Mailadresse wird auch von Personen exportiert auf die ich keinen Zugriff habe. (`can` steht in `app/domain/export/tabular/invitations/row.rb`  nicht zur Verfügung.) Brauche da einen Tipp - oder jemand von euch fixt das ;-)
* Export ist synchron, da ich den AsynExport nicht sinnvoll debuggen konnte. (ist was für den nächsten Hackaton)