### PR TITLE
Vermeidung von Commits ohne Changes

### DIFF
--- a/lib/release/highlevel.rb
+++ b/lib/release/highlevel.rb
@@ -70,6 +70,12 @@ module Release
                     failure: 'No changes in translations'
     end
 
+    def changes_to_be_committed?
+      execute_check 'test $(git diff --name-only --staged | wc -l) -gt 0',
+                    success: 'Staged changes found',
+                    failure: 'No staged changes found'
+    end
+
     def update_version(file:, to: @version)
       notify "writing version to #{file}"
       case file
@@ -79,7 +85,7 @@ module Release
         execute %(sed -i "s/VERSION\s*=\s*'[0-9.]*'/VERSION = '#{to}'/" #{file})
       end
       add file
-      commit 'Bump Version for Release'
+      commit 'Bump Version for Release' if changes_to_be_committed?
     end
 
     def update_changelog(file: 'CHANGELOG.md', to: @version)
@@ -109,7 +115,7 @@ module Release
     def record_submodule_state(with: @message)
       add 'hitobito'
       add 'hitobito_*'
-      commit with
+      commit with if changes_to_be_committed?
       submodule_status
     end
 

--- a/lib/release/lowlevel.rb
+++ b/lib/release/lowlevel.rb
@@ -38,7 +38,7 @@ module Release
     end
 
     def submodules(action)
-      notify 'executing action in all submodule'
+      notify "executing '#{action}' in all submodules"
       execute "git submodule foreach '#{action}'"
     end
 


### PR DESCRIPTION
Mitten im Trubel der Feiertagsvorbereitung und der Festtagsmusik nehmen wir uns häufig mehr vor, als wir sollten. Einige Leute machen sogar komplett unnötige Zusagen. Im Zwischenmenschlichen kann man dies noch als Scherz überspielen. "Haha, ich halte dir die Tür auf, die schon geöffnet ist :joy: ". 

`git` findet das allerdings nicht so gut. Und genau hier setzt dieser PR an. Es werden nur noch Commits gemacht, wenn es auch sinnvoll ist. 

Für eine bessere Welt, in der mehr Integrationsumgebungen mit dem gleichen Codestand deployed werden können.

Fixes #2268 