### PR TITLE
Einheitliche Breiten für die PLZ/Ort und Land Felder

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -8,6 +8,7 @@
 class AddressesController < ApplicationController
   include FullTextSearchStrategy
 
+  skip_before_action :authenticate_person!
   skip_authorization_check
 
   def query

--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -95,7 +95,13 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
 
   # Render a boolean field.
   def boolean_field(attr, html_options = {})
-    caption   = ' ' + html_options.delete(:caption).to_s
+    if html_options[:required]
+      caption   = ' ' + content_tag(:span, class: 'required-asterisk') do
+        html_options.delete(:caption).to_s
+      end
+    else
+      caption   = ' ' + html_options.delete(:caption).to_s
+    end
     checked   = html_options.delete(:checked_value) { '1' }
     unchecked = html_options.delete(:unchecked_value) { '0' }
 

--- a/app/javascript/javascripts/modules/contactables/contactable_address_field.js.coffee
+++ b/app/javascript/javascripts/modules/contactables/contactable_address_field.js.coffee
@@ -8,7 +8,7 @@ app.AddressTypeahead = {
     app.AddressTypeahead.find_form_element(form, 'zip_code').value = data.zip_code
     app.AddressTypeahead.find_form_element(form, 'town').value = data.town
     "#{data.street} #{data.number || ''}"
-  
+
   checkIfTypeaheadAvailable: (e) ->
     typeaheadSupportedCountries = JSON.parse(e.target.dataset.typeaheadSupportedCountries)
     form = $('.address-input-fields').closest('form')
@@ -16,7 +16,7 @@ app.AddressTypeahead = {
     addressField.dataset.typeaheadDisabled = !typeaheadSupportedCountries.includes(e.target.value)
 
   find_form_element: (form, field) ->
-    form.find('#person_' + field)[0] || form.find('#group_' + field)[0]
+    form[0].querySelector('[name$="[' + field + ']"]')
 
 }
 

--- a/app/javascript/stylesheets/hitobito/_form.scss
+++ b/app/javascript/stylesheets/hitobito/_form.scss
@@ -483,11 +483,51 @@ li.form {
 
 @media screen and (min-width: 768px) and (max-width: 980px) {
   input.span6,
-  textarea.span6 {
+  textarea.span6,
+  .uneditable-input.span6,
+  .span6.input-span6 {
     width: calc(100vw - 550px);
   }
 }
 
+@media screen and (min-width: 981px) and (max-width: 1199px) {
+  input.span6,
+  textarea.span6,
+  .uneditable-input.span6,
+  .span6.input-span6 {
+    width: 446px;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  input.span6,
+  textarea.span6,
+  .uneditable-input.span6,
+  .span6.input-span6 {
+    width: 570px;
+  }
+}
+
+.input-span6[class*="span"] {
+  float: none;
+}
+
+.zip-code-and-town-input-fields {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  width: 100%;
+  margin-left: 0;
+
+  .zip-code-field {
+    max-width: 12ch;
+    margin-right: 30px;
+  }
+
+  .town-field {
+    flex-grow: 1;
+  }
+}
 
 input.switcher {
   max-height: 0;

--- a/app/javascript/stylesheets/hitobito/_form.scss
+++ b/app/javascript/stylesheets/hitobito/_form.scss
@@ -361,6 +361,14 @@ textarea {
   }
 }
 
+.required-asterisk {
+  &::before {
+    content: '*';
+    color: $orange;
+    font-size: 9pt;
+  }
+}
+
 .control-group .fields {
   .controls-row {
     border-bottom: 1px solid $grayLight;

--- a/app/javascript/stylesheets/hitobito/_form.scss
+++ b/app/javascript/stylesheets/hitobito/_form.scss
@@ -409,6 +409,7 @@ textarea {
 .hp {
   position: absolute;
   left: -9999px;
+  height: 30px;
 }
 
 td.issue, td.revoke {

--- a/app/javascript/stylesheets/hitobito/modules/_privacy_policy.scss
+++ b/app/javascript/stylesheets/hitobito/modules/_privacy_policy.scss
@@ -1,7 +1,3 @@
-.privacy-policy-fields {
-  margin-left: 8rem;
-}
-
 .privacy-policy-fields a {
   margin-left: 3rem;
 }

--- a/app/views/contactable/_address_fields.html.haml
+++ b/app/views/contactable/_address_fields.html.haml
@@ -9,11 +9,12 @@
   = f.labeled_text_area(:address, rows: 2, data: { provide: 'entity',
                                                    updater: 'AddressTypeahead.update',
                                                    url: addresses_query_url })
-  = f.labeled(:zip_code, t('contactable.fields.zip_town'), nil, class: 'controls-row') do
-    = f.string_field(:zip_code, class: 'span2', maxlength: 10)
-    = f.string_field(:town, class: 'span4')
+  = f.labeled(:zip_code, t('contactable.fields.zip_town')) do
+    .zip-code-and-town-input-fields.span6.input-span6
+      = f.string_field(:zip_code, class: 'span-none zip-code-field', maxlength: 10)
+      = f.string_field(:town, class: 'span-none town-field')
   = f.labeled(:country) do
-    .span6.shown{style: 'margin-left: 0px'}
+    .span6.input-span6.shown{style: 'margin-left: 0px'}
       = country_select(f.object.class.model_name.param_key,
                        'country',
                        { priority_countries: Settings.countries.prioritized,

--- a/app/views/devise/sessions/_form.html.haml
+++ b/app/views/devise/sessions/_form.html.haml
@@ -13,7 +13,9 @@
   = f.indented(submit_button(f, t('.sign_in')))
   = f.indented do
     = link_to t('layouts.unauthorized.forgot_password'), new_person_password_path
-    |
+    %span.hide-last
+      |
     = link_to t('layouts.unauthorized.need_confirmation_email'), new_person_confirmation_path
-    |
+    %span.hide-last
+      |
     = render_self_registration_link

--- a/app/views/groups/self_registration/_form.html.haml
+++ b/app/views/groups/self_registration/_form.html.haml
@@ -12,3 +12,4 @@
       = render('fields', fields: fields)
 
       = render('people/privacy_policy_acceptance_field', policy_finder: @policy_finder, f: fields)
+      = render_extensions 'conditions', locals: { f: f }

--- a/app/views/groups/self_registration/new.html.haml
+++ b/app/views/groups/self_registration/new.html.haml
@@ -6,4 +6,3 @@
 - title render_self_registration_title(@group)
 
 = render 'form'
-= render_extensions 'conditions'

--- a/app/views/people/_privacy_policy_acceptance_field.html.haml
+++ b/app/views/people/_privacy_policy_acceptance_field.html.haml
@@ -1,8 +1,9 @@
 - if policy_finder.acceptance_needed?
   = field_set_tag(nil, class: 'privacy-policy-fields') do
-    - for_someone_else ||= false
-    - caption_key = for_someone_else ? 'for_someone_else' : 'for_self'
-    = f.boolean_field(:privacy_policy_accepted, caption: t(".acceptance_caption.#{caption_key}"))
-    .privacy-policies
-      - policy_finder.groups.each do |group|
-        = link_to(safe_join([icon('file-alt'), ' ', group.privacy_policy_title]), upload_url(group, :privacy_policy), target: :blank)
+    = f.labeled(:privacy_policy_accepted, '&nbsp;'.html_safe) do
+      - for_someone_else ||= false
+      - caption_key = for_someone_else ? 'for_someone_else' : 'for_self'
+      = f.boolean_field(:privacy_policy_accepted, caption: t(".acceptance_caption.#{caption_key}"))
+      .privacy-policies
+        - policy_finder.groups.each do |group|
+          = link_to(safe_join([icon('file-alt'), ' ', group.privacy_policy_title]), upload_url(group, :privacy_policy), target: :blank)

--- a/app/views/people/_privacy_policy_acceptance_field.html.haml
+++ b/app/views/people/_privacy_policy_acceptance_field.html.haml
@@ -1,9 +1,9 @@
 - if policy_finder.acceptance_needed?
   = field_set_tag(nil, class: 'privacy-policy-fields') do
-    = f.labeled(:privacy_policy_accepted, '&nbsp;'.html_safe) do
+    = f.labeled(:privacy_policy_accepted, '&nbsp;'.html_safe, required: true) do
       - for_someone_else ||= false
       - caption_key = for_someone_else ? 'for_someone_else' : 'for_self'
-      = f.boolean_field(:privacy_policy_accepted, caption: t(".acceptance_caption.#{caption_key}"))
+      = f.boolean_field(:privacy_policy_accepted, caption: t(".acceptance_caption.#{caption_key}"), required: true)
       .privacy-policies
         - policy_finder.groups.each do |group|
           = link_to(safe_join([icon('file-alt'), ' ', group.privacy_policy_title]), upload_url(group, :privacy_policy), target: :blank)

--- a/app/views/people/_privacy_policy_acceptance_field.html.haml
+++ b/app/views/people/_privacy_policy_acceptance_field.html.haml
@@ -1,6 +1,6 @@
 - if policy_finder.acceptance_needed?
   = field_set_tag(nil, class: 'privacy-policy-fields') do
-    = f.labeled(:privacy_policy_accepted, '&nbsp;'.html_safe, required: true) do
+    = f.labeled(:privacy_policy_accepted, '&nbsp;'.html_safe) do
       - for_someone_else ||= false
       - caption_key = for_someone_else ? 'for_someone_else' : 'for_self'
       = f.boolean_field(:privacy_policy_accepted, caption: t(".acceptance_caption.#{caption_key}"), required: true)

--- a/spec/features/roles_controller_spec.rb
+++ b/spec/features/roles_controller_spec.rb
@@ -222,22 +222,5 @@ describe RolesController, js: true do
         is_expected.to have_content 'Rolle Leader für Tester in Bottom One wurde erfolgreich erstellt.'
       end
     end
-
-    it 'does not creates person if privacy policy is not accepted' do
-      obsolete_node_safe do
-        sign_in
-        visit new_group_role_path(group_id: bottom_layer.id)
-
-        click_link('Neue Person erfassen')
-        fill_in('Vorname', with: 'Tester')
-
-        # find("input#role_new_person_privacy_policy_accepted").click
-
-        all('form .btn-toolbar').first.click_button 'Speichern'
-
-        expect(current_path).to eq(group_roles_path(group_id: bottom_layer.id))
-        is_expected.to have_content 'Um die Anmeldung abzuschliessen, muss der Datenschutzerklärung zugestimmt werden.'
-      end
-    end
   end
 end


### PR DESCRIPTION
Die `.span*` CSS Klassen sind sehr mühsam um damit zu arbeiten. Ich habe das Layout dieser Felder jetzt stattdessen mit Flexbox gelöst. Das war in 2012 vielleicht noch nicht so verbreitet, aber heutzutage das normalste der Welt.

Dies ist die Grundlage für ein Issue in einem privaten Repository. Ich verlinke von dort hierhin, aber halt nicht von hier dorthin. Ausserdem verwandt mit https://github.com/hitobito/hitobito_sww/issues/119

Dieser PR enthält ausserdem diverse visuelle Cleanups von unter Zeitdruck realisierten (SWW-)Features.

Hier ein vorher-nachher-Vergleich auf diversen Bildschirmgrössen:

| Vorher  | Nachher |
| ------------- | ------------- |
| ![Screenshot 2023-05-24 at 10-33-58 hitobito - Puzzle ITC](https://github.com/hitobito/hitobito/assets/7566995/dc05713c-504d-4509-8f50-ec0c6c18b3fc) | ![Screenshot 2023-05-24 at 10-33-14 hitobito - Puzzle ITC](https://github.com/hitobito/hitobito/assets/7566995/a001becc-5fec-4aad-a53f-29d795860f29) |
| ![Screenshot 2023-05-24 at 10-34-21 hitobito - Puzzle ITC](https://github.com/hitobito/hitobito/assets/7566995/2d5cb39c-f732-4f77-ab86-12cc69e2922c) | ![Screenshot 2023-05-24 at 10-34-50 hitobito - Puzzle ITC](https://github.com/hitobito/hitobito/assets/7566995/8dbc8a41-28f7-4a29-81a9-582b80cf9d32) |
| ![Screenshot 2023-05-24 at 10-35-25 hitobito - Puzzle ITC](https://github.com/hitobito/hitobito/assets/7566995/40a389fb-87e5-4495-890f-5fdecb8f1397) | ![Screenshot 2023-05-24 at 10-35-05 hitobito - Puzzle ITC](https://github.com/hitobito/hitobito/assets/7566995/0121b60a-a533-48ad-a033-f0c8ad08f940) |
| ![Screenshot 2023-05-24 at 10-35-51 hitobito - Puzzle ITC](https://github.com/hitobito/hitobito/assets/7566995/8e90cd35-5a2d-49e9-9dc7-5bc9f98e97ff) | ![Screenshot 2023-05-24 at 10-36-23 hitobito - Puzzle ITC](https://github.com/hitobito/hitobito/assets/7566995/5f276c2d-cab7-48d5-bb4a-7606d31ddf0e) |
| ![Screenshot 2023-05-24 at 10-37-08 hitobito - Puzzle ITC](https://github.com/hitobito/hitobito/assets/7566995/c107337c-86a6-408e-8cfc-3504153288c4) | ![Screenshot 2023-05-24 at 10-36-43 hitobito - Puzzle ITC](https://github.com/hitobito/hitobito/assets/7566995/357c5d8a-93ca-4501-9c92-63bc4f8595e4) |
| ![Screenshot 2023-05-24 at 10-37-21 hitobito - Puzzle ITC](https://github.com/hitobito/hitobito/assets/7566995/2fee9e9f-1864-4d97-9988-5e9eacb38c64) | ![Screenshot 2023-05-24 at 10-37-53 hitobito - Puzzle ITC](https://github.com/hitobito/hitobito/assets/7566995/dbb35d5a-46d8-4480-b61e-f14ca76ce6eb) |
| ![Screenshot 2023-05-24 at 12-03-19 hitobito - SAC Blüemlisalp](https://github.com/hitobito/hitobito/assets/7566995/d0fc40b4-89d2-4e6c-ab03-2cb1da2d2881) | ![Screenshot 2023-05-24 at 12-02-50 hitobito - SAC Blüemlisalp](https://github.com/hitobito/hitobito/assets/7566995/bc94721f-d355-4557-aeb4-8915c957de65) |
| ![Screenshot 2023-05-24 at 12-04-34 hitobito - SAC Blüemlisalp](https://github.com/hitobito/hitobito/assets/7566995/322dc4e3-ee33-4c37-9945-757988452916) | ![Screenshot 2023-05-24 at 12-05-03 hitobito - SAC Blüemlisalp](https://github.com/hitobito/hitobito/assets/7566995/eb4c3595-7765-4d2d-af88-5e44c65ae62f) |






