### PR TITLE
Enable subscriptions export to export table displays

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -61,7 +61,8 @@ class SubscriptionsController < CrudController
       Export::SubscriptionsJob.new(format,
                                    current_person.id,
                                    mailing_list.id,
-                                   params.slice(:household).merge(filename: filename)).enqueue!
+                                   params.slice(:household, :selection)
+                                         .merge(filename: filename)).enqueue!
     end
   end
 

--- a/app/jobs/export/subscriptions_job.rb
+++ b/app/jobs/export/subscriptions_job.rb
@@ -16,6 +16,13 @@ class Export::SubscriptionsJob < Export::ExportBaseJob
 
   private
 
+  def data
+    return super unless @options[:selection]
+
+    table_display = TableDisplay.for(@user_id, Person)
+    Export::Tabular::People::TableDisplays.export(@format, entries, table_display)
+  end
+
   def mailing_list
     @mailing_list ||= MailingList.find(@mailing_list_id)
   end
@@ -26,6 +33,7 @@ class Export::SubscriptionsJob < Export::ExportBaseJob
 
   def exporter
     return Export::Tabular::People::Households if @options[:household]
+    return Export::Tabular::People::TableDisplays if @options[:selection]
 
     Export::Tabular::People::PeopleAddress
   end


### PR DESCRIPTION
Context: https://help.puzzle.ch/#ticket/zoom/6146

https://github.com/hitobito/hitobito_pbs/pull/276

Even though in the views present, the subscriptions export never (AFAIK) exported table displays
