### PR TITLE
Added the possibility to only specify birth year (off by default)

### DIFF
--- a/app/helpers/format_helper.rb
+++ b/app/helpers/format_helper.rb
@@ -70,6 +70,13 @@ module FormatHelper
     end.gsub(/\//, '_') # deal with nested models
   end
 
+  def format_person_birthday(obj)
+    if obj.birth_year_only and obj.birthday != nil
+      obj.birthday.year.to_s
+    else
+      f(obj.birthday)
+    end
+  end
 
   ##############  STANDARD HTML SECTIONS  ############################
 

--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -118,10 +118,15 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
     # Can also be serialized column
     raw = @object.timeliness_cache_attribute(attr) if @object.is_a?(ActiveRecord::Base)
     if raw
-      raw
+      r = raw
     else
       val = @object.send(attr)
-      val.is_a?(Date) ? template.l(val) : val
+      r = val.is_a?(Date) ? template.l(val) : val
+    end
+    if(attr == :birthday and @object.birth_year_only and r.to_s =~ /^(\d{2}.){2}\d{4}$/)
+      r[6..]
+    else
+      r
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -142,6 +142,8 @@ people:
   default_sort: name
   abos: true
   totp_drift: 15
+  birth_year_only_allowed:
+    enabled: false
 
 event:
   attachments:

--- a/db/migrate/20230406000000_add_birth_year_only.rb
+++ b/db/migrate/20230406000000_add_birth_year_only.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Schweizer Wanderwege. This file is part of
+#  hitobito_sww and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sww.
+
+class AddBirthYearOnly < ActiveRecord::Migration[6.1]
+  def change
+    add_column :people, :birth_year_only, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_27_151218) do
+ActiveRecord::Schema.define(version: 2023_04_06_000000) do
 
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -828,6 +828,7 @@ ActiveRecord::Schema.define(version: 2023_03_27_151218) do
     t.text "encrypted_two_fa_secret"
     t.string "language", default: "de", null: false
     t.timestamp "privacy_policy_accepted_at"
+    t.boolean "birth_year_only", default: false, null: false
     t.index ["authentication_token"], name: "index_people_on_authentication_token"
     t.index ["confirmation_token"], name: "index_people_on_confirmation_token", unique: true
     t.index ["email"], name: "index_people_on_email", unique: true
@@ -990,7 +991,7 @@ ActiveRecord::Schema.define(version: 2023_03_27_151218) do
     t.index ["contactable_id", "contactable_type"], name: "index_social_accounts_on_contactable_id_and_contactable_type"
   end
 
-  create_table "subscription_tags", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "subscription_tags", charset: "utf8mb4", force: :cascade do |t|
     t.boolean "excluded", default: false
     t.integer "subscription_id", null: false
     t.integer "tag_id", null: false


### PR DESCRIPTION
Before: You have either the full date for the birthday field, or nothing.

After: If you turn on the config option, you can put only a year in the birthday field and this is accepted.

- All functionality depending on birthday still works because internally 31.12. is added to the year.
- If you turn the config option off after using it for a while, all the contacts which have a year-only birthday keep it, but after you change it to a full date you can't change it back to year-only.
- There might be places left where a year-only birthday shows up as 31.12. of that year (e.g. in exports), but in person-view and person-edit-view it shows up as just year.

I'll fix the specs and do some polishing (for example exports) if you actually want to merge it.