### PR TITLE
Update actions to follow deprecation warning

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout composition repo'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.composition }}
           ref: ${{ inputs.source_ref }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: 'Checkout composition repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Checkout hitobito core submodule and wagon submodules'
         run: git submodule update --init --recursive
@@ -84,14 +84,14 @@ jobs:
         working-directory: hitobito
         run: cp Gemfile.lock Gemfile.lock.backup
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: hitobito/vendor/bundle
           key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
           restore-keys: |
             ${{ runner.os }}-ruby-bundle-
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         if: ${{ inputs.wagon_dependency_repository != '' }}
         with:
           path: ${{ inputs.wagon_dependency_repository }}/vendor/bundle
@@ -100,7 +100,7 @@ jobs:
             ${{ runner.os }}-ruby-bundle-
 
       # Commented out for now because we would have to loop over all used wagons doing this
-#      - uses: actions/cache@v3
+#      - uses: actions/cache@v4
 #        with:
 #          path: ${{ env.WAGON_NAME }}/vendor/bundle
 #          key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
@@ -126,7 +126,7 @@ jobs:
 #            bundle install --jobs 4 --retry 3 --path vendor/bundle
 #          done
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: hitobito/node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Set up Ruby'
         uses: ruby/setup-ruby@v1
@@ -58,7 +58,7 @@ jobs:
         id: readToolVersions
 
       - name: Set up Node.js ${{ steps.readToolVersions.outputs.nodejs }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.readToolVersions.outputs.nodejs }}
 
@@ -74,7 +74,7 @@ jobs:
       - name: 'create cache key'
         run: cp Gemfile.lock Gemfile.lock.backup
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
@@ -88,7 +88,7 @@ jobs:
       - name: 'Make changes to Gemfile.lock transparent'
         run: git diff Gemfile.lock || true
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -79,7 +79,7 @@ jobs:
           echo "WAGON_NAME=${repository##*/}" >> $GITHUB_ENV
 
       - name: 'Checkout hitobito'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'hitobito/hitobito'
           ref: ${{ inputs.core_ref || 'master' }}
@@ -93,7 +93,7 @@ jobs:
           working-directory: hitobito
 
       - name: 'Set up Node'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '14'
 
@@ -110,7 +110,7 @@ jobs:
           cp -v Wagonfile.ci Wagonfile
 
       - name: 'Checkout dependency ${{ inputs.wagon_dependency_repository }}'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: ${{ inputs.wagon_dependency_repository != '' }}
         with:
           repository: hitobito/${{ inputs.wagon_dependency_repository }}
@@ -118,21 +118,21 @@ jobs:
           path: ${{ inputs.wagon_dependency_repository }}
 
       - name: Checkout ${{ env.WAGON_NAME }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ env.WAGON_NAME }}
 
       - name: 'Create cache key'
         run: cp Gemfile.lock Gemfile.lock.backup
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: hitobito/vendor/bundle
           key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
           restore-keys: |
             ${{ runner.os }}-ruby-bundle-
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         if: ${{ inputs.wagon_dependency_repository != '' }}
         with:
           path: ${{ inputs.wagon_dependency_repository }}/vendor/bundle
@@ -140,7 +140,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ruby-bundle-
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ env.WAGON_NAME }}/vendor/bundle
           key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
@@ -164,7 +164,7 @@ jobs:
             bundle install --jobs 4 --retry 3 --path vendor/bundle
           done
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, actions/cache@v3. For more information see:

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.