### PR TITLE
Structure parser

### DIFF
--- a/app/domain/structure_parser.rb
+++ b/app/domain/structure_parser.rb
@@ -160,7 +160,7 @@ class StructureParser
     second_pass
   end
 
-  def first_pass # rubocop:disable Metrics
+  def first_pass # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/AbcSize
     @structure.lines.each do |line|
       case line.delete_prefix(@common_indent).chomp
       when /^#{Regexp.escape(@list_marker)} (.*)$/
@@ -187,7 +187,7 @@ class StructureParser
     end
   end
 
-  def second_pass # rubocop:disable Metrics
+  def second_pass # rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/AbcSize
     first_pass = @result.dup
 
     @result = []

--- a/app/domain/structure_parser.rb
+++ b/app/domain/structure_parser.rb
@@ -1,0 +1,291 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023-2023, Jungschar EMK. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+
+require 'English'
+require 'pathname'
+require 'yaml'
+require 'active_support/inflector'
+
+# parses a structure as output by rake app:hitobito:roles
+class StructureParser
+  attr_reader :result
+
+  def initialize(structure, common_indent: 4, shiftwidth: 2, list_marker: '*')
+    # data
+    @structure = structure
+
+    # config
+    @common_indent = ' ' * common_indent.to_i
+    @shiftwidth = ' ' * shiftwidth.to_i
+    @list_marker = list_marker
+
+    # state init
+    @current_layer = nil
+    @current_group = nil
+    @result = {}
+  end
+
+  module Structure
+    class Group
+      attr_reader :name, :roles
+
+      def initialize(name)
+        @name = name
+
+        @roles = []
+      end
+
+      def inspect
+        to_s.inspect
+      end
+
+      def to_s
+        "Group #{@name} with #{@roles.count} role(s)"
+      end
+
+      def to_group
+        StructureParser::Group.new(@name)
+      end
+    end
+
+    class Layer < Group
+      attr_reader :children
+
+      def initialize(name)
+        super(name)
+        @children = []
+      end
+
+      def to_s
+        "Layer #{@name} with #{@children.count} subgroup(s)"
+      end
+    end
+  end
+
+  class Group
+    attr_reader :children, :roles
+    attr_accessor :layer_group, :layer_name, :name
+
+    def initialize(name)
+      @name = name
+
+      @layer_group = false
+      @children = []
+      @roles = []
+    end
+
+    def inspect
+      to_s.inspect
+    end
+
+    def to_s
+      type = @layer_group ? 'LayerGroup' : 'Group'
+      "#{type} #{@name} with #{@children.count} subgroup(s) and #{@roles.count} role(s)"
+    end
+
+    def class_name
+      @class_name ||= @name.encode(
+        'ASCII', 'UTF-8',
+        fallback: { 'ä' => 'ae', 'ü' => 'ue', 'ö' => 'oe' }
+      )
+    end
+
+    def child_class_names
+      @children.map do |child|
+        class_name + child.class_name
+      end
+    end
+
+    def role_class_names
+      @roles.map(&:class_name)
+    end
+
+    def yaml_key
+      @yaml_key ||= ActiveSupport::Inflector.underscore(class_name)
+    end
+  end
+
+  class Role
+    attr_accessor :group, :name
+
+    def initialize(name, permissions)
+      @name = name
+      @permissions = parse_permissions(permissions)
+    end
+
+    def parse_permissions(permissions)
+      instance_eval(permissions)
+    end
+
+    def permissions
+      @permissions.map(&:inspect).join(', ')
+    end
+
+    def inspect
+      to_s.inspect
+    end
+
+    def to_s
+      group_text = "in group #{group.name}" if group
+
+      "Role #{@name} with #{@permissions.inspect} #{group_text}".strip
+    end
+
+    def class_name
+      @class_name ||= @name.delete_suffix('/-in')
+                           .delete_suffix('/-r')
+                           .encode('ASCII', 'UTF-8', fallback: {
+                                     'ä' => 'ae',
+                                     'ü' => 'ue',
+                                     'ö' => 'oe'
+                                   })
+    end
+
+    def name_for_translation
+      @name.delete_prefix(group&.layer_name.to_s)
+    end
+
+    def yaml_key
+      "#{group.yaml_key}/#{ActiveSupport::Inflector.underscore(class_name)}"
+    end
+  end
+
+  def parse
+    first_pass
+    second_pass
+  end
+
+  def first_pass # rubocop:disable Metrics
+    @structure.lines.each do |line|
+      case line.delete_prefix(@common_indent).chomp
+      when /^#{Regexp.escape(@list_marker)} (.*)$/
+        name = Regexp.last_match(1)
+        layer = Structure::Layer.new(name)
+
+        @current_layer = layer
+        @current_group = layer
+        @result[layer] ||= {}
+      when /^#{@shiftwidth}#{Regexp.escape(@list_marker)} (.*)$/
+        name = Regexp.last_match(1)
+        group = Structure::Group.new(name)
+
+        @current_layer.children << group
+        @current_group = group
+        @result[@current_layer][group] ||= []
+      when /^#{@shiftwidth * 2}#{Regexp.escape(@list_marker)} (.*):\s+(\[.*\])$/
+        match = Regexp.last_match
+        role = Role.new(match[1], match[2])
+
+        @current_group.roles << role
+        @result[@current_layer][@current_group] << role
+      end
+    end
+  end
+
+  def second_pass # rubocop:disable Metrics
+    first_pass = @result.dup
+
+    @result = []
+    first_pass.each do |layer, groups|
+      groups.each do |group, roles|
+        new_group = Group.new(group.name)
+        if group.name == layer.name
+          new_group.layer_group = true
+          layer.children
+               .reject { |child| child.name == group.name }
+               .each { |child| new_group.children << child.to_group }
+        else
+          new_group.name = layer.name + group.name
+        end
+
+        roles.each do |role|
+          role.group = new_group
+          new_group.roles << role
+        end
+
+        @result << new_group
+      end
+    end
+  end
+
+  def output_groups
+    @result.map { |group| group_template(group) }
+  end
+
+  def output_translations
+    groups, roles = @result.reduce([[], []]) do |memos, group|
+      groups, roles = memos
+
+      groups << group
+      group.roles.each do |role|
+        roles << role
+      end
+
+      [groups, roles]
+    end
+
+    translations(groups, roles)
+  end
+
+  private
+
+  def group_template(group)
+    <<~CODE
+      class Group::#{group.class_name} < ::Group
+        #{'self.layer = true' if group.layer_group}
+        #{'children ' if group.children.any?}#{group.child_class_names.join(",\n")}
+
+        ### ROLES
+
+      #{group.roles.map { |role| role_template(role) }.join("\n\n")}
+
+        roles #{group.role_class_names.join(', ')}
+      end
+    CODE
+  end
+
+  def role_template(role)
+    <<-CODE
+  class #{role.class_name} < ::Role
+    self.permissions = [#{role.permissions}]
+  end
+    CODE
+  end
+
+  def translations(groups, roles)
+    <<~CODE
+      de:
+        activerecord:
+          models:
+
+            ### GROUPS
+
+      #{groups.map { |group| group_translations(group) }.join("\n")}
+
+            ### ROLES
+
+      #{roles.map { |role| role_translations(role) }.join("\n")}
+    CODE
+  end
+
+  def group_translations(group)
+    <<-YAML
+      group/#{group.yaml_key}:
+        one: #{group.name}
+        other: TODO
+    YAML
+  end
+
+  def role_translations(role)
+    <<-YAML
+      group/#{role.yaml_key}:
+        one: #{role.name_for_translation}
+        description: TODO
+    YAML
+  end
+end

--- a/lib/tasks/hitobito.rake
+++ b/lib/tasks/hitobito.rake
@@ -9,9 +9,9 @@ namespace :hitobito do
   desc 'Print all groups, roles and permissions'
   task roles: :environment do
     Role::TypeList.new(Group.root_types.first).each do |layer, groups|
-      puts '    * ' + layer
+      puts "    * #{layer}"
       groups.each do |group, roles|
-        puts '      * ' + group
+        puts "      * #{group}"
         roles.each do |r|
           twofa_tag = '2FA ' if r.two_factor_authentication_enforced
           puts "        * #{r.label}: #{twofa_tag}#{r.permissions.inspect}"
@@ -22,7 +22,7 @@ namespace :hitobito do
 
   namespace :roles do
     task update_readme: :environment do
-      stdout, _stderr, status = Open3.capture3("rake app:hitobito:roles")
+      stdout, _stderr, status = Open3.capture3('rake app:hitobito:roles')
       raise 'failed to generate role docs with `rake app:hitobito:roles`' unless status.success?
 
       roles = "#{stdout}\n(Output of rake app:hitobito:roles)"
@@ -31,11 +31,11 @@ namespace :hitobito do
       pattern = /#{start_tag}(.*)#{end_tag}/m
       readme_contents = File.read('README.md').strip
 
-      if pattern.match?(readme_contents)
-        updated_contents = readme_contents.gsub(pattern, "#{start_tag}\n#{roles}\n#{end_tag}")
-      else
-        updated_contents = "#{readme_contents}\n\n#{start_tag}\n#{roles}\n#{end_tag}\n"
-      end
+      updated_contents = if pattern.match?(readme_contents)
+                           readme_contents.gsub(pattern, "#{start_tag}\n#{roles}\n#{end_tag}")
+                         else
+                           "#{readme_contents}\n\n#{start_tag}\n#{roles}\n#{end_tag}\n"
+                         end
 
       File.write('README.md', updated_contents)
     end

--- a/lib/tasks/hitobito.rake
+++ b/lib/tasks/hitobito.rake
@@ -80,4 +80,25 @@ namespace :hitobito do
       end
     end
   end
+
+  desc 'Parse Structure and output classes and translations'
+  task :parse_structure, [:filename] do |_t, args| # rubocop:disable Rails/RakeEnvironment
+    require_relative '../../app/domain/structure_parser'
+    args.with_defaults({
+                         filename: './structure.txt'
+                       })
+
+    file = Pathname.new(args[:filename]).expand_path
+    puts "-------- Parsing #{file}"
+
+    parser = StructureParser.new(file.read, common_indent: 0, shiftwidth: 4, list_marker: '-')
+    puts parser.inspect
+    parser.parse
+
+    puts '-------- Groups and Roles as classes ------'
+    puts parser.output_groups
+    puts '-------- Translations for those -----------'
+    puts parser.output_translations
+    puts '-------- Done.'
+  end
 end

--- a/spec/domain/structure_parser_spec.rb
+++ b/spec/domain/structure_parser_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023-2023, Jungschar EMK. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+
+# load rails and dependencies, basically to widen the LOAD_PATH and have zeitgeist
+ENV['RAILS_ENV'] = 'test'
+require File.expand_path('../../config/environment', __dir__)
+
+# load system under test
+require 'structure_parser'
+
+describe StructureParser do
+  let(:structure) do
+    <<~TEXT
+      * Dachverband
+          * Dachverband
+              * Administrator/-in: [:admin, :layer_and_below_full, :impersonation]
+          * Vorstand
+              * Präsident/-in: [:layer_read, :group_and_below_full, :contact_data]
+              * Kassier/-in: [:layer_and_below_read, :finance, :contact_data]
+              * Mitglied:  [:layer_read, :contact_data]
+          * Geschäftsstelle
+              * Geschäftsleiter/-in: [:admin, :layer_and_below_full, :impersonation, :contact_data]
+              * Angestellte/-r: [:admin, :layer_and_below_full, :impersonation, :contact_data]
+          * Gremium
+              * Leiter/-in: [:layer_read, :group_and_below_full, :contact_data]
+              * Kassier/-in: [:layer_read, :finance]
+              * Mitglied: [:layer_read]
+          * Mitglieder
+              * Adressverwalter/-in: [:group_and_below_full]
+              * Mitglied: []
+      * Region
+          * Region
+              * Administrator/-in: [:layer_and_below_full]
+          * Vorstand
+              * Präsident/-in: [:layer_and_below_read, :group_and_below_full, :contact_data]
+              * Kassier/-in: [:layer_and_below_read, :finance, :contact_data]
+              * Mitglied: [:layer_and_below_read, :contact_data]
+          * Geschäftsstelle
+              * Geschäftsleiter/-in: [:layer_and_below_full, :finance, :contact_data]
+              * Angestellte/-r: [:layer_and_below_full, :finance, :contact_data]
+          * Gremium
+              * Leiter/-in: [:layer_and_below_read, :group_and_below_full, :contact_data]
+              * Kassier/-in: [:layer_and_below_read, :finance]
+              * Mitglied: [:group_and_below_read]
+          * Mitglieder
+              * Adressverwalter/-in: [:group_and_below_full]
+              * Mitglied: []
+      * Lagerverein
+          * Lagerverein
+              * Administrator/-in: [:layer_and_below_full]
+          * Verein
+              * Leiter/-in: [:layer_read, :group_and_below_full, :contact_data]
+              * Kassier/-in: [:layer_read, :finance]
+              * Mitglied: [:layer_read]
+      * Ortsjungschar
+          * Ortsjungschar
+              * Hauptleitung: [:layer_and_below_full, :contact_data]
+              * Leiter/-in: [:group_and_below_full, :contact_data]
+              * Adressverwaltung: [:group_and_below_full, :contact_data]
+              * Coach: [:layer_and_below_full, :approve_applications, :contact_data]
+              * Kassier: [:layer_read, :finance]
+              * Materialverantwortliche/-r: [:layer_and_below_read, :contact_data]
+              * Aktivmitglied: [:group_and_below_read]
+              * Passivmitglied: []
+          * Vorstand
+              * Präsident/-in: [:layer_full, :contact_data]
+              * Sekretär/-in: [:layer_full, :contact_data]
+              * Vorstandsmitglied: [:layer_full, :contact_data]
+          * Gremium/Projektgruppe
+              * Leiter/-in: [:group_and_below_full, :contact_data]
+              * Mitglied: [:group_and_below_read]
+          * Mitglieder
+              * Leiter/-in: [:group_and_below_full, :contact_data]
+              * Aktivmitglied: [:group_and_below_read]
+              * Passivmitglied: []
+    TEXT
+  end
+
+  it 'can be created' do
+    described_class.new(structure)
+  end
+
+  it 'can parse a structure' do
+    described_class.new(structure, common_indent: 0, shiftwidth: 4).parse
+  end
+
+  context 'has a result after simple "first pass"-parsing, which' do
+    subject do
+      described_class.new(
+        structure.lines.take(3).join("\n"),
+        common_indent: 0,
+        shiftwidth: 4
+      )
+    end
+    before(:each) { subject.first_pass }
+
+    it 'can be read' do
+      expect(subject.result).to_not be_nil
+    end
+
+    it 'is a hash' do
+      expect(subject.result).to be_a Hash
+    end
+
+    it 'has the expected structure' do
+      expect(subject.result.inspect).to eql({
+        'Layer Dachverband with 1 subgroup(s)' => {
+          'Group Dachverband with 1 role(s)' => [
+            'Role Administrator/-in with [:admin, :layer_and_below_full, :impersonation]'
+          ]
+        }
+      }.inspect)
+    end
+  end
+
+  context 'has a result after simple "two pass"-parsing' do
+    subject do
+      described_class.new(
+        structure.lines.take(17).join("\n"),
+        common_indent: 0,
+        shiftwidth: 4
+      )
+    end
+
+    before(:each) do
+      subject.first_pass
+      subject.second_pass
+    end
+
+    it 'can be read' do
+      expect(subject.result).to_not be_nil
+    end
+
+    it 'is a hash' do
+      expect(subject.result).to be_an Array
+    end
+
+    it 'has the expected first level structure' do
+      expect(subject.result.first.to_s)
+        .to eql 'LayerGroup Dachverband with 4 subgroup(s) and 1 role(s)'
+    end
+
+    it 'has the expected first level structure' do
+      actual = subject.result.map(&:to_s)
+      expected = [
+        'LayerGroup Dachverband with 4 subgroup(s) and 1 role(s)',
+        'Group DachverbandVorstand with 0 subgroup(s) and 3 role(s)',
+        'Group DachverbandGeschäftsstelle with 0 subgroup(s) and 2 role(s)',
+        'Group DachverbandGremium with 0 subgroup(s) and 3 role(s)',
+        'Group DachverbandMitglieder with 0 subgroup(s) and 2 role(s)'
+      ]
+      expect(actual).to match_array(expected)
+      expect(actual).to eql(expected)
+    end
+  end
+
+  context 'has a result after complete parsing, it' do
+    subject do
+      described_class.new(
+        structure,
+        common_indent: 0,
+        shiftwidth: 4
+      )
+    end
+
+    before(:each) do
+      subject.parse
+    end
+
+    it 'can be read' do
+      expect(subject.result).to_not be_nil
+    end
+
+    it 'is a hash' do
+      expect(subject.result).to be_an Array
+    end
+
+    it 'has the expected first level structure' do
+      expect(subject.result.first.to_s)
+        .to eql 'LayerGroup Dachverband with 4 subgroup(s) and 1 role(s)'
+    end
+
+    it 'has the expected roles on a certain group' do
+      # rubocop:disable Metrics/LineLength
+      expect(subject.result[1].roles.map(&:to_s)).to match_array [
+        'Role Präsident/-in with [:layer_read, :group_and_below_full, :contact_data] in group DachverbandVorstand',
+        'Role Kassier/-in with [:layer_and_below_read, :finance, :contact_data] in group DachverbandVorstand',
+        'Role Mitglied with [:layer_read, :contact_data] in group DachverbandVorstand'
+      ]
+      # rubocop:enable Metrics/LineLength
+    end
+
+    it 'has the expected structure' do
+      actual = subject.result.map(&:to_s)
+      expected = [
+        'LayerGroup Dachverband with 4 subgroup(s) and 1 role(s)',
+        'Group DachverbandVorstand with 0 subgroup(s) and 3 role(s)',
+        'Group DachverbandGeschäftsstelle with 0 subgroup(s) and 2 role(s)',
+        'Group DachverbandGremium with 0 subgroup(s) and 3 role(s)',
+        'Group DachverbandMitglieder with 0 subgroup(s) and 2 role(s)',
+        'LayerGroup Region with 4 subgroup(s) and 1 role(s)',
+        'Group RegionVorstand with 0 subgroup(s) and 3 role(s)',
+        'Group RegionGeschäftsstelle with 0 subgroup(s) and 2 role(s)',
+        'Group RegionGremium with 0 subgroup(s) and 3 role(s)',
+        'Group RegionMitglieder with 0 subgroup(s) and 2 role(s)',
+        'LayerGroup Lagerverein with 1 subgroup(s) and 1 role(s)',
+        'Group LagervereinVerein with 0 subgroup(s) and 3 role(s)',
+        'LayerGroup Ortsjungschar with 3 subgroup(s) and 8 role(s)',
+        'Group OrtsjungscharVorstand with 0 subgroup(s) and 3 role(s)',
+        'Group OrtsjungscharGremium/Projektgruppe with 0 subgroup(s) and 2 role(s)',
+        'Group OrtsjungscharMitglieder with 0 subgroup(s) and 3 role(s)'
+      ]
+      expect(actual).to match_array(expected)
+      expect(actual).to eql(expected)
+    end
+  end
+
+  context 'has assumptions' do
+    subject { described_class.new(structure) }
+
+    it 'can parse a line' do
+      input = <<~TEXT
+        * Dachverband
+      TEXT
+
+      line = input.lines.first
+      expect(line.delete_prefix('').chomp).to eql '* Dachverband'
+    end
+
+    it 'can extract a layer-name' do
+      /^\* (.*)$/ === '* Dachverband' # actually emulate case # rubocop:disable Lint/Void,Style/CaseEquality
+      expect(Regexp.last_match(1)).to eql 'Dachverband'
+    end
+  end
+end

--- a/spec/domain/structure_parser_spec.rb
+++ b/spec/domain/structure_parser_spec.rb
@@ -103,7 +103,7 @@ describe StructureParser do
       expect(subject.result).to_not be_nil
     end
 
-    it 'is a hash' do
+    it do
       expect(subject.result).to be_a Hash
     end
 
@@ -136,7 +136,7 @@ describe StructureParser do
       expect(subject.result).to_not be_nil
     end
 
-    it 'is a hash' do
+    it do
       expect(subject.result).to be_an Array
     end
 
@@ -176,7 +176,7 @@ describe StructureParser do
       expect(subject.result).to_not be_nil
     end
 
-    it 'is a hash' do
+    it do
       expect(subject.result).to be_an Array
     end
 


### PR DESCRIPTION
`rake hitobito:roles` generates a structure which we also use to describe new instances. Therefore, parsing this structure saves a lot of repetitive work and keeps things consistent. The generated content still needs to be placed into the right files and many more manual steps are needed for a full group-definition. But this can give you a head-start. Also, it might need more work with the next new instance.