### PR TITLE
Quickfix openstreetmap Search

### DIFF
--- a/app/helpers/people_helper.rb
+++ b/app/helpers/people_helper.rb
@@ -130,7 +130,7 @@ module PeopleHelper
 
   def openstreetmap_url(query_params)
     URI::HTTP.build(host: 'nominatim.openstreetmap.org',
-                    path: '/search.php',
+                    path: '/search.html',
                     query: query_params).to_s
   end
 


### PR DESCRIPTION
anpassen des "path" damit Links zu nominatim.openstreetmap.org keine Fehlermeldung (E404) mehr produzieren. Quickfix ohne genaue Überprüfung der API/Dokumentation von openstreetmap.