### PR TITLE
Trying to fix the api for service tokens

### DIFF
--- a/app/abilities/token_ability.rb
+++ b/app/abilities/token_ability.rb
@@ -96,6 +96,9 @@ class TokenAbility
     can :show, Group do |g|
       token_layer_and_below.include?(g)
     end
+    can :show_details, Group do |g|
+      token_layer_and_below.include?(g)
+    end
   end
 
   def define_invoice_abilities

--- a/app/abilities/token_ability.rb
+++ b/app/abilities/token_ability.rb
@@ -96,6 +96,7 @@ class TokenAbility
     can :show, Group do |g|
       token_layer_and_below.include?(g)
     end
+
     can :show_details, Group do |g|
       token_layer_and_below.include?(g)
     end

--- a/app/serializers/group_serializer.rb
+++ b/app/serializers/group_serializer.rb
@@ -47,7 +47,7 @@ class GroupSerializer < ApplicationSerializer
   include ContactableSerializer
 
   schema do # rubocop:disable Metrics/BlockLength
-    details = h.can?(:show_details, item)
+    details = h.can?(:show_details, Draper.undecorate(item))
 
     json_api_properties
 

--- a/spec/abilities/token_ability_spec.rb
+++ b/spec/abilities/token_ability_spec.rb
@@ -278,12 +278,24 @@ describe TokenAbility do
         is_expected.to be_able_to(:show, token.layer)
       end
 
+      it 'may show details of layer' do
+        is_expected.to be_able_to(:show_details, token.layer)
+      end
+
       it 'may show subgroup' do
         is_expected.to be_able_to(:show, groups(:top_group))
       end
 
+      it 'may show details of subgroup' do
+        is_expected.to be_able_to(:show_details, groups(:top_group))
+      end
+
       it 'may show subgroup from other layer' do
         is_expected.to be_able_to(:show, groups(:bottom_layer_one))
+      end
+
+      it 'may show details of subgroup from other layer' do
+        is_expected.to be_able_to(:show_details, groups(:bottom_layer_one))
       end
     end
 

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -75,7 +75,7 @@ describe GroupsController do
           json = JSON.parse(response.body)
           group = json['groups'].first
           expect(group['links']['children'].size).to eq(4)
-          expect(group).to include(:created_at, :updated_at, :deleted_at)
+          expect(group).to include('created_at', 'updated_at', 'deleted_at')
         end
       end
 
@@ -247,6 +247,26 @@ describe GroupsController do
         expect do
           get :show, params: { id: group.id, token: 'RejectedToken' }
         end.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    context 'json' do
+      render_views
+
+      it 'shows output when token is valid' do
+        get :show, params: { id: group.id, token: 'PermittedToken' }, format: :json
+        json = JSON.parse(response.body)
+        expect(json).not_to include('error')
+        group = json['groups'].first
+        expect(group['links']['children'].size).to eq(4)
+        expect(group).to include('created_at', 'updated_at', 'deleted_at')
+      end
+
+      it 'does not show output for unpermitted token' do
+        get :show, params: { id: group.id, token: 'RejectedToken' }, format: :json
+        json = JSON.parse(response.body)
+        expect(json).not_to include('groups')
+        expect(json).to include('error' => 'Sie sind nicht berechtigt, diese Seite anzuzeigen')
       end
     end
   end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -75,6 +75,7 @@ describe GroupsController do
           json = JSON.parse(response.body)
           group = json['groups'].first
           expect(group['links']['children'].size).to eq(4)
+          expect(group).to include(:created_at, :updated_at, :deleted_at)
         end
       end
 


### PR DESCRIPTION
Fixes #2160

Some attributes in the group serializer don't actually show when accessing the page by service token. 

The problem seems to be that the token isn't allowed to show_details:
https://github.com/hitobito/hitobito/blob/51e0e4779120b8c82c56817feb33c3f858504241/app/serializers/group_serializer.rb#L50

This fix looks very good, but doesn't work 😎 May it help someone else to find out what is going on