### PR TITLE
removes "deleted subgroups"- tab for unnecessary roles

### DIFF
--- a/app/abilities/group_ability.rb
+++ b/app/abilities/group_ability.rb
@@ -23,12 +23,14 @@ class GroupAbility < AbilityDsl::Base
       in_same_group_or_below
 
     permission(:group_full)
-      .may(:index_full_people, :export_events, :'export_event/courses', :reactivate, :deleted_subgroups)
+      .may(:index_full_people, :export_events, :'export_event/courses', :reactivate,
+            :deleted_subgroups)
       .in_same_group
     permission(:group_full).may(:update).in_same_group_if_active
 
     permission(:group_and_below_full)
-      .may(:index_full_people, :reactivate, :export_events, :'export_event/courses', :deleted_subgroups)
+      .may(:index_full_people, :reactivate, :export_events, :'export_event/courses', 
+            :deleted_subgroups)
       .in_same_group_or_below
     permission(:group_and_below_full).may(:update).in_same_group_or_below_if_active
     permission(:group_and_below_full).may(:create).with_parent_in_same_group_hierarchy

--- a/app/abilities/group_ability.rb
+++ b/app/abilities/group_ability.rb
@@ -13,7 +13,6 @@ class GroupAbility < AbilityDsl::Base
     permission(:any).
       may(:read, :index_events, :'index_event/courses', :index_mailing_lists).
       if_any_role
-    permission(:any).may(:deleted_subgroups).if_member
 
     permission(:contact_data).may(:index_people).all
 
@@ -24,12 +23,12 @@ class GroupAbility < AbilityDsl::Base
       in_same_group_or_below
 
     permission(:group_full)
-      .may(:index_full_people, :export_events, :'export_event/courses', :reactivate)
+      .may(:index_full_people, :export_events, :'export_event/courses', :reactivate, :deleted_subgroups)
       .in_same_group
     permission(:group_full).may(:update).in_same_group_if_active
 
     permission(:group_and_below_full)
-      .may(:index_full_people, :reactivate, :export_events, :'export_event/courses')
+      .may(:index_full_people, :reactivate, :export_events, :'export_event/courses', :deleted_subgroups)
       .in_same_group_or_below
     permission(:group_and_below_full).may(:update).in_same_group_or_below_if_active
     permission(:group_and_below_full).may(:create).with_parent_in_same_group_hierarchy
@@ -45,7 +44,7 @@ class GroupAbility < AbilityDsl::Base
     permission(:layer_full).may(:index_service_tokens).service_token_in_same_layer
     permission(:layer_full)
       .may(:index_person_add_requests, :index_notes, :index_deleted_people, :show_statistics,
-           :index_calendars).in_same_layer
+           :index_calendars, :deleted_subgroups).in_same_layer
     permission(:layer_full)
       .may(:update, :reactivate,
            :manage_person_tags, :activate_person_add_requests, :deactivate_person_add_requests)
@@ -61,7 +60,7 @@ class GroupAbility < AbilityDsl::Base
     permission(:layer_and_below_full).may(:destroy).in_same_layer_or_below_except_permission_giving
     permission(:layer_and_below_full).
       may(:update, :reactivate, :index_person_add_requests, :index_notes, :show_statistics,
-          :manage_person_tags, :index_deleted_people).in_same_layer_or_below
+          :manage_person_tags, :index_deleted_people, :deleted_subgroups).in_same_layer_or_below
     permission(:layer_and_below_full).may(:modify_superior).in_below_layers_if_active
     permission(:layer_and_below_full).may(:index_service_tokens).service_token_in_same_layer
     permission(:layer_and_below_full).may(:index_calendars).in_same_layer

--- a/spec/abilities/group_ability_spec.rb
+++ b/spec/abilities/group_ability_spec.rb
@@ -54,6 +54,10 @@ describe GroupAbility do
         is_expected.to be_able_to(:show_statistics, group)
       end
 
+      it 'may show deleted subgroups' do
+        is_expected.to be_able_to(:deleted_subgroups, group)
+      end
+
       it 'may show service_tokens' do
         is_expected.to be_able_to(:index_service_tokens, group)
       end
@@ -100,6 +104,10 @@ describe GroupAbility do
         is_expected.to be_able_to(:show_statistics, group)
       end
 
+      it 'may show deleted subgroups' do
+        is_expected.to be_able_to(:deleted_subgroups, group)
+      end
+
       it 'may not index service tokens' do
         is_expected.not_to be_able_to(:index_service_tokens, group)
       end
@@ -136,6 +144,10 @@ describe GroupAbility do
         is_expected.to be_able_to(:show_statistics, group)
       end
 
+      it 'may show deleted subgroups' do
+        is_expected.to be_able_to(:deleted_subgroups, group)
+      end
+
       it 'may show service tokens' do
         is_expected.to be_able_to(:index_service_tokens, group)
       end
@@ -154,6 +166,10 @@ describe GroupAbility do
 
       it 'may not show statistics' do
         is_expected.not_to be_able_to(:show_statistics, group)
+      end
+
+      it 'may not show deleted subgroups' do
+        is_expected.not_to be_able_to(:deleted_subgroups, group)
       end
 
       it 'may not show person notes' do
@@ -214,6 +230,10 @@ describe GroupAbility do
         is_expected.to be_able_to(:show_statistics, group)
       end
 
+      it 'may show deleted subgroups' do
+        is_expected.to be_able_to(:deleted_subgroups, group)
+      end
+
       it 'may show service tokens' do
         is_expected.to be_able_to(:index_service_tokens, group)
       end
@@ -250,6 +270,10 @@ describe GroupAbility do
         is_expected.to be_able_to(:show_statistics, group)
       end
 
+      it 'may show deleted subgroups' do
+        is_expected.to be_able_to(:deleted_subgroups, group)
+      end
+
       it 'may show service tokens' do
         is_expected.to be_able_to(:index_service_tokens, group)
       end
@@ -284,6 +308,10 @@ describe GroupAbility do
 
       it 'may not show statistics' do
         is_expected.not_to be_able_to(:show_statistics, group)
+      end
+
+      it 'may not show deleted subgroups' do
+        is_expected.not_to be_able_to(:deleted_subgroups, group)
       end
 
       it 'may not show service tokens' do
@@ -349,6 +377,10 @@ describe GroupAbility do
         is_expected.not_to be_able_to(:show_statistics, group)
       end
 
+      it 'may show deleted subgroups' do
+        is_expected.to be_able_to(:deleted_subgroups, group)
+      end
+
       it 'mayi not show service tokens' do
         is_expected.not_to be_able_to(:index_service_tokens, group)
       end
@@ -366,6 +398,10 @@ describe GroupAbility do
       it 'may not create subgroup' do
         is_expected.not_to be_able_to(:create, Group.new)
       end
+
+      it 'may not show deleted subgroups' do
+        is_expected.not_to be_able_to(:deleted_subgroups, group)
+      end
     end
 
     context 'in other group from same layer' do
@@ -373,12 +409,20 @@ describe GroupAbility do
       it 'may create subgroup' do
         is_expected.to be_able_to(:create, group.children.new)
       end
+
+      it 'may not show deleted subgroups' do
+        is_expected.not_to be_able_to(:deleted_subgroups, group)
+      end
     end
 
     context 'in group from lower layer' do
       let(:group) { groups(:bottom_layer_one) }
       it 'may not create subgroup' do
         is_expected.not_to be_able_to(:create, group.children.new)
+      end
+
+      it 'may not show deleted subgroups' do
+        is_expected.not_to be_able_to(:deleted_subgroups, group)
       end
     end
   end
@@ -412,6 +456,10 @@ describe GroupAbility do
         is_expected.not_to be_able_to(:show_statistics, group)
       end
 
+      it 'may show deleted subgroups' do
+        is_expected.to be_able_to(:deleted_subgroups, group)
+      end
+
       it 'may not show service tokens' do
         is_expected.not_to be_able_to(:index_service_tokens, group)
       end
@@ -429,6 +477,10 @@ describe GroupAbility do
       it 'may not create subgroup' do
         is_expected.not_to be_able_to(:create, Group.new)
       end
+
+      it 'may not show deleted subgroups' do
+        is_expected.not_to be_able_to(:deleted_subgroups, group)
+      end
     end
 
     context 'in other group from same layer' do
@@ -436,12 +488,20 @@ describe GroupAbility do
       it 'may not create subgroup' do
         is_expected.not_to be_able_to(:create, group.children.new)
       end
+
+      it 'may not show deleted subgroups' do
+        is_expected.not_to be_able_to(:deleted_subgroups, group)
+      end
     end
 
     context 'in group from lower layer' do
       let(:group) { groups(:bottom_layer_one) }
       it 'may not create subgroup' do
         is_expected.not_to be_able_to(:create, group.children.new)
+      end
+
+      it 'may not show deleted subgroups' do
+        is_expected.not_to be_able_to(:deleted_subgroups, group)
       end
     end
   end

--- a/spec/abilities/group_ability_spec.rb
+++ b/spec/abilities/group_ability_spec.rb
@@ -624,6 +624,10 @@ describe GroupAbility do
       is_expected.not_to be_able_to(:read, groups(:bottom_layer_one))
     end
 
+    it 'may not show deleted subgroups' do
+      is_expected.not_to be_able_to(:deleted_subgroups, group)
+    end
+
     it 'may not show_details any group' do
       is_expected.not_to be_able_to(:show_details, groups(:bottom_layer_one))
     end

--- a/spec/abilities/group_ability_spec.rb
+++ b/spec/abilities/group_ability_spec.rb
@@ -625,7 +625,7 @@ describe GroupAbility do
     end
 
     it 'may not show deleted subgroups' do
-      is_expected.not_to be_able_to(:deleted_subgroups, group)
+      is_expected.not_to be_able_to(:deleted_subgroups, groups{:bottom_layer_one})
     end
 
     it 'may not show_details any group' do


### PR DESCRIPTION
The tab for deleted subgroups was visible for everyone. Now only the following permissions can access it: 
- layer and below full
- layer full
- group and below full
- group full