### PR TITLE
Task/sac 97 future roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hitobito Changelog
 
+## Unreleased
+
+*  Rollen mit Start Datum in der Zukunft können erfasst werden (hitobito#2237)
+
 ## Version 1.30
 
 *  Der Buchungsbeleg berücksichtigt neu keine Rechnungen mit dem Status "Storniert" (hitobito_sww#136)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*  Rollen mit Start Datum in der Zukunft können erfasst werden (hitobito#2237)
+*  Rollen mit Start-Datum in der Zukunft können erfasst werden (hitobito#2237)
 
 ## Version 1.30
 

--- a/app/controllers/person/history_controller.rb
+++ b/app/controllers/person/history_controller.rb
@@ -14,6 +14,7 @@ class Person::HistoryController < ApplicationController
   def index
     @roles = fetch_roles(:with_deleted, :without_future)
     @future_roles = fetch_roles(:future)
+    @inactive_roles = fetch_roles(:inactive)
     @participations_by_event_type = participations_by_event_type
   end
 

--- a/app/controllers/person/history_controller.rb
+++ b/app/controllers/person/history_controller.rb
@@ -12,17 +12,18 @@ class Person::HistoryController < ApplicationController
   decorates :group, :person
 
   def index
-    @roles = fetch_roles
+    @roles = fetch_roles(:with_deleted, :without_future)
+    @future_roles = fetch_roles(:future)
     @participations_by_event_type = participations_by_event_type
   end
 
   private
 
-  def fetch_roles
-    Person::PreloadGroups.for([entry]).first.roles.
-      with_deleted.
-      includes(group: :parent).
-      sort_by { |r| GroupDecorator.new(r.group).name_with_layer }
+  def fetch_roles(*scopes)
+    scope = Person::PreloadGroups.for([entry]).first.roles.includes(group: :parent)
+    scopes
+      .inject(scope) { |current, additional| current.send(additional) }
+      .sort_by { |r| GroupDecorator.new(r.group).name_with_layer }
   end
 
   def fetch_participations

--- a/app/controllers/person/history_controller.rb
+++ b/app/controllers/person/history_controller.rb
@@ -12,7 +12,7 @@ class Person::HistoryController < ApplicationController
   decorates :group, :person
 
   def index
-    @roles = fetch_roles(:with_deleted, :without_future)
+    @roles = fetch_roles(:without_deleted, :without_future)
     @future_roles = fetch_roles(:future)
     @inactive_roles = fetch_roles(:inactive)
     @participations_by_event_type = participations_by_event_type

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -173,9 +173,9 @@ class RolesController < CrudController # rubocop:disable Metrics/ClassLength
     @type = @group.class.find_role_type!(type)
 
     if start_at&.future?
-      FutureRole.new(convert_to: @type, convert_on: start_at)
+      FutureRole.new(convert_to: @type, convert_on: start_at, created_at: Time.zone.now)
     else
-      @type.new
+      @type.new(created_at: start_at)
     end
   end
 

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -168,17 +168,14 @@ class RolesController < CrudController # rubocop:disable Metrics/ClassLength
   def build_role
     type = extract_model_attr(:type)
     start_at = extract_start_at
-    if type.present?
-      @type = @group.class.find_role_type!(type)
-      if start_at&.future?
-        convert_to = @type
-        @type = FutureRole
-        @type.new(convert_to: convert_to, convert_on: start_at)
-      else
-        @type.new
-      end
+    return Role.new(convert_on: start_at) if type.blank?
+
+    @type = @group.class.find_role_type!(type)
+
+    if start_at&.future?
+      FutureRole.new(convert_to: @type, convert_on: start_at)
     else
-      Role.new
+      @type.new
     end
   end
 

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -5,7 +5,7 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
-class RolesController < CrudController
+class RolesController < CrudController # rubocop:disable Metrics/ClassLength
   include PrivacyPolicyAcceptable
 
   respond_to :js
@@ -167,9 +167,15 @@ class RolesController < CrudController
 
   def build_role
     type = extract_model_attr(:type)
+    start_at = extract_start_at
     if type.present?
-      @type = @group.class.find_role_type!(type)
-      @type.new
+      if start_at&.future?
+        @type = FutureRole
+        @type.new(convert_to: type, convert_on: start_at)
+      else
+        @type = @group.class.find_role_type!(type)
+        @type.new
+      end
     else
       Role.new
     end
@@ -190,7 +196,7 @@ class RolesController < CrudController
   def permitted_params(role_type = entry.class)
     @permitted_params ||=
       begin
-        permitted_attrs = role_type.used_attributes
+        permitted_attrs = role_type.used_attributes + [:convert_on]
         permitted_attrs -= [:deleted_at, :delete_on] unless can?(:destroy, @role)
         model_params.permit(permitted_attrs)
       end
@@ -281,4 +287,13 @@ class RolesController < CrudController
     entry.group
   end
 
+  def extract_start_at
+    Date.parse(delete_model_param(:created_at) || delete_model_param(:convert_on))
+  rescue TypeError, Date::Error
+    nil
+  end
+
+  def delete_model_param(key)
+    model_params&.delete(key).presence
+  end
 end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -169,11 +169,12 @@ class RolesController < CrudController # rubocop:disable Metrics/ClassLength
     type = extract_model_attr(:type)
     start_at = extract_start_at
     if type.present?
+      @type = @group.class.find_role_type!(type)
       if start_at&.future?
+        convert_to = @type
         @type = FutureRole
-        @type.new(convert_to: type, convert_on: start_at)
+        @type.new(convert_to: convert_to, convert_on: start_at)
       else
-        @type = @group.class.find_role_type!(type)
         @type.new
       end
     else

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -85,6 +85,14 @@ class PersonDecorator < ApplicationDecorator
     super.without_archived
   end
 
+  def current_roles_grouped
+    @current_roles_grouped ||= roles_grouped(scope: person.roles.without_future)
+  end
+
+  def future_roles_grouped
+    @future_roles_grouped ||= roles_grouped(scope: person.roles.future)
+  end
+
   def roles_list(group = nil, multiple_groups = false)
     roles_short(group, multiple_groups, edit: false)
   end
@@ -100,13 +108,6 @@ class PersonDecorator < ApplicationDecorator
       filtered_functions(roles.to_a, :group).select { |r| group.subgroup_ids.include? r.group_id }
     else
       filtered_functions(roles.to_a, :group, group)
-    end
-  end
-
-  # returns roles grouped by their group
-  def roles_grouped
-    roles.each_with_object(Hash.new { |h, k| h[k] = [] }) do |role, memo|
-      memo[role.group] << role
     end
   end
 
@@ -143,6 +144,13 @@ class PersonDecorator < ApplicationDecorator
     last_role.group.deleted_at? ? default_group : last_role.group
   end
 
+  # returns roles grouped by their group
+  def roles_grouped(scope: roles)
+    scope.each_with_object(Hash.new { |h, k| h[k] = [] }) do |role, memo|
+      memo[role.group] << role
+    end
+  end
+
   private
 
   def event_queries
@@ -153,7 +161,7 @@ class PersonDecorator < ApplicationDecorator
     html = content_tag(:strong, company_name)
     if full_name.present?
       html << br
-      html << full_name
+     html << full_name
     end
     html
   end

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -161,7 +161,7 @@ class PersonDecorator < ApplicationDecorator
     html = content_tag(:strong, company_name)
     if full_name.present?
       html << br
-     html << full_name
+      html << full_name
     end
     html
   end

--- a/app/domain/person/filter/list.rb
+++ b/app/domain/person/filter/list.rb
@@ -48,7 +48,7 @@ class Person::Filter::List
     if chain.present?
       chain.filter(list_range)
     else
-      list_range.where(roles: { archived_at: nil } )
+      list_range.where(roles: { archived_at: nil })
                 .or(list_range.where(Role.arel_table[:archived_at].gt(Time.now.utc)))
                 .members
     end

--- a/app/domain/person/filter/list.rb
+++ b/app/domain/person/filter/list.rb
@@ -48,7 +48,7 @@ class Person::Filter::List
     if chain.present?
       chain.filter(list_range)
     else
-      list_range.where(roles: { archived_at: nil })
+      list_range.where(roles: { archived_at: nil } )
                 .or(list_range.where(Role.arel_table[:archived_at].gt(Time.now.utc)))
                 .members
     end

--- a/app/helpers/roles_helper.rb
+++ b/app/helpers/roles_helper.rb
@@ -72,6 +72,8 @@ module RolesHelper
   end
 
   def existing_role(role)
+    return role.convert_to if role.is_a?(FutureRole)
+
     role ? role.type : nil
   end
 

--- a/app/jobs/people/create_roles_job.rb
+++ b/app/jobs/people/create_roles_job.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+#
+class People::CreateRolesJob < RecurringJob
+
+  run_every 15.minutes
+  Error = Class.new(StandardError)
+
+  def perform
+    future_roles.find_each { |role| convert(role) }
+  end
+
+  private
+
+  def future_roles
+    FutureRole.where('convert_on <= ?', Time.zone.today).order(:convert_on)
+  end
+
+  def convert(role)
+    role.convert!
+  rescue => e
+    message = "#{e.message} - FutureRole(#{role.id})"
+    role.update!(label: message)
+    notify(message)
+  end
+
+  def notify(message)
+    Raven.capture_exception(Error.new(message))
+  end
+end

--- a/app/jobs/people/create_roles_job.rb
+++ b/app/jobs/people/create_roles_job.rb
@@ -4,7 +4,7 @@
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
-#
+
 class People::CreateRolesJob < RecurringJob
 
   run_every 15.minutes

--- a/app/jobs/people/create_roles_job.rb
+++ b/app/jobs/people/create_roles_job.rb
@@ -8,6 +8,7 @@
 class People::CreateRolesJob < RecurringJob
 
   run_every 15.minutes
+
   Error = Class.new(StandardError)
 
   def perform
@@ -17,7 +18,7 @@ class People::CreateRolesJob < RecurringJob
   private
 
   def future_roles
-    FutureRole.where('convert_on <= ?', Time.zone.today).order(:convert_on)
+    FutureRole.where('convert_on <= :today', today: Time.zone.today).order(:convert_on)
   end
 
   def convert(role)

--- a/app/models/future_role.rb
+++ b/app/models/future_role.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+#
+# Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+# hitobito_sac_cas and licensed under the Affero General Public License version 3
+# or later. See the COPYING file at the top-level directory or at
+# https://github.com/hitobito/hitobito
+
+class FutureRole < Role
+  self.kind = :future
+  self.basic_permissions_only = true
+
+  IGNORED_ATTRS = %w(id type convert_on convert_to created_at).freeze
+
+  skip_callback :create, :after, :set_first_primary_group
+  skip_callback :create, :after, :set_contact_data_visible
+  skip_callback :destroy, :after, :reset_contact_data_visible
+  skip_callback :destroy, :after, :reset_primary_group
+
+  validates :person, :group, presence: true
+  validates :convert_to, inclusion: { within: :group_role_types }, if: :group
+  validates_date :convert_on, on_or_after: -> { Time.zone.today }
+
+  def to_s(_long = nil)
+    "#{convert_to_model_name} (#{formatted_start_date})"
+  end
+
+  def convert!
+    Role.transaction do
+      group.roles.create!(relevant_attrs)
+      really_destroy!
+    end
+  end
+
+  private
+
+  def group_role_types
+    group.role_types.map(&:sti_name)
+  end
+
+  def relevant_attrs
+    attributes.except(*IGNORED_ATTRS).merge(created_at: Time.zone.now, type: convert_to)
+  end
+
+  def formatted_start_date
+    I18n.t('global.start_on', date: I18n.l(convert_on))
+  end
+
+  def convert_to_model_name
+    convert_to.constantize.model_name.human
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -275,6 +275,7 @@ class Group < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
     ActiveRecord::Base.transaction do
       self.archived_at = Time.zone.now
       Role.where(group_id: id).tap do |roles|
+        roles.where(type: FutureRole.sti_name).delete_all
         roles.update_all(archived_at: archived_at)
         roles.where('delete_on >= ?', archived_at).update_all(delete_on: nil)
       end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -195,6 +195,10 @@ class Role < ActiveRecord::Base
     convert_on || created_at&.to_date || Time.zone.today
   end
 
+  def end_on
+    delete_on || deleted_at&.to_date
+  end
+
   private
 
   def nextcloud_group_details

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -132,6 +132,7 @@ class Role < ActiveRecord::Base
   scope :without_archived, -> { where(archived_at: nil) }
   scope :only_archived, -> { where.not(archived_at: nil).where(archived_at: ..Time.now.utc) }
   scope :future, -> { where(type: FutureRole.sti_name) }
+  scope :inactive, -> { with_deleted.where('deleted_at IS NOT NULL OR archived_at <= ?', Time.now.utc) }
 
   ### CLASS METHODS
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -132,7 +132,8 @@ class Role < ActiveRecord::Base
   scope :without_archived, -> { where(archived_at: nil) }
   scope :only_archived, -> { where.not(archived_at: nil).where(archived_at: ..Time.now.utc) }
   scope :future, -> { where(type: FutureRole.sti_name) }
-  scope :inactive, -> { with_deleted.where('deleted_at IS NOT NULL OR archived_at <= ?', Time.now.utc) }
+  scope :inactive, -> { with_deleted.where('deleted_at IS NOT NULL OR archived_at <= ?',
+                                           Time.now.utc) }
 
   ### CLASS METHODS
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -11,6 +11,8 @@
 #
 #  id          :integer          not null, primary key
 #  archived_at :datetime
+#  convert_on  :date
+#  convert_to  :string(255)
 #  delete_on   :date
 #  deleted_at  :datetime
 #  label       :string(255)

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -124,12 +124,14 @@ class Role < ActiveRecord::Base
   after_destroy :reset_contact_data_visible
   after_destroy :reset_primary_group
 
-  before_save :prevent_changes, if: ->(r) { r.archived? }
+  before_save :prevent_changes, if: :archived?
 
   ### SCOPES
 
+  scope :without_future, -> { where.not(type: FutureRole.sti_name) }
   scope :without_archived, -> { where(archived_at: nil) }
   scope :only_archived, -> { where.not(archived_at: nil).where(archived_at: ..Time.now.utc) }
+  scope :future, -> { where(type: FutureRole.sti_name) }
 
   ### CLASS METHODS
 
@@ -187,6 +189,10 @@ class Role < ActiveRecord::Base
     end
   end
 
+  def start_on
+    convert_on || created_at&.to_date || Time.zone.today
+  end
+
   private
 
   def nextcloud_group_details
@@ -233,6 +239,8 @@ class Role < ActiveRecord::Base
   end
 
   def assert_type_is_allowed_for_group
+    return if type == FutureRole.sti_name
+
     if type && group && !group.role_types.collect(&:sti_name).include?(type)
       errors.add(:type, :type_not_allowed)
     end

--- a/app/models/role/types.rb
+++ b/app/models/role/types.rb
@@ -23,7 +23,7 @@ module Role::Types
                              group_and_below_full: :group_and_below_read,
                              group_full: :group_read }
 
-  Kinds = [:member, :passive, :external]
+  Kinds = [:member, :passive, :external, :future]
 
   # All possible permissions with writing permission
   WRITING_PERMISSIONS = [

--- a/app/views/people/_roles.html.haml
+++ b/app/views/people/_roles.html.haml
@@ -3,4 +3,6 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-= render 'roles_aside', title: t('.title'), grouped_roles: entry.roles_grouped
+= render 'roles_aside', title: t('.title'), grouped_roles: entry.current_roles_grouped
+- if entry.roles.future.any?
+  = render 'roles_aside', title: t('.convertable_title'), grouped_roles: entry.future_roles_grouped

--- a/app/views/person/history/_roles_table.html.haml
+++ b/app/views/person/history/_roles_table.html.haml
@@ -1,7 +1,7 @@
 - if roles.present?
   %h2=title
 
-  = table(roles, class: 'table table-striped') do |t|
+  = table(roles, class: 'table table-striped table-fixed') do |t|
     - t.col(Group.model_name.human) do |r|
       = GroupDecorator.new(r.group).link_with_layer
     - t.col(Role.model_name.human) do |r|

--- a/app/views/person/history/_roles_table.html.haml
+++ b/app/views/person/history/_roles_table.html.haml
@@ -1,3 +1,8 @@
+-# Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+-# hitobito_sac_cas and licensed under the Affero General Public License version 3
+-# or later. See the COPYING file at the top-level directory or at
+-# https://github.com/hitobito/hitobito
+
 - if roles.present?
   %h2=title
 

--- a/app/views/person/history/_roles_table.html.haml
+++ b/app/views/person/history/_roles_table.html.haml
@@ -12,5 +12,5 @@
     - t.col(Role.model_name.human) do |r|
       = r.to_s
     - t.attr(:created_at, t('global.from')) { |r| I18n.l(r.start_on) }
-    - t.attr(:deleted_at, t('global.until'))
+    - t.attr(:deleted_at, t('global.until')) { |r| r.end_on.present? ? I18n.l(r.end_on) : '' }
     - render_extensions :history_columns, locals: { t: t }

--- a/app/views/person/history/_roles_table.html.haml
+++ b/app/views/person/history/_roles_table.html.haml
@@ -1,0 +1,11 @@
+- if roles.present?
+  %h2=title
+
+  = table(roles, class: 'table table-striped') do |t|
+    - t.col(Group.model_name.human) do |r|
+      = GroupDecorator.new(r.group).link_with_layer
+    - t.col(Role.model_name.human) do |r|
+      = r.to_s
+    - t.attr(:created_at, t('global.from')) { |r| I18n.l(r.start_on) }
+    - t.attr(:deleted_at, t('global.until'))
+    - render_extensions :history_columns, locals: { t: t }

--- a/app/views/person/history/index.html.haml
+++ b/app/views/person/history/index.html.haml
@@ -3,16 +3,8 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-%h2= Role.model_name.human(count: 2)
-
-= table(@roles, class: 'table table-striped') do |t|
-  - t.col(Group.model_name.human) do |r|
-    = GroupDecorator.new(r.group).link_with_layer
-  - t.col(Role.model_name.human) do |r|
-    = r.to_s
-  - t.attr(:created_at, t('global.from'))
-  - t.attr(:deleted_at, t('global.until'))
-  - render_extensions :history_columns, locals: { t: t }
+= render "roles_table", title: Role.model_name.human(count: 2), roles: @roles
+= render("roles_table", title: FutureRole.model_name.human(count: 2), roles: @future_roles)
 
 = render_extensions :history_members_form
 

--- a/app/views/person/history/index.html.haml
+++ b/app/views/person/history/index.html.haml
@@ -5,6 +5,7 @@
 
 = render "roles_table", title: Role.model_name.human(count: 2), roles: @roles
 = render("roles_table", title: FutureRole.model_name.human(count: 2), roles: @future_roles)
+= render("roles_table", title: t('.inactive_roles_title'), roles: @inactive_roles)
 
 = render_extensions :history_members_form
 

--- a/app/views/roles/_fields.html.haml
+++ b/app/views/roles/_fields.html.haml
@@ -21,7 +21,7 @@
 
 = field_set_tag Role.human_attribute_name(:dates) do
   = f.labeled(:created_at) do
-    = f.date_field(:created_at, class: 'date span6', value: f(@role.created_at.try(:to_date) || Time.zone.today))
+    = f.date_field(:created_at, class: 'date span6', value: f(@role.start_on))
   = f.labeled(:delete_on) do
     = f.date_field(:delete_on, disabled: !can?(:destroy, @role), class: 'date span6', value: f(@role.delete_on))
 

--- a/app/views/roles/_modal.html.haml
+++ b/app/views/roles/_modal.html.haml
@@ -21,7 +21,7 @@
                           GroupDecorator.decorate(@group).possible_roles,
                           :sti_name,
                           :label,
-                          { },
+                          roles_type_select_options(@group, entry),
                           { class: 'chosen-select',
                             data: { remote: true,
                                     url: details_group_roles_path(@group),
@@ -37,4 +37,6 @@
   - if @person_id
     = f.hidden_field :person_id, value: @person_id
 
+  = f.hidden_field :convert_on, value: entry.convert_on
+  = f.hidden_field :delete_on, value: entry.delete_on
   = form_buttons(f, submit_label: ti(:"button.save"), cancel_url: '#')

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -230,6 +230,9 @@ de:
       event/date:
         one: Datum
         other: Daten
+      future_role:
+        one: Zukünftige Rolle
+        other: Zukünftige Rollen
       family_member:
         one: Familienmitglied
         other: Familienmitglieder
@@ -667,6 +670,7 @@ de:
         participation: Person
         remove_participant_role: Allfällige Teilnehmer*Innen-Rolle entfernen
 
+
       family_member:
         kind: Verwandschaftsverhältnis
         kinds:
@@ -775,6 +779,9 @@ de:
             external:
               one: Extern
               other: Externe
+            future:
+              one: Zukünftig
+              other: Zukünftige
 
       contact_account:
         predefined_labels:

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -23,6 +23,7 @@ de:
     chosen_no_results: Keine Einträge gefunden mit
     selected: Ausgewählt
     columns: Spalten
+    start_on: ab %{date}
 
     gender:
       male: männlich
@@ -1570,6 +1571,7 @@ de:
 
     roles:
       title: Aktive Rollen
+      convertable_title: Zukünftige Rollen
 
     roles_aside:
       add_role: Rolle hinzufügen

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -1352,6 +1352,9 @@ de:
           approved: "Die Zugriffsanfrage für %{person} wurde bereits freigegeben."
           rejected: "Die Zugriffsanfrage für %{person} wurde bereits abgelehnt."
 
+    history:
+      index:
+        inactive_roles_title: 'Inaktive Rollen'
     households:
       form:
         address_updated: "Adresse aktualisiert"

--- a/db/migrate/20231016131405_add_convert_on_to_roles.rb
+++ b/db/migrate/20231016131405_add_convert_on_to_roles.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class AddConvertOnToRoles < ActiveRecord::Migration[6.1]
+  def change
+    change_table(:roles) do |t|
+      t.date :convert_on
+      t.string :convert_to
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_16_092502) do
+ActiveRecord::Schema.define(version: 2023_10_16_131405) do
+
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -974,6 +975,8 @@ ActiveRecord::Schema.define(version: 2023_10_16_092502) do
     t.datetime "deleted_at"
     t.datetime "archived_at"
     t.date "delete_on"
+    t.date "convert_on"
+    t.string "convert_to"
     t.index ["person_id", "group_id"], name: "index_roles_on_person_id_and_group_id"
     t.index ["type"], name: "index_roles_on_type"
   end

--- a/lib/tasks/delayed_jobs.rake
+++ b/lib/tasks/delayed_jobs.rake
@@ -27,7 +27,7 @@ namespace :delayed_job do
     end
 
     if missing.any?
-      puts "Missing: #{missing.to_sentence}"
+      puts 'Missing: ' + missing.to_sentence
       exit false
     else
       puts 'All expected jobs are scheduled.'
@@ -75,6 +75,7 @@ module HitobitoDelayedJobs
       DownloadCleanerJob,
       Payments::EbicsImportJob,
       People::DuplicateLocatorJob,
+      People::CreateRolesJob,
       People::DestroyRolesJob,
       ReoccuringMailchimpSynchronizationJob,
       SessionsCleanerJob,

--- a/spec/controllers/person/history_controller_spec.rb
+++ b/spec/controllers/person/history_controller_spec.rb
@@ -23,10 +23,14 @@ describe Person::HistoryController do
         r2 = Fabricate(Group::BottomGroup::Member.name.to_sym, group: groups(:bottom_group_two_one), person: person, created_at: Date.today - 3.years, deleted_at: Date.today - 2.years)
         r3 = Fabricate(Group::BottomGroup::Leader.name.to_sym, group: groups(:bottom_group_two_one), person: person)
         r4 = Fabricate(Group::BottomGroup::Member.name.to_sym, group: groups(:bottom_group_one_one_one), person: person)
+        r5 = FutureRole.create!(group: groups(:bottom_group_two_one), convert_to: Group::BottomGroup::Member.name, person: person, created_at: Time.zone.now, convert_on: 10.days.from_now, delete_on: 20.days.from_now)
+        r6 = FutureRole.create!(group: groups(:bottom_group_two_one), convert_to: Group::BottomGroup::Member.name, person: person, convert_on: 10.days.from_now)
 
         get :index, params: { group_id: groups(:bottom_group_one_one).id, id: person.id }
 
-        expect(assigns(:roles)).to eq([r1, r4, r2, r3])
+        expect(assigns(:roles)).to eq([r1, r4, r3])
+        expect(assigns(:inactive_roles)).to eq([r2])
+        expect(assigns(:future_roles)).to eq([r5, r6])
       end
     end
 

--- a/spec/domain/person/filter/list_spec.rb
+++ b/spec/domain/person/filter/list_spec.rb
@@ -8,44 +8,75 @@
 require 'spec_helper'
 
 describe Person::Filter::List do
+  let(:top_leader) { people(:top_leader) }
+  let(:top_group) { groups(:top_group) }
+  let(:bottom_group) { groups(:bottom_group_one_one) }
 
-  it 'empty filter works for normal user' do
-    list = filter_list
-    expect(list.all_count).to eq 1
-    expect(list.entries.to_a).to have(1).items
+
+  context 'top group' do
+    it 'empty filter lists top_leader' do
+      list = filter_list
+      expect(list.all_count).to eq 1
+      expect(list.entries.to_a).to have(1).items
+      expect(list.entries.collect(&:id)).to eq [top_leader.id]
+    end
   end
 
-  it 'empty filter works for normal user' do
-    list = filter_list
-    expect(list.all_count).to eq 1
-    expect(list.entries.to_a).to have(1).items
+  context 'bottom group' do
+    it 'empty filter returns empty list' do
+      list = filter_list(group: bottom_group)
+      expect(list.all_count).to eq 0
+      expect(list.entries.to_a).to be_empty
+    end
+
+    context 'with future role' do
+      before do
+        Fabricate(:future_role, person: top_leader, group: bottom_group, convert_to: bottom_group.role_types.first)
+      end
+
+      it 'does not include future role' do
+        list = filter_list(group: bottom_group)
+        expect(list.all_count).to eq 0
+        expect(list.entries.to_a).to be_empty
+      end
+
+      it 'includes future role when explicitly specified via role_type_ids' do
+        params = { filters: { role: { role_type_ids: FutureRole.id } } }
+        list = filter_list(group: bottom_group, filter: params)
+        expect(list.chain).to be_present
+        expect(list.all_count).to eq 1
+        expect(list.entries.to_a).to be_empty
+      end
+    end
   end
 
-  it 'empty filter with range deep does not list people from archived groups' do
-    groups(:top_group).archive!
-    expect(groups(:top_group).archived_at).to_not be_nil
-    list = filter_list(person: people(:root))
-    expect(list.all_count).to eq 0
-    expect(list.entries.to_a).to have(0).items
+  context 'archived groups' do
+    let(:root) { people(:root) }
+    before do
+      top_group.archive!
+      expect(top_group.archived_at).to_not be_nil
+    end
+
+    it 'empty filter with range deep does not list people from archived groups' do
+      list = filter_list(person: root)
+      expect(list.all_count).to eq 0
+      expect(list.entries.to_a).to have(0).items
+    end
+
+    it 'empty filter with range layer does not list people from archived groups' do
+      list = filter_list(person: root)
+      expect(list.all_count).to eq 0
+      expect(list.entries.to_a).to have(0).items
+    end
+
+    it 'empty filter with empty range does not list people from archived groups' do
+      list = filter_list(person: root)
+      expect(list.all_count).to eq 0
+      expect(list.entries.to_a).to have(0).items
+    end
   end
 
-  it 'empty filter with range layer does not list people from archived groups' do
-    groups(:top_group).archive!
-    expect(groups(:top_group).archived_at).to_not be_nil
-    list = filter_list(person: people(:root), filter: PeopleFilter.new(name: 'name', range: 'layer'))
-    expect(list.all_count).to eq 0
-    expect(list.entries.to_a).to have(0).items
-  end
-
-  it 'empty filter with empty range does not list people from archived groups' do
-    groups(:top_group).archive!
-    expect(groups(:top_group).archived_at).to_not be_nil
-    list = filter_list(person: people(:root))
-    expect(list.all_count).to eq 0
-    expect(list.entries.to_a).to have(0).items
-  end
-
-  def filter_list(person: people(:top_leader), group: groups(:top_group), filter: PeopleFilter.new(name: 'name'))
+  def filter_list(person: top_leader, group: top_group, filter: PeopleFilter.new(name: 'name'))
     described_class.new(group, person, filter)
   end
 end

--- a/spec/fabricators/role_fabricator.rb
+++ b/spec/fabricators/role_fabricator.rb
@@ -32,3 +32,6 @@ end
 Role.all_types.collect { |r| r.name.to_sym }.each do |t|
   Fabricator(t, from: :role, class_name: t)
 end
+Fabricator(:future_role, from: :role, class_name: FutureRole) do
+  convert_on { Time.zone.tomorrow }
+end

--- a/spec/features/roles/future_roles_spec.rb
+++ b/spec/features/roles/future_roles_spec.rb
@@ -1,3 +1,10 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
 require 'spec_helper'
 
 describe 'Future Roles behaviour' do

--- a/spec/features/roles/future_roles_spec.rb
+++ b/spec/features/roles/future_roles_spec.rb
@@ -1,0 +1,159 @@
+require 'spec_helper'
+
+describe 'Future Roles behaviour' do
+
+  let(:top_leader) { people(:top_leader) }
+  let(:bottom_member) { people(:bottom_member) }
+  let(:top_group) { groups(:top_group) }
+  let(:bottom_layer) { groups(:bottom_layer_one) }
+  let(:role_type) { Group::TopGroup::Member.sti_name }
+  let(:tomorrow) { Time.zone.tomorrow }
+
+  let(:current_roles_aside) { 'section:nth-of-type(2)' }
+  let(:future_roles_aside) { 'section:nth-of-type(3)' }
+
+  before do
+    sign_in(top_leader)
+    Capybara.default_max_wait_time = 0.5
+  end
+
+  def create_future_role(person: bottom_member, group: top_group, type: role_type, convert_on: tomorrow)
+    Fabricate(:role, type: FutureRole.sti_name, person: person, group: group, convert_on: convert_on, convert_to: type)
+  end
+
+  describe 'group bottom_members list' do
+    it 'hides pill if no future roles exist' do
+      visit group_people_path(top_group, locale: :de)
+      expect(page).not_to have_link 'Zukünftige'
+    end
+
+    it 'lists future roles in seperate pill' do
+      create_future_role
+      visit group_people_path(top_group, locale: :de)
+      expect(page).not_to have_link 'Member Bottom'
+      expect(page).to have_link 'Zukünftige (1)'
+
+      click_on 'Zukünftige (1)'
+      expect(page).to have_link 'Member Bottom'
+      expect(page).to have_content "Member (ab #{I18n.l(tomorrow)})"
+    end
+
+    describe 'filter' do
+      it 'does not list future role type in roles filter' do
+        visit new_group_people_filter_path(top_group, locale: :de)
+        click_on 'Rollen'
+
+        # Counts are without future role
+        expect(page).to have_css('#roles .same-layer .checkbox.inline', count: 8)
+        expect(page).to have_css('#roles .same-group .checkbox.inline', count: 6)
+      end
+    end
+  end
+
+  describe 'showing future roles' do
+    describe 'people show' do
+      it 'lists future roles in seperate section' do
+        create_future_role
+        visit group_person_path(bottom_layer, bottom_member, locale: :de)
+        expect(page).to have_css "#{future_roles_aside} h2", text: 'Zukünftige Rollen'
+        expect(page).to have_css future_roles_aside, text: "Top / TopGroup\nMember (ab #{I18n.l(tomorrow)})"
+      end
+
+      it 'does not show section if no future roles exist' do
+        visit group_person_path(bottom_layer, bottom_member, locale: :de)
+        expect(page).not_to have_text 'Zukünftige Rollen'
+      end
+    end
+  end
+
+  describe 'person history' do
+    it 'lists future roles in seperate section' do
+      create_future_role
+      visit history_group_person_path(bottom_layer, bottom_member, locale: :de)
+      expect(page).to have_css 'h2', text: 'Zukünftige Rollen'
+      expect(page).to have_text "Top / TopGroup Member (ab #{I18n.l(tomorrow)}) #{I18n.l(tomorrow)}"
+    end
+
+    it 'does not show section if no future roles exist' do
+      visit history_group_person_path(bottom_layer, bottom_member, locale: :de)
+      expect(page).not_to have_css 'h2', text: 'Zukünftige Rollen'
+    end
+  end
+
+
+  describe 'versions', versioning: true do
+    before { create_future_role }
+
+    it 'lists future role in person log' do
+      visit log_group_person_path(bottom_layer, bottom_member, locale: :de)
+      expect(page).to have_content "Rolle Member (ab #{I18n.l(tomorrow)}) wurde hinzugefügt"
+    end
+
+    it 'lists future role in group log' do
+      visit log_group_person_path(bottom_layer, bottom_member, locale: :de)
+      expect(page).to have_content "Rolle Member (ab #{I18n.l(tomorrow)}) wurde hinzugefügt"
+    end
+  end
+
+  describe 'managing future roles' do
+    def existing_role_attrs
+      bottom_member.roles.find_by(type: 'FutureRole').attributes.symbolize_keys
+    end
+
+    def choose_role(role, current_selection: nil)
+      find('#role_type_select a.chosen-single').click
+      expect(page).to have_css('#role_type_select a.chosen-single > span', text: current_selection)
+      find('#role_type_select ul.chosen-results').find('li', text: role).click
+    end
+
+    it 'can create new future role', :js do
+      visit group_person_path(bottom_layer, bottom_member, locale: :de)
+
+      click_on 'Rolle hinzufügen'
+      choose_role 'Member'
+      fill_in 'Von', with: tomorrow
+      expect do
+        first(:button, 'Speichern').click
+      end.to change { bottom_member.roles.count }.by(1)
+
+      role = bottom_member.roles.last
+      expect(role.type).to eq FutureRole.sti_name
+      expect(role.convert_to).to eq 'Group::BottomLayer::Member'
+      expect(role.convert_on).to eq tomorrow
+      expect(role.created_at.to_date).to eq Time.zone.today
+    end
+
+    it 'can convert type of future role on people list', :js do
+      create_future_role
+      visit group_people_path(top_group, locale: :de)
+      click_on 'Zukünftige (1)'
+      expect(page).to have_css('li.active', text: 'Zukünftige (1)')
+      click_on 'Bearbeiten'
+      choose_role 'Leader', current_selection: 'Member'
+      expect do
+        click_on 'Speichern'
+        expect(page).not_to have_css '.popover'
+      end.to change { existing_role_attrs[:convert_to] }
+        .from(role_type).to('Group::TopGroup::Leader')
+        .and not_change { existing_role_attrs[:convert_on] }
+    end
+
+    it 'can convert future role to active role via person show page', :js do
+      create_future_role
+      visit group_person_path(bottom_layer, bottom_member, locale: :de)
+      expect(page).to have_css("#{future_roles_aside} h2", text: 'Zukünftige Rollen')
+      within(future_roles_aside) { click_on 'Bearbeiten' }
+      fill_in 'Von', with: Time.zone.yesterday
+      first(:button, 'Speichern').click
+      expect(page).not_to have_text 'Zukünftige Rollen'
+    end
+
+    it 'cannot convert active role to future role' do
+      visit group_person_path(bottom_layer, bottom_member, locale: :de)
+      within(current_roles_aside) { click_on 'Bearbeiten' }
+      fill_in 'Von', with: tomorrow
+      first(:button, 'Speichern').click
+      expect(page).to have_css '.alert-error', text: 'Von kann nicht später als heute sein'
+    end
+  end
+end

--- a/spec/fixtures/roles.yml
+++ b/spec/fixtures/roles.yml
@@ -8,6 +8,8 @@
 #
 #  id          :integer          not null, primary key
 #  archived_at :datetime
+#  convert_on  :date
+#  convert_to  :string(255)
 #  delete_on   :date
 #  deleted_at  :datetime
 #  label       :string(255)

--- a/spec/helpers/filter_navigation/people_spec.rb
+++ b/spec/helpers/filter_navigation/people_spec.rb
@@ -50,6 +50,11 @@ describe 'FilterNavigation::People' do
         expect(subject.main_items.last).to match(/Externe \(0\)/)
       end
 
+      it 'contains future item with count if future roles exist' do
+        Fabricate(:future_role, person: people(:top_leader), group: group, convert_to: group.role_types.first)
+        expect(subject.main_items.last).to match(/Zukünftige \(1\)/)
+      end
+
       it 'entire layer contains only layer role types' do
         subject.dropdown.items.first.url =~ /#{[Role::External,
                                                 Group::GlobalGroup::Leader,

--- a/spec/jobs/people/create_roles_job_spec.rb
+++ b/spec/jobs/people/create_roles_job_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+#
+
+require 'spec_helper'
+
+describe People::CreateRolesJob do
+  let(:person) { people(:bottom_member) }
+  let(:top_group) { groups(:top_group) }
+  let(:role_type) { Group::TopGroup::Member.sti_name }
+  let(:tomorrow) { Time.zone.tomorrow }
+
+
+  subject(:job) { described_class.new }
+
+  def create_future_role(attrs = {})
+    defaults = { person: person, group: top_group, convert_to: role_type }
+    Fabricate(:future_role, defaults.merge(attrs))
+  end
+
+  it 'noops if not scheduled' do
+    expect { job.perform }.to not_change { person.roles.count }
+  end
+
+  it 'noops if node is scheduled for tomorrow' do
+    create_future_role(convert_on: Time.zone.tomorrow)
+    expect { job.perform }.to not_change { person.roles.where(type: role_type).count }
+      .and not_change { person.roles.where(type: FutureRole.sti_name).count }
+  end
+
+  it 'destroys and creates role if scheduled for today' do
+    create_future_role(convert_on: Time.zone.today)
+    expect { job.perform }.to change { person.roles.where(type: role_type).count }.by(1)
+      .and change { person.roles.where(type: FutureRole.sti_name).count }.by(-1)
+  end
+
+  it 'destroys and creates multiples' do
+    create_future_role(convert_on: Time.zone.today)
+    create_future_role(convert_on: Time.zone.today, person: people(:top_leader))
+    expect { job.perform }.to change { Role.where(type: role_type).count }.by(2)
+      .and change { Role.where(type: FutureRole.sti_name).count }.by(-2)
+  end
+
+  it 'logs errors and continues' do
+    role = create_future_role(convert_on: Time.zone.tomorrow)
+    create_future_role(convert_on: Time.zone.tomorrow, person: people(:top_leader))
+    allow_any_instance_of(FutureRole).to receive(:convert!).and_wrap_original do |m|
+      raise 'ouch' if m.receiver.person == person
+      m.call
+    end
+    expect(Raven).to receive(:capture_exception).with(described_class::Error.new("ouch - FutureRole(#{role.id})"))
+
+    expect do
+      travel_to(Time.zone.tomorrow) { job.perform  }
+    end.to change { Role.where(type: role_type).count }.by(1)
+      .and change { Role.where(type: FutureRole.sti_name).count }.by(-1)
+  end
+end
+

--- a/spec/jobs/people/create_roles_job_spec.rb
+++ b/spec/jobs/people/create_roles_job_spec.rb
@@ -14,7 +14,6 @@ describe People::CreateRolesJob do
   let(:role_type) { Group::TopGroup::Member.sti_name }
   let(:tomorrow) { Time.zone.tomorrow }
 
-
   subject(:job) { described_class.new }
 
   def create_future_role(attrs = {})

--- a/spec/models/future_role_spec.rb
+++ b/spec/models/future_role_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+#
+# Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+# hitobito_sac_cas and licensed under the Affero General Public License version 3
+# or later. See the COPYING file at the top-level directory or at
+# https://github.com/hitobito/hitobito
+
+require 'spec_helper'
+
+describe FutureRole do
+  let(:person) { people(:bottom_member) }
+  let(:top_group) { groups(:top_group) }
+  let(:role_type) { Group::TopGroup::Member.sti_name }
+  let(:tomorrow) { Time.zone.tomorrow }
+
+  def build(attrs = {})
+    defaults = { person: person, group: top_group, convert_to: role_type, convert_on: tomorrow }
+    Fabricate.build(:future_role, defaults.merge(attrs))
+  end
+
+  describe 'validations' do
+    it 'fabrication builds valid model' do
+      expect(build).to be_valid
+    end
+
+    it 'is invalid with blank person or group' do
+      expect(build(person: nil)).to have(1).error_on(:person)
+      expect(build(group: nil)).to have(1).error_on(:group)
+    end
+
+    it 'validates that convert_on is present and not in the past' do
+      expect(build(convert_on: nil)).to have(1).error_on(:convert_on)
+      expect(build(convert_on: Time.zone.yesterday)).to have(1).error_on(:convert_on)
+      expect(build(convert_on: Time.zone.today)).to be_valid
+    end
+
+    it 'validates that convert_to is present and of type supported by group' do
+      expect(build(convert_to: nil)).to have(1).error_on(:convert_to)
+      expect(build(convert_to: Group::TopLayer::TopAdmin.sti_name)).to have(1).error_on(:convert_to)
+      expect(build(convert_to: Group::TopGroup::Leader.sti_name)).to be_valid
+    end
+  end
+
+  describe 'callbacks' do
+    it 'skips create callbacks' do
+      role = build
+      expect(role).not_to receive(:set_contact_data_visible)
+      expect(role).not_to receive(:set_first_primary_group)
+      role.save!
+    end
+
+    it 'skips destroy callbacks' do
+      role = build.tap(&:save!)
+      expect(role).not_to receive(:reset_contact_data_visible)
+      expect(role).not_to receive(:reset_primary_group)
+      role.destroy!
+    end
+  end
+
+  describe '#to_s' do
+    it 'includes starting date' do
+      travel_to(Time.zone.local(2023, 11, 3, 14)) do
+        expect(build.to_s).to eq 'Member (ab 04.11.2023)'
+      end
+    end
+  end
+
+  describe '#convert!' do
+    it 'really_destroys self and creates new role with same attributes' do
+      attrs = { created_at: 10.days.ago.noon, delete_on: 10.days.from_now.noon, label: 'test' }
+      role = build(attrs).tap(&:save!)
+      expect { role.convert! }.not_to change { Role.unscoped.count }
+      expect(person.roles.where(attrs.except(:created_at).merge(type: role_type))).to be_exist
+    end
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -626,6 +626,15 @@ describe Group do
           expect(group).to be_archived
           expect(role.reload.delete_on).to be_present
         end
+
+        it 'future roles are hard deleted' do
+          Fabricate(:future_role, person: role.person, group: group, convert_to: group.role_types.first)
+          expect do
+            group.archive!
+          end.to change { group.roles.with_deleted.future.count }.by(-1)
+
+          expect(group).to be_archived
+        end
       end
 
       describe 'mailing lists' do

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -34,6 +34,7 @@ describe Role do
 
   context 'validates' do
     let(:group) { groups(:bottom_layer_one) }
+
     def build(attrs)
       Fabricate.build(:'Group::BottomLayer::Leader', attrs.merge(group: group))
     end
@@ -234,6 +235,27 @@ describe Role do
     end
   end
 
+  context '#start_on' do
+    let(:tomorrow) { Time.zone.tomorrow }
+    let(:today) { Time.zone.today }
+
+    def build(attrs = {})
+      Fabricate.build(:'Group::BottomLayer::Leader', attrs)
+    end
+
+    it 'returns today if created_at and convert_on is nil' do
+      expect(build.start_on).to eq today
+    end
+
+    it 'returns created_at date if created_at is present and convert_on is nil' do
+      expect(build(created_at: 1.day.ago).start_on).to eq Time.zone.yesterday
+    end
+
+    it 'returns convert_on if convert_on and created_at is set' do
+      expect(build(created_at: 1.day.ago, convert_on: tomorrow).start_on).to eq tomorrow
+    end
+  end
+
   context '#destroy' do
     it 'deleted young roles from database' do
       a = Fabricate(Group::BottomLayer::Leader.name.to_s, label: 'foo',
@@ -373,7 +395,6 @@ describe Role do
     end
   end
 
-
   context 'nextcloud groups' do
     let(:person) { Fabricate(:person) }
     let(:group) { groups(:bottom_layer_one) }
@@ -487,7 +508,6 @@ describe Role do
         )
       end
     end
-
   end
 
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -59,6 +59,29 @@ describe Role do
     end
   end
 
+  describe '::inactive scope' do
+    subject(:inactive) { Role.inactive }
+
+    it 'excludes active roles' do
+      expect(inactive).to be_empty
+    end
+
+    it 'includes deleted roles' do
+      roles(:bottom_member).update(deleted_at: 1.day.ago)
+      expect(inactive).to have(1).item
+    end
+
+    it 'includes archived roles from the past' do
+      roles(:bottom_member).update(archived_at: 3.days.ago)
+      expect(inactive).to have(1).item
+    end
+
+    it 'excludes archived roles from the future' do
+      roles(:bottom_member).update(archived_at: 3.days.from_now)
+      expect(inactive).to be_empty
+    end
+  end
+
   context 'class' do
     subject { described_class }
 

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -11,14 +11,21 @@
 #
 #  id          :integer          not null, primary key
 #  archived_at :datetime
+#  convert_on  :date
+#  convert_to  :string(255)
 #  delete_on   :date
 #  deleted_at  :datetime
 #  label       :string(255)
 #  type        :string(255)      not null
 #  created_at  :datetime
 #  updated_at  :datetime
-#  deleted_at  :datetime
-#  archived_at :datetime
+#  group_id    :integer          not null
+#  person_id   :integer          not null
+#
+# Indexes
+#
+#  index_roles_on_person_id_and_group_id  (person_id,group_id)
+#  index_roles_on_type                    (type)
 #
 
 require 'spec_helper'

--- a/spec/regressions/person/history_controller_spec.rb
+++ b/spec/regressions/person/history_controller_spec.rb
@@ -39,7 +39,7 @@ describe Person::HistoryController, type: :controller do
       role.destroy
       get :index, params: params
       expect(dom.all('table tbody tr').size).to eq 2
-      role_row = dom.find('table tbody tr:eq(1)')
+      role_row = dom.find('div.table-responsive:last table tbody tr')
       expect(role_row.find('td:eq(1) a:eq(2)').text).to eq 'Group 11'
       expect(role_row.find('td:eq(2)').text.strip).to eq 'Member'
       expect(role_row.find('td:eq(3)').text).to be_present
@@ -61,7 +61,7 @@ describe Person::HistoryController, type: :controller do
       role.destroy
       get :index, params: params
       expect(dom.all('table tbody tr').size).to eq 2
-      role_row = dom.find('table tbody tr:eq(2)')
+      role_row = dom.find('div.table-responsive:last table tbody tr')
       expect(role_row.find('td:eq(1) a:eq(2)').text).to eq 'TopGroup'
       expect(role_row.find('td:eq(4)').text).to be_present
     end


### PR DESCRIPTION
Ein PoC für zukünftige Rollen, wie eine Lösung auf basis eines neuen Rollen Attributes `convert_on` aussehen könnte. 

Ich bin mir nicht sicher, wo diese Rollen jetzt überall nicht mehr erscheinen dürfen, denke aber das über den Filter die meisten Orte erwischt werden (Personen Liste, Export). 

fixes #2237