### PR TITLE
Do not implement logic on class level for permissions

### DIFF
--- a/app/abilities/various_ability.rb
+++ b/app/abilities/various_ability.rb
@@ -28,21 +28,19 @@ class VariousAbility < AbilityDsl::Base
     permission(:any).may(:create, :update, :destroy, :show).own_unless_only_basic_permissions_roles
   end
 
-  if Group.course_types.present?
-    on(Event::Kind) do
-      class_side(:index).if_admin
-      permission(:admin).may(:manage).all
-    end
+  on(Event::Kind) do
+    class_side(:index).if_admin_and_course_types_present
+    permission(:admin).may(:manage).if_course_types_present
+  end
 
-    on(QualificationKind) do
-      class_side(:index).if_admin
-      permission(:admin).may(:manage).all
-    end
+  on(QualificationKind) do
+    class_side(:index).if_admin_and_course_types_present
+    permission(:admin).may(:manage).if_course_types_present
+  end
 
-    on(Event::KindCategory) do
-      class_side(:index).if_admin
-      permission(:admin).may(:manage).all
-    end
+  on(Event::KindCategory) do
+    class_side(:index).if_admin_and_course_types_present
+    permission(:admin).may(:manage).if_course_types_present
   end
 
   def own_unless_only_basic_permissions_roles
@@ -53,5 +51,13 @@ class VariousAbility < AbilityDsl::Base
 
   def everybody_unless_only_basic_permissions_roles
     !user.roles.all?(&:basic_permissions_only)
+  end
+
+  def if_admin_and_course_types_present
+    if_admin && if_course_types_present
+  end
+
+  def if_course_types_present
+    Group.course_types.present?
   end
 end


### PR DESCRIPTION
This has been a pain because when the Ability constant gets referenced before any course types have been defined (e.g in the wagon.rb of a wagon) the permissions just did not get registered. This happened because when the Ability constant was loaded, the VariousAbility constant was aswell. Thus already evaluating course types before they were loaded

Fixes: https://github.com/hitobito/hitobito_jubla/actions/runs/5239299435/jobs/9458999780
Fixes: #2113 