### PR TITLE
Moved salutation to core and added configurable custom gender (off by default)

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -16,8 +16,8 @@ class PeopleController < CrudController
   self.remember_params += [:name, :range, :filters, :filter_id]
 
   self.permitted_attrs = [:first_name, :last_name, :company_name, :nickname, :company,
-                          :gender, :birthday, :title, :salutation, :additional_information,
-                          :picture, :remove_picture] +
+                          :gender, :gender_custom, :birthday, :title, :salutation,
+                          :additional_information, :picture, :remove_picture] +
                           Contactable::ACCESSIBLE_ATTRS +
                           [family_members_attributes: [:id, :kind, :other_id, :_destroy]] +
                           [household_people_ids: []] +

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -16,7 +16,8 @@ class PeopleController < CrudController
   self.remember_params += [:name, :range, :filters, :filter_id]
 
   self.permitted_attrs = [:first_name, :last_name, :company_name, :nickname, :company,
-                          :gender, :birthday, :additional_information, :picture, :remove_picture] +
+                          :gender, :birthday, :title, :salutation, :additional_information,
+                          :picture, :remove_picture] +
                           Contactable::ACCESSIBLE_ATTRS +
                           [family_members_attributes: [:id, :kind, :other_id, :_destroy]] +
                           [household_people_ids: []] +

--- a/app/domain/export/tabular/invoices/list.rb
+++ b/app/domain/export/tabular/invoices/list.rb
@@ -13,7 +13,7 @@ module Export::Tabular::Invoices
                         cost vat total amount_paid).freeze
 
 
-    CUSTOM_METHODS = %w(cost_centers accounts payments)
+    CUSTOM_METHODS = %w(cost_centers accounts payments salutation)
 
 
     self.model_class = Invoice

--- a/app/domain/export/tabular/invoices/row.rb
+++ b/app/domain/export/tabular/invoices/row.rb
@@ -43,6 +43,10 @@ module Export::Tabular::Invoices
       end
     end
 
+    def salutation
+      Salutation.new(entry.recipient).value
+    end
+
     private
 
     def with_precision(number)

--- a/app/domain/gender_custom.rb
+++ b/app/domain/gender_custom.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, GSoA. This file is part of
+#  hitobito_die_mitte and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class GenderCustom
+
+  I18N_KEY_PREFIX = 'activerecord.models.gender_custom'
+
+  class << self
+    def available
+      available = {}
+      I18n.t("#{I18N_KEY_PREFIX}.available").each do |salutation|
+        available[salutation.first.to_s] = salutation.last
+      end
+      {"" => available.delete("_nil")}.merge!(available)
+    end
+  end
+
+  def initialize(person)
+    @person = person
+  end
+
+  def available
+    result = self.class.available
+    if (Person::GENDERS & result.keys).include? @person.gender.presence
+      result = {@person.gender => result.delete(@person.gender)}.merge!(result)
+    end
+    result
+  end
+end

--- a/app/domain/salutation.rb
+++ b/app/domain/salutation.rb
@@ -51,7 +51,8 @@ class Salutation
   end
 
   def value
-    gender = person.gender.presence || 'other'
+    gender = person.gender_custom.presence || person.gender.presence
+    gender = 'other' if not ['w', 'm'].include? gender
     if salutation == 'custom'
       @salutation
     else

--- a/app/domain/salutation.rb
+++ b/app/domain/salutation.rb
@@ -25,8 +25,10 @@ class Salutation
     end
 
     def available
-      I18n.t("#{I18N_KEY_PREFIX}.available").each_with_object({}) do |s, h|
-        h[s.first.to_s] = s.last[:label]
+      available = {}
+      available[""] = I18n.t("#{I18N_KEY_PREFIX}.default.label")
+      I18n.t("#{I18N_KEY_PREFIX}.available").each_with_object(available) do |salutation, available_so_far|
+        available_so_far[salutation.first.to_s] = salutation.last[:label]
       end
     end
   end
@@ -36,17 +38,29 @@ class Salutation
     @salutation = (salutation || person.try(:salutation)).to_s
   end
 
+  def available
+    result = self.class.available
+    if salutation == 'custom'
+      result[@salutation] = @salutation
+    end
+    result
+  end
+
   def label
     I18n.translate("#{I18N_KEY_PREFIX}.#{salutation}.label")
   end
 
   def value
     gender = person.gender.presence || 'other'
-    I18n.translate("#{I18N_KEY_PREFIX}.#{salutation}.value.#{gender}", attributes)
+    if salutation == 'custom'
+      @salutation
+    else
+      I18n.translate("#{I18N_KEY_PREFIX}.#{salutation}.value.#{gender}", attributes)
+    end
   end
 
   def value_for_household(housemates)
-    join_salutations(housemates.map { |housemate| Salutation.new(housemate, @salutation).value })
+    join_salutations(housemates.map { |housemate| Salutation.new(housemate).value })
   end
 
   def join_salutations(salutations)
@@ -72,12 +86,14 @@ class Salutation
   end
 
   def salutation
-    if self.class.available.keys.include?(@salutation)
+    if not @salutation.blank? and self.class.available.keys.include?(@salutation)
       "available.#{@salutation}"
     elsif @salutation == 'personal' && @person.try(:salutation?)
       "available.#{@person.salutation}"
-    else
+    elsif @salutation.blank?
       'default'
+    else
+      'custom'
     end
   end
 end

--- a/app/helpers/format_helper.rb
+++ b/app/helpers/format_helper.rb
@@ -3,7 +3,7 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
-# A view helper to standartize often used functions like formatting,
+# A view helper to standardize often used functions like formatting,
 # tables, forms or action links. This helper is ideally defined in the
 # ApplicationController.
 module FormatHelper
@@ -70,6 +70,9 @@ module FormatHelper
     end.gsub(/\//, '_') # deal with nested models
   end
 
+  def format_person_salutation(obj)
+    Salutation.new(obj).value
+  end
 
   ##############  STANDARD HTML SECTIONS  ############################
 
@@ -166,6 +169,7 @@ module FormatHelper
   private
 
   # Helper methods that are not directly called from templates.
+
 
   # Formats an arbitrary attribute of the given object depending on its data type.
   # For ActiveRecords, take the defined data type into account for special types

--- a/app/helpers/format_helper.rb
+++ b/app/helpers/format_helper.rb
@@ -74,6 +74,11 @@ module FormatHelper
     Salutation.new(obj).value
   end
 
+  def format_person_gender_custom(obj)
+    gender = obj.gender_custom || "_nil"
+    I18n.t("activerecord.models.gender_custom.available.#{gender}")
+  end
+
   ##############  STANDARD HTML SECTIONS  ############################
 
   # Renders an arbitrary content with the given label. Used for uniform presentation.
@@ -169,7 +174,6 @@ module FormatHelper
   private
 
   # Helper methods that are not directly called from templates.
-
 
   # Formats an arbitrary attribute of the given object depending on its data type.
   # For ActiveRecords, take the defined data type into account for special types

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -66,8 +66,8 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
 
   PUBLIC_ATTRS = [ # rubocop:disable Style/MutableConstant meant to be extended in wagons
     :id, :first_name, :last_name, :nickname, :company_name, :company,
-    :email, :address, :zip_code, :town, :country, :gender, :birthday,
-    :title, :salutation, :picture, :primary_group_id
+    :email, :address, :zip_code, :town, :country, :gender, :gender_custom,
+    :birthday, :title, :salutation, :picture, :primary_group_id
   ]
 
   INTERNAL_ATTRS = [ # rubocop:disable Style/MutableConstant meant to be extended in wagons

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -67,7 +67,7 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   PUBLIC_ATTRS = [ # rubocop:disable Style/MutableConstant meant to be extended in wagons
     :id, :first_name, :last_name, :nickname, :company_name, :company,
     :email, :address, :zip_code, :town, :country, :gender, :birthday,
-    :picture, :primary_group_id
+    :title, :salutation, :picture, :primary_group_id
   ]
 
   INTERNAL_ATTRS = [ # rubocop:disable Style/MutableConstant meant to be extended in wagons
@@ -348,6 +348,10 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
 
   def greeting_name
     first_name.presence || nickname.presence || last_name.presence || company_name
+  end
+
+  def salutation_value
+    Salutation.new(self).value
   end
 
   def default_group_id

--- a/app/views/people/_attrs.html.haml
+++ b/app/views/people/_attrs.html.haml
@@ -11,6 +11,8 @@
       %div
         = render_attrs(entry, :birthday, :gender)
 
+        = render_attrs(entry, :title, :salutation)
+
         = render_extensions :details, locals: { show_full: can?(:show_full, entry) }
 
         - if can?(:update, entry)

--- a/app/views/people/_attrs.html.haml
+++ b/app/views/people/_attrs.html.haml
@@ -9,7 +9,13 @@
     - if can?(:show_details, entry)
       %h2= t('.additional_data')
       %div
-        = render_attrs(entry, :birthday, :gender)
+        = render_attrs(entry, :birthday)
+
+        - FeatureGate.if('people.gender_binary') do
+          = render_attrs(entry, :gender)
+
+        - FeatureGate.if('people.gender_custom') do
+          = render_attrs(entry, :gender_custom)
 
         = render_attrs(entry, :title, :salutation)
 

--- a/app/views/people/_fields.html.haml
+++ b/app/views/people/_fields.html.haml
@@ -25,9 +25,19 @@
 = render 'contactable/fields', f: f
 
 = field_set_tag do
-  = f.labeled(:gender) do
-    - (Person::GENDERS + ['']).each do |key|
-      = f.inline_radio_button(:gender, key, entry.gender_label(key))
+  - FeatureGate.if('people.gender_binary') do
+    = f.labeled(:gender) do
+      - (Person::GENDERS + ['']).each do |key|
+        = f.inline_radio_button(:gender, key, entry.gender_label(key))
+
+  - FeatureGate.if('people.gender_custom') do
+    = f.labeled_collection_select(:gender_custom,
+                                  GenderCustom.new(@person).available,
+                                  :first,
+                                  :last,
+                                  { include_blank: false },
+                                  class: 'span6')
+
 
   = f.labeled_string_field(:birthday,
                            value: f.date_value(:birthday),

--- a/app/views/people/_fields.html.haml
+++ b/app/views/people/_fields.html.haml
@@ -41,6 +41,14 @@
                                   { prompt: true },
                                   class: 'span6')
 
+= field_set_tag do
+  = f.labeled_input_field :title
+  = f.labeled_collection_select(:salutation,
+                                Salutation.new(@person).available,
+                                :first,
+                                :last,
+                                { include_blank: false },
+                                class: 'span6')
 
 = render_extensions :fields, locals: { f: f }
 

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -437,6 +437,7 @@ de:
         town: Ort
         country: Land
         gender: Geschlecht
+        gender_custom: Anredengeschlecht
         genders:
           m: männlich
           w: weiblich

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -334,19 +334,36 @@ de:
         personal:
           label: persönliche Anrede
         default:
-          label: Hallo [Name]
+          label: "Voreinstellung (aktuell: Hallo [Name])"
           value:
             m: Hallo %{greeting_name}
             w: Hallo %{greeting_name}
             other: Hallo %{greeting_name}
         available:
+          hallo_vorname:
+            label: Hallo [Name]
+            value:
+              m: Hallo %{greeting_name}
+              w: Hallo %{greeting_name}
+              other: Hallo %{greeting_name}
           lieber_vorname:
             label: Liebe*r [Vorname]
             value:
               m: Lieber %{first_name}
               w: Liebe %{first_name}
               other: Liebe*r %{first_name}
-
+          lieber_titel_nachname:
+            label: Liebe*r Frau*Herr [Titel] [Nachname]
+            value:
+              m: Lieber Herr %{title_last_name}
+              w: Liebe Frau %{title_last_name}
+              other: Liebe*r %{title_last_name}
+          sehr_geehrter_titel_nachname:
+            label: Sehr geehrte*r Frau*Herr [Titel] [Nachname]
+            value:
+              m: Sehr geehrter Herr %{title_last_name}
+              w: Sehr geehrte Frau %{title_last_name}
+              other: Sehr geehrte*r %{title_last_name}
       service_token:
         one: API-Key
         other: API-Keys
@@ -960,6 +977,7 @@ de:
         cost_centers: Kostenstellen
         accounts: Konten
         payments: Zahlungseingänge
+        salutation: Anrede
 
       invoice_article:
         number: Artikelnummer

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -142,6 +142,10 @@ people:
   default_sort: name
   abos: true
   totp_drift: 15
+  gender_custom:
+    enabled: false
+  gender_binary:
+    enabled: true
 
 event:
   attachments:

--- a/db/migrate/20230325000000_add_salutation_title_to_person.rb
+++ b/db/migrate/20230325000000_add_salutation_title_to_person.rb
@@ -1,0 +1,7 @@
+class AddSalutationTitleToPerson < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:people, :title, :string, null: true) unless column_exists?(:people, :title)
+    add_column(:people, :salutation, :string, null: true) unless column_exists?(:people, :salutation)
+    Person.reset_column_information
+  end
+end

--- a/db/migrate/20230326000000_add_custom_gender_to_person.rb
+++ b/db/migrate/20230326000000_add_custom_gender_to_person.rb
@@ -1,0 +1,6 @@
+class AddCustomGenderToPerson < ActiveRecord::Migration[6.0]
+  def change
+    add_column :people, :gender_custom, :string, null: true
+    Person.reset_column_information
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_27_151218) do
+ActiveRecord::Schema.define(version: 2023_04_05_000000) do
 
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -845,6 +845,8 @@ ActiveRecord::Schema.define(version: 2023_03_27_151218) do
     t.text "encrypted_two_fa_secret"
     t.string "language", default: "de", null: false
     t.timestamp "privacy_policy_accepted_at"
+    t.string "title"
+    t.string "salutation"
     t.index ["authentication_token"], name: "index_people_on_authentication_token"
     t.index ["confirmation_token"], name: "index_people_on_confirmation_token", unique: true
     t.index ["email"], name: "index_people_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -847,6 +847,7 @@ ActiveRecord::Schema.define(version: 2023_04_05_000000) do
     t.timestamp "privacy_policy_accepted_at"
     t.string "title"
     t.string "salutation"
+    t.string "gender_custom"
     t.index ["authentication_token"], name: "index_people_on_authentication_token"
     t.index ["confirmation_token"], name: "index_people_on_confirmation_token", unique: true
     t.index ["email"], name: "index_people_on_email", unique: true


### PR DESCRIPTION
This PR goes along with a PR in hitobito_generic which demonstrates the use of the new features in core. Both PRs have one commit for the salutation stuff and one for the gender stuff (so you can take it apart if you want, although the gender stuff won't work without the salutation stuff).

Before: There was already some salutation code in core, but it was incomplete. The gender field was ternary female/male/unknown.

After:

- Salutation (including title) works in core and is a bit more polished than some of the solutions I've seen implemented in wagons.
  - There is a new feature where you can put an arbitrary string in the salutation field using code (not in the UI) and this string is used as is for the entire salutation. When editing the person in the UI, you can keep this custom salutation or switch to one of the configured standard ones. It's intended to make it easier to import datasets with irregular salutations.
  - In the person view the salutation is displayed correctly not as the unformatted template string as before.
  - The salutation is added to invoice exports. Usually we send a letter along with the invoice which needs a salutation.
  - Salutations for households didn't work correctly before, now they do.
  - Made the person edit interface clearer so that the default salutation isn't just a blank field
  - The migrations for this are conditional, but because wagon migrations run after core migrations, all wagons which already have the field still need to be changed to make their migration also conditional in the same way as the migration in the core.
- Gender for salutations: I tried to come up with a pragmatic solution that works for everyone so we wouldn't need to maintain something separate.
  - Added new gender_custom field with choices defined in translation file. This field is disabled by default. In hitobito_generic I enable it for demonstration purposes and call it "Anredengeschlecht" with options male, female, neutral salutation, didn't want to answer question, unknown/blank.
  - If this gender_custom field is set to a non-blank value, it has precedence over the gender field for the salutation. It's not used otherwise.
  - Anything other than male/female gets a neutral salutation, i.e. the same as unknown gender.
  - The old gender field can be disabled with a FeatureGate/config option.
  - To migrate, it's possible to enable the new gender field and have both for a while and eventually maybe disable the old gender field. Or to switch immediately new gender field on, old field off (no data loss). Or to just start with the new one.
  - I'm sure there is a bunch of code that still depends on the old gender field, so if someone wants to disable the old field and needs the functionality there is still work to do. It won't break because the field is just removed from the UI, but it can't be updated anymore from the UI when it's disabled, so...

Tests: Rubocop passes, but a whole bunch of tests fail and I don't see any relation to my changes. If you want to accept the PR and would like me to investigate, just ping me.