### PR TITLE
RELEASE: Einsprachigkeit

### DIFF
--- a/lib/release/highlevel.rb
+++ b/lib/release/highlevel.rb
@@ -39,11 +39,11 @@ module Release
       execute 'git fetch && git fetch --tags'
     end
 
-    def update_translations
-      # configured = execute_check 'test -f .tx/config',
-      #                            success: 'Transifex is configured',
-      #                            failure: 'Transifex seems not configured'
-      # return unless configured
+    def update_translations # rubocop:disable Metrics/MethodLength
+      configured = execute_check 'test -f .tx/config',
+                                 success: 'Transifex is configured',
+                                 failure: 'Transifex seems not configured'
+      return unless configured
 
       notify 'Pulling translation from transifex'
       execute 'tx pull -f'

--- a/lib/release/highlevel.rb
+++ b/lib/release/highlevel.rb
@@ -39,22 +39,28 @@ module Release
       execute 'git fetch && git fetch --tags'
     end
 
-    def update_translations # rubocop:disable Metrics/MethodLength
-      configured = execute_check 'test -f .tx/config',
-                                 success: 'Transifex is configured',
-                                 failure: 'Transifex seems not configured'
-      return unless configured
+    def update_translations
+      return unless translations_configured?
 
       notify 'Pulling translation from transifex'
       execute 'tx pull -f'
       add 'config/locales/*.yml'
 
-      changes = execute_check 'test $(git status -s -- config/locales | wc -l) -gt 0',
-                              success: 'Updated translations found',
-                              failure: 'No changes in translations'
-      return unless changes
+      return unless translations_changed?
 
       commit 'Pull translations from transifex'
+    end
+
+    def translations_configured?
+      execute_check 'test -f .tx/config',
+                    success: 'Transifex is configured',
+                    failure: 'Transifex seems not configured'
+    end
+
+    def translations_changed?
+      execute_check 'test $(git status -s -- config/locales | wc -l) -gt 0',
+                    success: 'Updated translations found',
+                    failure: 'No changes in translations'
     end
 
     def update_version(file:, to: @version)

--- a/lib/release/main.rb
+++ b/lib/release/main.rb
@@ -82,12 +82,6 @@ class Release::Main
     abort("USAGE: #{$PROGRAM_NAME} $WAGONS or WAGONS='wagon1 wagon2' #{$PROGRAM_NAME}")
   end
 
-  def untranslated_wagons
-    # if you want to extend this list: rather check if a transifex-config is
-    # present (see update_translations)
-    %w(cevi jubla)
-  end
-
   def first_wagon=(first_wagon)
     self.all_wagons = sort_wagons(@all_wagons, first_wagon)
 
@@ -145,7 +139,7 @@ class Release::Main
       in_dir("hitobito_#{wagon}") do
         break if existing_version_again?
 
-        update_translations unless untranslated_wagons.include?(wagon)
+        update_translations
         update_changelog
         update_version file: "lib/hitobito_#{wagon}/version.rb"
         release_version @version


### PR DESCRIPTION
Since some wagons have translations via transifex and others don't, the release-script should not
care. Therefore, this adds a check to only update the translations of wagons which have transifex
configured.

Fixes hitobito/hitobito_jemk#7
