### PR TITLE
Add groups to json:api

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+def gr(resource, scope: nil, params: {}, as: Role.first.person)
+  raise "#{resource} is not a resource class" unless resource <= ApplicationResource
+
+  context = OpenStruct.new(current_ability: Ability.new(as))
+  Graphiti.with_context(context, params: params) do
+    action_controller_params = ActionController::Parameters.new(params)
+    resources = resource.all(action_controller_params, scope || resource.new.base_scope)
+    JSON.parse(resources.to_jsonapi).deep_symbolize_keys
+  end
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 *  Rollen mit Start-Datum in der Zukunft können erfasst werden (hitobito#2237)
+*  Eigener JSON:API Endpoint für Gruppen (hitobito#2243)
 
 ## Version 1.30
 
@@ -12,7 +13,7 @@
 *  Der Gruppen-Tab "Einstellungen" wurde entfernt und die Optionen sind neu in der Bearbeitungsansicht der Gruppe unter dem Tab "Abos" (#2165)
 *  Einführung von Gruppen-Attributen sowie Migration der Gruppen-Einstellungen (#2165)
 *  Sammelrechnungen können neu gelöscht werden (#1387)
-*  Neu gibt es für Gruppen mit aktivierter Selbstregistrierung eine Seite, über welche sich eingeloggte Personen 
+*  Neu gibt es für Gruppen mit aktivierter Selbstregistrierung eine Seite, über welche sich eingeloggte Personen
    in der Gruppe einschreiben können (#2180)
 *  Logo kann auf Rechnungen angezeigt werden (#hitobito_sww#144)
     - konfigurierbar pro Layer
@@ -20,7 +21,7 @@
 
 ## Version 1.30
 
-*  Die JSON:API liefert für Personen neu auch die Sprache (#2104) 
+*  Die JSON:API liefert für Personen neu auch die Sprache (#2104)
 *  Der Sicherheits-Tab einer Person kann neu die Gruppen und Rollen, welche `:show_details` Zugriff auf einem haben, auflisten. Merci @cdn64! (hitobito_pbs#257)
 *  Auf der Personen-Listenansicht können neu via Multiselekt Personen als Abonnenten einem Abo hinzugefügt werden (#2110)
 
@@ -67,7 +68,7 @@
 *  Personen mit layer_full oder layer_and_below_full können neu Personen, welche in ihren Ebenen unter "Ohne Rollen" erscheinen, per globale Suchfunktion finden und anzeigen. (hitobito_sww#80)
 *  Anbindung an Nextcloud möglich (#1854)
 *  Rechnungen werden neu in einem Hintergrundprozess gedruckt (#2014)
-*  Auf dem Buchungsbeleg sind die einzelnen Positionen nun verlinkt und führen auf eine Auflistung aller Rechnungen, welche die jeweilige Position beinhalten (hitobito_sww#69) 
+*  Auf dem Buchungsbeleg sind die einzelnen Positionen nun verlinkt und führen auf eine Auflistung aller Rechnungen, welche die jeweilige Position beinhalten (hitobito_sww#69)
 
 
 ## Version 1.27

--- a/app/controllers/json_api/groups_controller.rb
+++ b/app/controllers/json_api/groups_controller.rb
@@ -8,19 +8,13 @@
 class JsonApi::GroupsController < JsonApiController
   def index
     authorize!(:index, Group)
-    resources = resource_class.all(params, without_archived)
+    resources = resource_class.all(params)
     render(jsonapi: resources)
   end
 
   def show
-    group = without_archived.find(params[:id])
+    group = Group.find(params[:id])
     authorize!(:show, group)
     super
-  end
-
-  private
-
-  def without_archived
-    Group.without_archived
   end
 end

--- a/app/controllers/json_api/groups_controller.rb
+++ b/app/controllers/json_api/groups_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+class JsonApi::GroupsController < JsonApiController
+  def index
+    authorize!(:index, Group)
+    resources = resource_class.all(params, without_archived)
+    render(jsonapi: resources)
+  end
+
+  def show
+    group = without_archived.find(params[:id])
+    authorize!(:show, group)
+    super
+  end
+
+  private
+
+  def without_archived
+    Group.without_archived
+  end
+end

--- a/app/controllers/json_api/people_controller.rb
+++ b/app/controllers/json_api/people_controller.rb
@@ -21,8 +21,6 @@ class JsonApi::PeopleController < JsonApiController
     super
   end
 
-  private
-
   def entry
     @entry ||= Person.find(params[:id])
   end

--- a/app/controllers/json_api/people_controller.rb
+++ b/app/controllers/json_api/people_controller.rb
@@ -21,6 +21,8 @@ class JsonApi::PeopleController < JsonApiController
     super
   end
 
+  private
+
   def entry
     @entry ||= Person.find(params[:id])
   end

--- a/app/resources/group_resource.rb
+++ b/app/resources/group_resource.rb
@@ -53,7 +53,9 @@ class GroupResource < ApplicationResource
   end
 
   filter :with_archived, :boolean, :single do
-    eq do |scope, _value|
+    eq do |scope, value|
+      next scope unless value
+
       scope.unscope(where: :archived_at)
     end
   end

--- a/app/resources/group_resource.rb
+++ b/app/resources/group_resource.rb
@@ -6,10 +6,13 @@
 #  https://github.com/hitobito/hitobito.
 
 class GroupResource < ApplicationResource
+  primary_endpoint 'groups', [:index, :show]
+
   with_options writable: false do
     attribute :name, :string
     attribute :short_name, :string
     attribute(:display_name, :string) { @object.display_name }
+    attribute :description, :string
     attribute(:layer, :boolean) { @object.layer? }
     attribute :type, :string
     attribute :email, :string
@@ -17,10 +20,28 @@ class GroupResource < ApplicationResource
     attribute :zip_code, :integer
     attribute :town, :string
     attribute :country, :string
+
+    attribute :require_person_add_requests, :boolean
+    attribute(:self_registration_url, :string) do
+      context.group_self_registration_url(group_id: @object.id)
+    end
+
+    attribute :archived_at, :datetime
     attribute :created_at, :datetime
     attribute :updated_at, :datetime
     attribute :deleted_at, :datetime
+
+    extra_attribute :logo, :string do
+      next unless @object.logo.attached?
+
+      context.rails_storage_proxy_url(@object.logo.blob)
+    end
   end
+
+  belongs_to :contact, resource: PersonResource, writable: false, foreign_key: :contact_id
+  belongs_to :creator, resource: PersonResource, writable: false, foreign_key: :creator_id
+  belongs_to :updater, resource: PersonResource, writable: false, foreign_key: :updater_id
+  belongs_to :deleter, resource: PersonResource, writable: false, foreign_key: :deleter_id
 
   belongs_to :parent, resource: GroupResource, writable: false, foreign_key: :parent_id
   belongs_to :layer_group, resource: GroupResource, writable: false, foreign_key: :layer_group_id do

--- a/app/resources/group_resource.rb
+++ b/app/resources/group_resource.rb
@@ -52,6 +52,12 @@ class GroupResource < ApplicationResource
     end
   end
 
+  filter :with_archived, :boolean, :single do
+    eq do |scope, _value|
+      scope.unscope(where: :archived_at)
+    end
+  end
+
   def authorize_create(model)
     # Writing groups is disabled for now
     raise CanCan::AccessDenied
@@ -64,5 +70,9 @@ class GroupResource < ApplicationResource
 
   def index_ability
     JsonApi::GroupAbility.new(current_ability)
+  end
+
+  def base_scope
+    Group.without_archived
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -391,6 +391,7 @@ Hitobito::Application.routes.draw do
 
   scope path: ApplicationResource.endpoint_namespace, module: :json_api, constraints: { format: 'jsonapi' }, defaults: { format: 'jsonapi' } do
     resources :people, only: [:index, :show, :update]
+    resources :groups, only: [:index, :show]
   end
 
   # The priority is based upon order of creation:

--- a/doc/development/05_json_api.md
+++ b/doc/development/05_json_api.md
@@ -13,6 +13,8 @@ Currently the following endpoints are provided:
 | GET    | /api/people/                                      | List all accessible people                                                      |
 | GET    | /api/people/:id                                   | Fetch a single person entry, replace :id with the person's primary key          |
 | PATCH  | /api/people/:id                                   | Update a person entry, replace :id with the person's primary key                |
+| GET    | /api/groups/                                      | List all accessible groups                                                      |
+| GET    | /api/groups/:id                                   | Fetch a single group entry, replace :id with the groups's primary key           |
 
 Visit your hitobito's swagger UI [/api-docs](/api-docs) for detailed documentation and a sandbox for testing/developing requests.
 
@@ -280,6 +282,6 @@ Checklist for creating/extending JSON:API endpoints:
 #### Permissions
 
 Permissions are primarly checked in graphiti resources `app/resources`, not in controllers like
-in non JSON:API controllers. For this there's specific abilities in `app/abilities/json_api`. 
+in non JSON:API controllers. For this there's specific abilities in `app/abilities/json_api`.
 We're also authorizing inside the JSON:API controllers to make sure
 the right HTTP status code is returned. (e.g. 403 instead of 404 if access denied)

--- a/spec/controllers/json_api/groups_controller_spec.rb
+++ b/spec/controllers/json_api/groups_controller_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require 'spec_helper'
+
+describe JsonApi::PeopleController, type: [:request] do
+  let(:params) { {} }
+  let(:top_leader) { people(:top_leader) }
+  let(:bottom_member) { people(:bottom_member) }
+
+  describe 'GET #index' do
+    context 'unauthorized' do
+      it 'returns 401' do
+        jsonapi_get '/api/groups', params: params
+
+        expect(response).to have_http_status(401)
+
+        errors = jsonapi_errors
+
+        expect(errors.first.status).to eq('401')
+
+        expect(errors.first.title).to eq('Login benötigt')
+        expect(errors.first.detail).to eq('Du must dich einloggen bevor du auf diese Resource zugreifen kannst.')
+      end
+    end
+
+  end
+
+  context 'authorized' do
+    let(:permitted_service_token) { service_tokens(:permitted_top_layer_token) }
+    let(:params) { { token: permitted_service_token.token } }
+    let(:group) { groups(:bottom_group_two_one) }
+    before { group.update!(archived_at: Time.zone.now) }
+
+    it 'GET#index does not include archived group' do
+      jsonapi_get '/api/groups', params: params
+      expect(response).to have_http_status(200)
+      expect(JSON.parse(response.body)['data'].size).to eq Group.count - 1
+    end
+
+    it 'GET#show does find archived group' do
+      groups(:bottom_group_two_one).update!(archived_at: Time.zone.now)
+      jsonapi_get "/api/groups/#{group.id}", params: params
+      expect(response).to have_http_status(404)
+    end
+  end
+end

--- a/spec/controllers/json_api/groups_controller_spec.rb
+++ b/spec/controllers/json_api/groups_controller_spec.rb
@@ -42,10 +42,16 @@ describe JsonApi::PeopleController, type: [:request] do
       expect(JSON.parse(response.body)['data'].size).to eq Group.count - 1
     end
 
-    it 'GET#index does include archived group via filter' do
+    it 'GET#index does include archived group with filter with_archived=true' do
       jsonapi_get '/api/groups', params: params.merge(filter: { with_archived: true })
       expect(response).to have_http_status(200)
       expect(JSON.parse(response.body)['data'].size).to eq Group.count
+    end
+
+    it 'GET#index does not include archived group with filter with_archived=false' do
+      jsonapi_get '/api/groups', params: params.merge(filter: { with_archived: false })
+      expect(response).to have_http_status(200)
+      expect(JSON.parse(response.body)['data'].size).to eq Group.count - 1
     end
 
     it 'GET#show does find archived group' do

--- a/spec/controllers/json_api/groups_controller_spec.rb
+++ b/spec/controllers/json_api/groups_controller_spec.rb
@@ -42,6 +42,12 @@ describe JsonApi::PeopleController, type: [:request] do
       expect(JSON.parse(response.body)['data'].size).to eq Group.count - 1
     end
 
+    it 'GET#index does include archived group via filter' do
+      jsonapi_get '/api/groups', params: params.merge(filter: { with_archived: true })
+      expect(response).to have_http_status(200)
+      expect(JSON.parse(response.body)['data'].size).to eq Group.count
+    end
+
     it 'GET#show does find archived group' do
       groups(:bottom_group_two_one).update!(archived_at: Time.zone.now)
       jsonapi_get "/api/groups/#{group.id}", params: params

--- a/spec/requests/json_api/group_schema.rb
+++ b/spec/requests/json_api/group_schema.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+class JsonApi::GroupSchema
+
+  def self.read
+    self.new.data
+  end
+
+  def data
+    { type: :object,
+      properties: {
+        data: {
+          type: :object,
+          properties: {
+            id: { type: :string, description: 'ID'},
+            type: { type: :string, enum: ['groups'], default: 'groups'},
+          }
+        },
+      }
+    }
+  end
+
+  def attributes
+    { type: :object,
+      properties: {
+        name: { type: :string },
+        description: { type: :string }
+      },
+      description: 'Group attributes' }
+  end
+end

--- a/spec/requests/json_api/groups_spec.rb
+++ b/spec/requests/json_api/groups_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require 'swagger_helper'
+# require_relative 'group_schema'
+
+RSpec.describe 'json_api/groups', type: :request do
+  let(:'X-TOKEN') { service_tokens(:permitted_top_layer_token).token }
+  let(:token) { service_tokens(:permitted_top_layer_token).token }
+  let(:include) { [] }
+
+  path '/api/groups' do
+
+    # add pagination
+    # add filter for updated_at
+
+    get('list groups') do
+      parameter(
+        name: 'include',
+        in: :query,
+        required: false,
+        explode: false,
+        schema: {
+          type: :array,
+          enum: %w(contact creator updater deleter parent layer_group),
+          nullable: true
+        }
+      )
+
+      parameter(name: 'extra_fields', in: :query, required: false, schema: { type: :string, enum: %w(logo) })
+      parameter(name: 'filter[type][eq]', in: :query, required: false, schema: { type: :string, enum: Group.all_types })
+
+      response(200, 'successful') do
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/vnd.json+api' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+
+      response(200, 'successful') do
+        let(:include) { %w(contact creator updater deleter parent layer_group) }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/groups/{id}' do
+    let(:id) { groups(:top_group).id }
+    parameter name: :id, in: :path, type: :string
+
+    get('fetch group') do
+      response(200, 'successful') do
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/vnd.json+api' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/json_api/person_schema.rb
+++ b/spec/requests/json_api/person_schema.rb
@@ -1,3 +1,10 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
 class JsonApi::PersonSchema
 
   def self.read

--- a/spec/resources/group/reads_spec.rb
+++ b/spec/resources/group/reads_spec.rb
@@ -109,11 +109,20 @@ describe GroupResource, type: :resource do
       expect(d).to be_empty
     end
 
-    it 'can include archived group via filter default' do
-      group.update_columns(archived_at: Time.zone.now)
-      params[:filter] = { type: 'Group::TopGroup', with_archived: true }
-      render
-      expect(d).to have(1).item
+    context 'by with_archived' do
+      before { group.update_columns(archived_at: Time.zone.now) }
+
+      it 'when true it includes archived groups' do
+        params[:filter] = { type: 'Group::TopGroup', with_archived: true }
+        render
+        expect(d).to have(1).item
+      end
+
+      it 'when false it excludes archived groups' do
+        params[:filter] = { type: 'Group::TopGroup', with_archived: false }
+        render
+        expect(d).to be_empty
+      end
     end
   end
 

--- a/spec/resources/person/reads_spec.rb
+++ b/spec/resources/person/reads_spec.rb
@@ -9,12 +9,7 @@ require 'spec_helper'
 
 describe PersonResource, type: :resource do
   let(:user) { user_role.person }
-
-  around do |example|
-    RSpec::Mocks.with_temporary_scope do
-      Graphiti.with_context(double({ current_ability: Ability.new(user) })) { example.run }
-    end
-  end
+  let(:ability) { Ability.new(user) }
 
   describe 'serialization' do
     let!(:person) { Fabricate(:person, birthday: Date.today, gender: 'm') }

--- a/spec/resources/person/reads_spec.rb
+++ b/spec/resources/person/reads_spec.rb
@@ -10,10 +10,12 @@ require 'spec_helper'
 describe PersonResource, type: :resource do
   let(:user) { user_role.person }
   let(:ability) { Ability.new(user) }
+  let(:top_group) { groups(:top_group) }
+  let(:bottom_layer_one) { groups(:bottom_layer_one) }
 
   describe 'serialization' do
     let!(:person) { Fabricate(:person, birthday: Date.today, gender: 'm') }
-    let!(:role) { Fabricate(Group::BottomLayer::Member.name, person: person, group: groups(:bottom_layer_one)) }
+    let!(:role) { Fabricate(Group::BottomLayer::Member.name, person: person, group: bottom_layer_one) }
 
     def serialized_attrs
       [
@@ -56,7 +58,7 @@ describe PersonResource, type: :resource do
     end
 
     context 'with appropriate permission' do
-      let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: role.group) }
+      let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, group: role.group) }
 
       it 'works' do
         render
@@ -79,7 +81,7 @@ describe PersonResource, type: :resource do
     end
 
     context 'with show_details permission, it' do
-      let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: role.group) }
+      let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, group: role.group) }
       it 'includes restricted attrs' do
         render
 
@@ -89,8 +91,8 @@ describe PersonResource, type: :resource do
 
     context 'without show_details permission, it' do
       # Both have contact_data, so they can see each other, but not each other's details
-      let!(:role) { Fabricate(Group::BottomLayer::Leader.name, person: person, group: groups(:bottom_layer_one)) }
-      let!(:user_role) { Fabricate(Group::TopGroup::Member.name, person: Fabricate(:person), group: groups(:top_group)) }
+      let!(:role) { Fabricate(Group::BottomLayer::Leader.name, person: person, group: bottom_layer_one) }
+      let!(:user_role) { Fabricate(Group::TopGroup::Member.name, group: top_group) }
       it 'does not include restricted attrs' do
         render
 
@@ -99,7 +101,7 @@ describe PersonResource, type: :resource do
     end
 
     context 'with person language' do
-      let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: role.group) }
+      let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, group: role.group) }
 
       context 'enabled' do
         it 'includes language' do
@@ -141,9 +143,9 @@ describe PersonResource, type: :resource do
   end
 
   describe 'filtering' do
-    let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: groups(:bottom_layer_one)) }
-    let!(:role1) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: groups(:bottom_layer_one)) }
-    let!(:role2) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: groups(:bottom_layer_one)) }
+    let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, group: bottom_layer_one) }
+    let!(:role1) { Fabricate(Group::BottomLayer::Leader.name, group: bottom_layer_one) }
+    let!(:role2) { Fabricate(Group::BottomLayer::Leader.name, group: bottom_layer_one) }
     let(:person1) { role1.person }
     let(:person2) { role2.person }
 
@@ -162,8 +164,9 @@ describe PersonResource, type: :resource do
       before do
         person1.update_attribute(:updated_at, 1.minute.ago)
         person2.update_attribute(:updated_at, 1.day.ago)
-        params[:filter] = { updated_at: { gt: 1.hour.ago.to_s }}
+        params[:filter] = { updated_at: { gt: 1.hour.ago.to_s } }
       end
+
       it 'works' do
         render
         expect(d.map(&:id)).to include(person1.id)
@@ -173,9 +176,9 @@ describe PersonResource, type: :resource do
   end
 
   describe 'sorting' do
-    let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: groups(:bottom_layer_one)) }
-    let!(:role1) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: groups(:bottom_layer_one)) }
-    let!(:role2) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: groups(:bottom_layer_one)) }
+    let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, group: bottom_layer_one) }
+    let!(:role1) { Fabricate(Group::BottomLayer::Leader.name, group: bottom_layer_one) }
+    let!(:role2) { Fabricate(Group::BottomLayer::Leader.name, group: bottom_layer_one) }
     let(:person1) { role1.person }
     let(:person2) { role2.person }
 
@@ -209,7 +212,7 @@ describe PersonResource, type: :resource do
   end
 
   describe 'sideloading' do
-    let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: groups(:bottom_layer_one)) }
+    let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, group: bottom_layer_one) }
     let(:role) { roles(:bottom_member) }
     let!(:person) { role.person }
 

--- a/spec/resources/role/reads_spec.rb
+++ b/spec/resources/role/reads_spec.rb
@@ -10,12 +10,7 @@ require 'spec_helper'
 describe RoleResource, type: :resource do
   let!(:role) { roles(:bottom_member) }
   let(:user) { user_role.person }
-
-  around do |example|
-    RSpec::Mocks.with_temporary_scope do
-      Graphiti.with_context(double({ current_ability: Ability.new(user) })) { example.run }
-    end
-  end
+  let(:ability) { Ability.new(user) }
 
   before do
     allow(Graphiti.context[:object]).to receive(:can?).and_return(true)

--- a/spec/resources/role/reads_spec.rb
+++ b/spec/resources/role/reads_spec.rb
@@ -9,8 +9,7 @@ require 'spec_helper'
 
 describe RoleResource, type: :resource do
   let!(:role) { roles(:bottom_member) }
-  let(:user) { user_role.person }
-  let(:ability) { Ability.new(user) }
+  let(:person) { user_role.person }
 
   before do
     allow(Graphiti.context[:object]).to receive(:can?).and_return(true)
@@ -28,7 +27,7 @@ describe RoleResource, type: :resource do
     before { params[:filter] = { id: { eq: role.id } } }
 
     context 'without appropriate permission' do
-      let(:user) { Fabricate(:person) }
+      let(:person) { Fabricate(:person) }
 
       it 'does not expose data' do
         render
@@ -37,7 +36,7 @@ describe RoleResource, type: :resource do
     end
 
     context 'with appropriate permission' do
-      let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: role.group) }
+      let(:person) { Fabricate(Group::BottomLayer::Leader.name, group: role.group).person }
 
       it 'works' do
         render
@@ -66,7 +65,7 @@ describe RoleResource, type: :resource do
       before { params[:include] = 'person' }
 
       context 'without appropriate permission' do
-        let(:user) { Fabricate(:person) }
+        let(:person) { Fabricate(:person) }
 
         it 'does not expose data' do
           render
@@ -75,7 +74,7 @@ describe RoleResource, type: :resource do
       end
 
       context 'with appropriate permission' do
-        let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: role.group) }
+        let(:person) { Fabricate(Group::BottomLayer::Leader.name, group: role.group).person }
 
         it 'it works' do
           render
@@ -90,7 +89,7 @@ describe RoleResource, type: :resource do
       before { params[:include] = 'group' }
 
       context 'without appropriate permission' do
-        let(:user) { Fabricate(:person) }
+        let(:person) { Fabricate(:person) }
 
         it 'does not expose data' do
           render
@@ -99,7 +98,7 @@ describe RoleResource, type: :resource do
       end
 
       context 'with appropriate permission' do
-        let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: role.group) }
+        let(:person) { Fabricate(Group::BottomLayer::Leader.name, group: role.group).person }
 
         it 'it works' do
           render
@@ -114,7 +113,7 @@ describe RoleResource, type: :resource do
       before { params[:include] = 'layer_group' }
 
       context 'without appropriate permission' do
-        let(:user) { Fabricate(:person) }
+        let(:person) { Fabricate(:person) }
 
         it 'does not expose data' do
           render
@@ -123,7 +122,7 @@ describe RoleResource, type: :resource do
       end
 
       context 'with appropriate permission' do
-        let!(:user_role) { Fabricate(Group::BottomLayer::Leader.name, person: Fabricate(:person), group: role.group) }
+        let(:person) { Fabricate(Group::BottomLayer::Leader.name, group: role.group).person }
 
         it 'it works' do
           render

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -176,6 +176,7 @@ RSpec.configure do |config|
   config.include GraphitiSpecHelpers::RSpec
   config.include GraphitiSpecHelpers::Sugar
   config.include Graphiti::Rails::TestHelpers
+  config.include ResourceSpecHelper, type: :resource
 
   config.before :each do
     handle_request_exceptions(false)

--- a/spec/support/resource_spec_helper.rb
+++ b/spec/support/resource_spec_helper.rb
@@ -1,0 +1,28 @@
+#  frozen_string_literal: true
+
+#  Copyright (c) 2023, Schweizer Wanderwege. This file is part of
+#  hitobito_sww and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sww.
+#
+module ResourceSpecHelper
+  extend ActiveSupport::Concern
+
+  included do
+    let(:ability) { Ability.new(person) }
+    let(:person) { people(:top_leader) }
+    let(:url_options) { { host: 'example.com' } }
+
+    let(:context) do
+      double(current_ability: ability, url_options: url_options).tap do |context|
+        context.extend(Rails.application.routes.url_helpers)
+      end
+    end
+
+    around do |example|
+      RSpec::Mocks.with_temporary_scope do
+        Graphiti.with_context(context) { example.run }
+      end
+    end
+  end
+end

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -22,7 +22,7 @@ paths:
           - parent
           - layer_group
           nullable: true
-      - name: extra_fields
+      - name: extra_fields[groups]
         in: query
         required: false
         schema:
@@ -41,6 +41,11 @@ paths:
           - Group::BottomGroup
           - Group::MountedAttrsGroup
           - Group::GlobalGroup
+      - name: filter[with_archived]
+        in: query
+        required: false
+        schema:
+          type: boolean
       responses:
         '200':
           description: successful
@@ -149,10 +154,29 @@ paths:
                         last_name:
                           type: string
                       description: Person attributes
-                    extra_fields:
-                      type: array
-                      items:
-                        type: string
+                    relationships:
+                      type: object
+                      properties:
+                        phone_numbers:
+                          type: object
+                          properties:
+                            data:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                    - phone_numbers
+                                    default: phone_numbers
+                                  id:
+                                    type: string
+                                  method:
+                                    type: string
+                                    enum:
+                                    - update
+                                    default: update
                 included:
                   type: array
                   items:
@@ -161,13 +185,8 @@ paths:
                       type:
                         type: string
                         enum:
-                        - contact
-                        - creator
-                        - updater
-                        - deleter
-                        - parent
-                        - layer_group
-                        default: contact
+                        - phone_numbers
+                        default: phone_numbers
                       id:
                         type: string
                       attributes:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -4,6 +4,58 @@ info:
   title: JSON:API
   version: v1
 paths:
+  "/api/groups":
+    get:
+      summary: list groups
+      parameters:
+      - name: include
+        in: query
+        required: false
+        explode: false
+        schema:
+          type: array
+          enum:
+          - contact
+          - creator
+          - updater
+          - deleter
+          - parent
+          - layer_group
+          nullable: true
+      - name: extra_fields
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - logo
+      - name: filter[type][eq]
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - Group::TopLayer
+          - Group::TopGroup
+          - Group::BottomLayer
+          - Group::BottomGroup
+          - Group::MountedAttrsGroup
+          - Group::GlobalGroup
+      responses:
+        '200':
+          description: successful
+  "/api/groups/{id}":
+    parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      summary: fetch group
+      responses:
+        '200':
+          description: successful
   "/api/people":
     get:
       summary: list people
@@ -97,29 +149,10 @@ paths:
                         last_name:
                           type: string
                       description: Person attributes
-                    relationships:
-                      type: object
-                      properties:
-                        phone_numbers:
-                          type: object
-                          properties:
-                            data:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                    - phone_numbers
-                                    default: phone_numbers
-                                  id:
-                                    type: string
-                                  method:
-                                    type: string
-                                    enum:
-                                    - update
-                                    default: update
+                    extra_fields:
+                      type: array
+                      items:
+                        type: string
                 included:
                   type: array
                   items:
@@ -128,8 +161,13 @@ paths:
                       type:
                         type: string
                         enum:
-                        - phone_numbers
-                        default: phone_numbers
+                        - contact
+                        - creator
+                        - updater
+                        - deleter
+                        - parent
+                        - layer_group
+                        default: contact
                       id:
                         type: string
                       attributes:


### PR DESCRIPTION
fixes hitobito#2243

Ich denke das setzt grob mal den endpoint um. Bei den specs bin ich mir noch unsicher, folgendes ist mir unklar:
- Wofür genau brauche ich das schema in der swagger api doku? Wieviel JSON:API standard wollen wir nachbauen? 
- Wollen/Brauchen wir wirklich so umfangreiche controller specs wie bei people? 

Fürs Api selber denke ich es wäre besser den type filter as is zu belassen und nicht wie spezifiziert hier noch auf human names zu mappen. Archivierte Gruppen habe ich jetzt grundsätzlich mal nicht drinnen via endpoint, müssten noch schauen ob das via filter sinnvoll zu machen und wie das zu dokumentieren wäre