### PR TITLE
Make groups searchable by static name

### DIFF
--- a/app/controllers/subscriber/group_controller.rb
+++ b/app/controllers/subscriber/group_controller.rb
@@ -47,10 +47,17 @@ module Subscriber
     def groups_query
       possible = Subscription.new(mailing_list: @mailing_list).possible_groups
       possible.where(search_condition('groups.name', 'parents_groups.name')).
+               or(possible.where(id: group_ids_by_static_name(possible))).
                includes(:parent).
                references(:parent).
                reorder("#{Group.quoted_table_name}.lft").
                limit(10)
+    end
+
+    def group_ids_by_static_name(possible)
+      possible.select do |group|
+        group.static_name && group.class.label.downcase.include?(search_param.downcase)
+      end.collect(&:id)
     end
 
     def assign_attributes


### PR DESCRIPTION
Closes: #2270 

Im `subscriber/event_controller` kann auch ein Anlass via Gruppenname gesucht werden.. Ich fand das jetzt aber zu komplex um mir dafür noch ein Bein auszureissen. Zumal man dort via Event auf Gruppe schliessen muss etc.
Wenn das aber noch nötig ist, müssen wir dort nochmal dahinter.