### PR TITLE
Control public events application_attrs via class_method

### DIFF
--- a/app/controllers/public_events_controller.rb
+++ b/app/controllers/public_events_controller.rb
@@ -20,10 +20,21 @@ class PublicEventsController < ApplicationController
                 :resource, # enable login-form
                 :group, :event, # enable external login
                 :can? # enable permission checks
+
   decorates :entry
   delegate :can?, to: :ability
 
+  # Allow wagons to hide application attrs
+  class_attribute :render_application_attrs
+  helper_method :render_application_attrs?
+
+  self.render_application_attrs = true
+
   private
+
+  def render_application_attrs?
+    render_application_attrs && entry.participant_types.present?
+  end
 
   def assert_external_application_possible
     session[:person_return_to] = event_url

--- a/app/views/public_events/show.html.haml
+++ b/app/views/public_events/show.html.haml
@@ -17,7 +17,7 @@
     %aside.span5
       = render 'events/attrs_contact'
 
-      - if entry.participant_types.present?
+      - if render_application_attrs?
         = render 'events/attrs_application'
 
       = render_extensions 'show_right'

--- a/app/views/public_events/show.html.haml
+++ b/app/views/public_events/show.html.haml
@@ -30,7 +30,7 @@
   .row-fluid
     %article.span6
       %h3= t('event.register.index.login')
-      = render 'devise/sessions/form'
+      = render 'devise/sessions/form', autofocus_email: false
 
     %article.span6
       %h3= t('event.register.index.no_login')

--- a/spec/controllers/public_events_controller_spec.rb
+++ b/spec/controllers/public_events_controller_spec.rb
@@ -45,9 +45,13 @@ describe PublicEventsController do
 
         it 'hides application if configured to do so' do
           controller.render_application_attrs = false
-          event.update(external_applications: false)
           get :show, params: { group_id: group.id, id: event.id }
           expect(page).not_to have_css('h2', text: 'Anmeldung')
+        end
+
+        it 'does not autofocuses anything' do
+          get :show, params: { group_id: group.id, id: event.id }
+          expect(page).not_to have_css('input[autofocus]')
         end
       end
     end

--- a/spec/controllers/public_events_controller_spec.rb
+++ b/spec/controllers/public_events_controller_spec.rb
@@ -32,6 +32,24 @@ describe PublicEventsController do
 
         is_expected.to redirect_to(new_person_session_path)
       end
+
+      describe 'with views' do
+        render_views
+        let(:page) { Capybara::Node::Simple.new(response.body) }
+        before { event.update(external_applications: true) }
+
+        it 'renders application attrs' do
+          get :show, params: { group_id: group.id, id: event.id }
+          expect(page).to have_css('h2', text: 'Anmeldung')
+        end
+
+        it 'hides application if configured to do so' do
+          controller.render_application_attrs = false
+          event.update(external_applications: false)
+          get :show, params: { group_id: group.id, id: event.id }
+          expect(page).not_to have_css('h2', text: 'Anmeldung')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Avoid copying duplicated template code in wagon by controlling visibility of `application_attrs` on `public_events/show` page via class_attribute