### PR TITLE
fix: enlarged profil image for mobile devices

### DIFF
--- a/app/javascript/stylesheets/hitobito/modules/_profil.scss
+++ b/app/javascript/stylesheets/hitobito/modules/_profil.scss
@@ -27,7 +27,7 @@
   }
   .img {
     width: 512px;
-    height: 512px;
+    max-width: 98vw;
     margin: 50px auto;
     padding: 5px;
     background: $white;


### PR DESCRIPTION
Limit width of enlarged profile image to be the maximum of the screen width.

Relates to #2044