### PR TITLE
Speed up people#index by removing 3n+1 queries

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -180,11 +180,13 @@ class PeopleController < CrudController
   end
 
   def prepare_entries(entries)
-    if index_full_ability?
-      entries.includes(:additional_emails, :phone_numbers)
-    else
-      entries.preload_public_accounts
-    end
+    entries = if index_full_ability?
+                entries.includes(:additional_emails, :phone_numbers)
+              else
+                entries.preload_public_accounts
+              end
+
+    entries.includes(:picture_attachment)
   end
 
   def render_tabular_entries_in_background(format)

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -82,7 +82,7 @@ class PersonDecorator < ApplicationDecorator
   end
 
   def roles
-    super.without_archived
+    super.reject(&:archived?)
   end
 
   def current_roles_grouped

--- a/app/views/people/_roles.html.haml
+++ b/app/views/people/_roles.html.haml
@@ -4,5 +4,5 @@
 -#  https://github.com/hitobito/hitobito.
 
 = render 'roles_aside', title: t('.title'), grouped_roles: entry.current_roles_grouped, primary_group_link: true
-- if entry.roles.future.any?
+- if entry.roles.any? { |r| r.is_a?(FutureRole) }
   = render 'roles_aside', title: t('.convertable_title'), grouped_roles: entry.future_roles_grouped


### PR DESCRIPTION
Seems to improve people#index page by about 30-50%

- include picture_attachment in scope
- filter preloaded roles in memory