### PR TITLE
Let's keep running brakeman

### DIFF
--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -21,7 +21,8 @@ jobs:
 
       - name: Run security checks
         run: |
-          bin/bundle exec brakeman -q --exit-on-warn --ensure-ignore-notes --ensure-latest
+          # bin/bundle exec brakeman -q --exit-on-warn --ensure-ignore-notes --ensure-latest
+          bin/bundle exec brakeman -q --exit-on-warn --ensure-ignore-notes
 
   notify_statuscope:
     uses: ./.github/workflows/notify-statuscope.yml


### PR DESCRIPTION
The current version of brakeman (rightfully) drops support for Ruby 2.7.
We do not (yet).

So, long story short: we use the best brakeman-version there is today for our current ruby-version.
This PR should change our workflow to not complain about not using the latest version anymore.
