### PR TITLE
Allow 2fa reset for layer and below full

### DIFF
--- a/app/abilities/person_ability.rb
+++ b/app/abilities/person_ability.rb
@@ -72,6 +72,7 @@ class PersonAbility < AbilityDsl::Base
       if_permissions_in_all_capable_groups_or_layer_or_above
     permission(:layer_and_below_full).may(:create).all # restrictions are on Roles
     permission(:layer_and_below_full).may(:show).deleted_people_in_same_layer_or_below
+    permission(:layer_and_below_full).may(:totp_reset).in_same_layer_or_visible_below
 
     permission(:finance).may(:index_invoices).in_same_layer_or_below
     permission(:finance).may(:create_invoice).in_same_layer_or_below

--- a/app/abilities/person_ability.rb
+++ b/app/abilities/person_ability.rb
@@ -59,6 +59,7 @@ class PersonAbility < AbilityDsl::Base
     permission(:layer_full).may(:update_email).if_permissions_in_all_capable_groups_or_layer
     permission(:layer_full).may(:create).all # restrictions are on Roles
     permission(:layer_full).may(:show).deleted_people_in_same_layer
+    permission(:layer_full).may(:totp_reset).in_same_layer
 
     permission(:layer_and_below_read).
       may(:show, :show_full, :show_details, :history).
@@ -72,7 +73,7 @@ class PersonAbility < AbilityDsl::Base
       if_permissions_in_all_capable_groups_or_layer_or_above
     permission(:layer_and_below_full).may(:create).all # restrictions are on Roles
     permission(:layer_and_below_full).may(:show).deleted_people_in_same_layer_or_below
-    permission(:layer_and_below_full).may(:totp_reset).in_same_layer_or_visible_below
+    permission(:layer_and_below_full).may(:totp_reset).in_same_layer_or_below
 
     permission(:finance).may(:index_invoices).in_same_layer_or_below
     permission(:finance).may(:create_invoice).in_same_layer_or_below

--- a/spec/abilities/person_ability_spec.rb
+++ b/spec/abilities/person_ability_spec.rb
@@ -1443,6 +1443,22 @@ describe PersonAbility do
         is_expected.to_not be_able_to(:totp_reset, people(:bottom_member))
       end
     end
+
+    context 'layer and below full' do
+      let(:role) { Fabricate(Group::TopGroup::Leader.name.to_sym, group: groups(:top_group)) }
+
+      it 'can reset other person' do
+        is_expected.to be_able_to(:totp_reset, people(:bottom_member))
+      end
+    end
+
+    context 'layer full' do
+      let(:role) { Fabricate(Group::TopGroup::LocalGuide.name.to_sym, group: groups(:top_group)) }
+
+      it 'can reset other person' do
+        is_expected.to be_able_to(:totp_reset, people(:bottom_member))
+      end
+    end
   end
 
   context :totp_disable do

--- a/spec/abilities/person_ability_spec.rb
+++ b/spec/abilities/person_ability_spec.rb
@@ -1456,6 +1456,7 @@ describe PersonAbility do
       let(:role) { Fabricate(Group::TopGroup::LocalGuide.name.to_sym, group: groups(:top_group)) }
 
       it 'can reset other person' do
+        Fabricate(Group::TopGroup::Member.name.to_sym, person: people(:bottom_member), group: groups(:top_group))
         is_expected.to be_able_to(:totp_reset, people(:bottom_member))
       end
     end


### PR DESCRIPTION
Wir erhalten viele Anfragen von Abteilungen und Kantonalverbänden, dass sich Personen mit 2FA nicht einloggen können, oder dass 2FA für diese Personen nicht zurückgesetzt werden kann. Ich schlage deshalb vor, dass nicht nur admins, sondern auch Personen mit layer_and_below_full oder layer_full für ihre Mitglieder 2FA zurücksetzen können.

Das Deaktivieren (ungleich Zurücksetzen) von 2FA soll weiterhin nur für admins zur Verfügung stehen. Somit können Admin weiterhin 2FA für einzelne Personen forcieren, ohne von lokalen Leiter*innen übersteuert zu werden. Ausserdem entsteht für die lokalen Leiter*innen weniger die Verwirrung ums Zurücksetzen und Deaktivieren, da letztere Option gar nicht zur Verfügung steht.