### PR TITLE
Remove invoice config payment slip translations

### DIFF
--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -986,10 +986,6 @@ de:
         payment_slip: Einzahlungsschein
         payment_slips:
           qr: QR Rechnung
-          ch_es: Roter Einzahlungsschein Post (CH)
-          ch_bes: Roter Einzahlungsschein Bank (CH)
-          ch_esr: Oranger Einzahlungsschein Post (CH)
-          ch_besr: Oranger Einzahlungsschein Bank (CH)
           no_ps: Keiner
         participant_number: Teilnehmernummer
         participant_number_internal: Teilnehmernummer intern

--- a/config/locales/models.en.yml
+++ b/config/locales/models.en.yml
@@ -822,10 +822,6 @@ en:
         payment_slip: Payment slip
         payment_slips:
           qr: QR invoice
-          ch_es: Red payment slip Post (CH)
-          ch_bes: Red payment slip Bank (CH)
-          ch_esr: Orange payment slip Post (CH)
-          ch_besr: Orange payment slip Bank (CH)
           no_ps: None
         participant_number: Participant Nr
         participant_number_internal: Participant Nr internal

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -967,10 +967,6 @@ fr:
         payment_slip: Bulletin de versement
         payment_slips:
           qr: Facture QR
-          ch_es: Bulletin de versement postal rouge (CH)
-          ch_bes: Bulletin de versement bancaire rouge (CH)
-          ch_esr: Bulletin de versement postal orange (CH)
-          ch_besr: Bulletin de versement bancaire orange (CH)
           no_ps: Aucun
         participant_number: Numéro du participant
         participant_number_internal: Numéro du participant interne

--- a/config/locales/models.it.yml
+++ b/config/locales/models.it.yml
@@ -959,10 +959,6 @@ it:
         payment_slip: Polizza di versamento
         payment_slips:
           qr: Fattura QR
-          ch_es: Polizza di versamento postale rossa (CH)
-          ch_bes: Polizza di versamento bancaria rossa (CH)
-          ch_esr: Polizza di versamento postale arancione (CH)
-          ch_besr: Polizza di versamento bancaria arancione (CH)
           no_ps: Nessuno
         participant_number: Numero di partecipante
         participant_number_internal: Numero interno del partecipante


### PR DESCRIPTION
This also removes them as dropdown options from the form which should have already been done in #2011

Closes: #1982 