### PR TITLE
rszr

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           sudo apt-get -qq update
           sudo apt-get install sphinxsearch
+          sudo apt-get install libimlib2 libimlib2-dev
           echo "ruby version: $(ruby -v)"
           echo "node version: $(node -v)"
           echo "yarn version: $(yarn -v)"

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get install libimlib2 libimlib2-dev
+
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,7 @@ jobs:
         run: |
           sudo apt-get -qq update
           sudo apt-get install sphinxsearch
+          sudo apt-get install libimlib2 libimlib2-dev
           echo "ruby version: $(ruby -v)"
           echo "bundle version: $(bundle -v)"
           echo "node version: $(node -v)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ ARG NODEJS_VERSION="16"
 ARG YARN_VERSION="1.22.19"
 
 # Packages
-ARG BUILD_PACKAGES="nodejs git sqlite3 libsqlite3-dev imagemagick build-essential default-libmysqlclient-dev"
-ARG RUN_PACKAGES="imagemagick shared-mime-info pkg-config libmagickcore-dev libmagickwand-dev default-libmysqlclient-dev libjemalloc-dev libjemalloc2"
+ARG BUILD_PACKAGES="nodejs git sqlite3 libsqlite3-dev libimlib2 libimlib2-dev build-essential default-libmysqlclient-dev"
+ARG RUN_PACKAGES="shared-mime-info pkg-config libimlib2 libimlib2-dev default-libmysqlclient-dev libjemalloc-dev libjemalloc2"
 
 # Scripts
 ARG PRE_INSTALL_SCRIPT="\

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -54,7 +54,6 @@ gem 'magiclabs-userstamp', require: 'userstamp'
 gem 'mail' # add mail here to have it loaded
 gem 'matrix' # required but removed from stlib since ruby 3.2
 gem 'mime-types'
-gem 'mini_magick'
 gem 'mysql2'
 gem 'nested_form'
 gem 'nokogiri'
@@ -80,6 +79,7 @@ gem 'rotp'
 gem 'rqrcode'
 gem 'rswag-api', '~> 2.13'
 gem 'rswag-ui', '~> 2.13'
+gem 'rszr'
 gem 'rubyzip'
 gem 'seed-fu'
 gem 'sentry-raven'

--- a/app/helpers/upload_display_helper.rb
+++ b/app/helpers/upload_display_helper.rb
@@ -30,7 +30,8 @@ module UploadDisplayHelper
     if upload_exists?(model, name)
       model.send(name.to_sym).then do |pic|
         if size
-          # variant passes to mini_magick, rszr or vips, I assume rszr here, mini_magick could work as well
+          # variant passes to mini_magick, rszr or vips, I assume rszr here,
+          # mini_magick could work as well
           pic.variant(resize_to_limit: extract_image_dimensions(size))
         else
           pic

--- a/app/helpers/upload_display_helper.rb
+++ b/app/helpers/upload_display_helper.rb
@@ -30,7 +30,7 @@ module UploadDisplayHelper
     if upload_exists?(model, name)
       model.send(name.to_sym).then do |pic|
         if size
-          # variant passes to mini_magick or vips, I assume mini_magick here
+          # variant passes to mini_magick, rszr or vips, I assume mini_magick or rszr here
           pic.variant(resize_to_limit: extract_image_dimensions(size))
         else
           pic

--- a/app/helpers/upload_display_helper.rb
+++ b/app/helpers/upload_display_helper.rb
@@ -30,7 +30,7 @@ module UploadDisplayHelper
     if upload_exists?(model, name)
       model.send(name.to_sym).then do |pic|
         if size
-          # variant passes to mini_magick, rszr or vips, I assume mini_magick or rszr here
+          # variant passes to mini_magick, rszr or vips, I assume rszr here, mini_magick could work as well
           pic.variant(resize_to_limit: extract_image_dimensions(size))
         else
           pic
@@ -75,7 +75,7 @@ module UploadDisplayHelper
 
   def extract_image_dimensions(width_x_height)
     case width_x_height
-    when /^\d+x\d+$/ then width_x_height.split('x')
+    when /^\d+x\d+$/ then width_x_height.split('x').map(&:to_i)
     end
   end
 end

--- a/app/models/oauth/application.rb
+++ b/app/models/oauth/application.rb
@@ -34,11 +34,18 @@ module Oauth
 
     has_one_attached :logo do |attachable|
       attachable.variant :thumb, resize_to_fill: [64, 64]
+      # attachable.variant :logo, resize_to_fill: [512, 512]
     end
-    validates :logo, dimension: { width: { max: 8_000 }, height: { max: 8_000 } },
-                     content_type: ['image/jpeg', 'image/gif', 'image/png']
+    validates :logo, dimension: {
+      width: { max: Settings.application.image_upload.max_dimension },
+      height: { max: Settings.application.image_upload.max_dimension }
+    }, content_type: Settings.application.image_upload.content_types
 
     scope :list, -> { order(:name) }
+
+    def logo_default
+      'oauth_app.png'
+    end
 
     def self.human_scope(key)
       I18n.t("doorkeeper.scopes.#{key}")

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -89,7 +89,7 @@ module Hitobito
     config.cache_store = :mem_cache_store, { compress: true,
                                              namespace: ENV['RAILS_HOST_NAME'] || 'hitobito' }
 
-    config.active_storage.variant_processor = :mini_magick
+    config.active_storage.variant_processor = :rszr
 
     config.debug_exception_response_format = :api
 

--- a/config/initializers/rszr.rb
+++ b/config/initializers/rszr.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024-2024, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'rszr/image_processing'
+
+Rszr.autorotate = true


### PR DESCRIPTION
In order to reduce the memory footprint, image size, attack surface and overall complexity, this PR removes ImageMagick (used through `mini_magick`) and adds libimlib2 (used through `rszr`).

I transferred all processing instructions from the previous carrierwave-uploaders. Also, this adds auto-rotation to all uploads. Therefore, this offers more features than before were available. The loss of the auto-rotation was a regression of the carrierwave->activestorage migration.

See #1658, needs #2343 