### PR TITLE
Tasks/replace turbolinks with turbo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ gem 'sqlite3' # required for asset generation
 gem 'strip_attributes' # strip whitespace of attributes
 gem 'thinking-sphinx'
 gem 'truemail'
+gem 'turbo-rails'
 gem 'validates_by_schema'
 gem 'validates_timeliness'
 gem 'vcard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     aws-sigv4 (1.6.0)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
-    bcrypt (3.1.19)
+    bcrypt (3.1.20)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
@@ -204,7 +204,7 @@ GEM
     delayed_job_heartbeat_plugin (0.5.0)
       delayed_job (>= 4.1.0)
       delayed_job_active_record (>= 4.1.0)
-    devise (4.8.1)
+    devise (4.9.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -366,7 +366,7 @@ GEM
       activesupport (>= 4)
       lograge (< 1.0)
       railties (>= 4)
-    loofah (2.21.3)
+    loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     magiclabs-userstamp (3.0)
@@ -532,7 +532,7 @@ GEM
       rack (>= 1.4)
     rescue_registry (1.0.0)
       activesupport (>= 5.0)
-    responders (3.1.0)
+    responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
     rest-client (2.1.0)
@@ -655,7 +655,7 @@ GEM
       joiner (>= 0.3.4)
       middleware (>= 0.1.0)
       riddle (~> 2.3)
-    thor (1.2.2)
+    thor (1.3.0)
     tilt (2.3.0)
     timeliness (0.4.5)
     timeout (0.4.1)
@@ -663,6 +663,10 @@ GEM
     truemail (3.0.9)
       simpleidn (~> 0.2.1)
     ttfunk (1.7.0)
+    turbo-rails (2.0.3)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unaccent (0.4.0)
@@ -837,6 +841,7 @@ DEPENDENCIES
   test-prof
   thinking-sphinx
   truemail
+  turbo-rails
   validates_by_schema
   validates_timeliness
   vcard

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::Base
   include Sentry
   include ParamConverters
   include PaperTrailed
+  include Turbo::Redirection
 
   # protect with null_session only in specific api controllers
   protect_from_forgery with: :exception

--- a/app/controllers/concerns/turbo/redirection.rb
+++ b/app/controllers/concerns/turbo/redirection.rb
@@ -1,0 +1,31 @@
+module Turbo
+  module Redirection
+    extend ActiveSupport::Concern
+
+    def redirect_to(url = {}, options = {})
+      turbo = options.delete(:turbo)
+
+      super.tap do
+        if turbo != false && request.xhr? && !request.get?
+          visit_location_with_turbo(location, turbo)
+        end
+      end
+    end
+
+    private
+      def visit_location_with_turbo(location, action)
+        visit_options = {
+          action: action.to_s == "advance" ? action : "replace"
+        }
+
+        script = []
+        script << "Turbo.cache.clear()"
+        script << "Turbo.visit(#{location.to_json}, #{visit_options.to_json})"
+
+        self.status = 200
+        self.response_body = script.join("\n")
+        response.content_type = "text/javascript"
+        response.headers["X-Xhr-Redirect"] = location
+      end
+  end
+end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -242,7 +242,8 @@ class RolesController < CrudController # rubocop:disable Metrics/ClassLength
   def after_update_location
     return group_person_path(entry.group_id, entry.person_id) unless entry.deleted?
 
-    can?(:show, entry.person) ? person_path(entry.person_id) : group_path(parent)
+    # NOTE - as people#show responds to explicit result turbo_stream format
+    can?(:show, entry.person) ? person_path(entry.person_id, format: :html) : group_path(parent)
   end
 
   def set_group_selection

--- a/app/helpers/action_helper.rb
+++ b/app/helpers/action_helper.rb
@@ -11,14 +11,14 @@ module ActionHelper
   # Uses the current record if none is given.
   def button_action_show(path = nil, options = {})
     path ||= path_args(entry)
-    action_button ti(:"link.show"), path, 'zoom-in', options
+    action_button ti(:'link.show'), path, 'zoom-in', options
   end
 
   # Standard button action to the edit page of a given record.
   # Uses the current record if none is given.
   def button_action_edit(path = nil, options = {})
     path ||= path_args(entry)
-    action_button ti(:"link.edit"),
+    action_button ti(:'link.edit'),
                   path.is_a?(String) ? path : edit_polymorphic_path(path),
                   'edit',
                   options
@@ -30,14 +30,14 @@ module ActionHelper
     path ||= path_args(entry)
     options[:data] ||= {}
     options[:data].reverse_merge!(confirm: ti(:confirm_delete), method: :delete)
-    action_button ti(:"link.delete"), path, 'trash-alt', options
+    action_button ti(:'link.delete'), path, 'trash-alt', options
   end
 
   # Standard button action to the list page.
   # Links to the current model_class if no path is given.
   def button_action_index(path = nil, url_options = { returning: true }, options = {})
     path ||= path_args(model_class)
-    action_button ti(:"link.list"),
+    action_button ti(:'link.list'),
                   path.is_a?(String) ? path : polymorphic_path(path, url_options),
                   'list',
                   options
@@ -47,7 +47,7 @@ module ActionHelper
   # Links to the current model_class if no path is given.
   def button_action_add(path = nil, url_options = {}, options = {})
     path ||= path_args(model_class)
-    action_button ti(:"link.add"),
+    action_button ti(:'link.add'),
                   path.is_a?(String) ? path : new_polymorphic_path(path, url_options),
                   'plus',
                   options
@@ -60,8 +60,8 @@ module ActionHelper
     remote = options[:remote]
     link_to(icon(:edit),
             path.is_a?(String) ? path : edit_polymorphic_path(path),
-            title: ti(:"link.edit"),
-            alt: ti(:"link.edit"),
+            title: ti(:'link.edit'),
+            alt: ti(:'link.edit'),
             remote: remote)
   end
 
@@ -72,10 +72,9 @@ module ActionHelper
     link_to label,
             path,
             class: 'action',
-            title: ti(:"link.delete"),
-            alt: ti(:"link.delete"),
-            data: { confirm: ti(:confirm_delete),
-                    method: :delete }
+            title: ti(:'link.delete'),
+            alt: ti(:'link.delete'),
+            data: { confirm: ti(:confirm_delete), method: :delete }
   end
 
   private

--- a/app/helpers/dropdown/invoice_new.rb
+++ b/app/helpers/dropdown/invoice_new.rb
@@ -8,7 +8,7 @@
 module Dropdown
   class InvoiceNew < Base
     def initialize(template, people: [], mailing_list: nil, filter: nil, # rubocop:disable Metrics/ParameterLists
-                             group: nil, invoice_items: nil, label: nil)
+                   group: nil, invoice_items: nil, label: nil)
       super(template, label, :plus)
       @people = people
       @group = group

--- a/app/helpers/dropdown/invoice_sending.rb
+++ b/app/helpers/dropdown/invoice_sending.rb
@@ -13,7 +13,7 @@ module Dropdown
 
     def initialize(template, params)
       super(template, translate(:button), :envelope)
-      @params      = params
+      @params = params
       @invoice_list_id = template.invoice_list&.id
       init_items
     end

--- a/app/helpers/dropdown/participation_lists.rb
+++ b/app/helpers/dropdown/participation_lists.rb
@@ -20,6 +20,7 @@ module Dropdown
     def init_items
       ::Event.all_types.each do |event|
         next unless authorized?(event)
+
         add_item(event.label,
                  build_event_participation_lists_path(event),
                  **participation_lists_options)

--- a/app/helpers/dropdown/table_displays.rb
+++ b/app/helpers/dropdown/table_displays.rb
@@ -34,7 +34,7 @@ module Dropdown
     end
 
     def render_items
-      options = { class: 'dropdown-menu float-end', data: { persistent: true }, role: 'menu' }
+      options = { class: 'dropdown-menu float-end', data: { turbo_permanent: true }, role: 'menu' }
 
       content_tag(:ul, options) do
         items = table_display.available(@list).collect do |column|
@@ -68,7 +68,7 @@ module Dropdown
       {
         id: dom_id(parent),
         class: 'table-display-dropdown',
-        data: { turbolinks_permanent: 1 }
+        data: { turbo_permanent: 1 }
       }
     end
 

--- a/app/helpers/event/participation_banner.rb
+++ b/app/helpers/event/participation_banner.rb
@@ -8,7 +8,7 @@
 class Event::ParticipationBanner
 
   delegate :t, :action_button, :can?, :group_event_participation_path,
-    :content_tag, :safe_join, :parent, to: :@context
+           :content_tag, :safe_join, :parent, to: :@context
   delegate :pending?, :waiting_list?, to: :@user_participation
 
   def initialize(user_participation, event, context)
@@ -32,13 +32,13 @@ class Event::ParticipationBanner
   end
 
   def status_text
-    if waiting_list?
-      key = 'waiting_list'
-    elsif pending?
-      key = 'pending'
-    else
-      key = 'explanation'
-    end
+    key = if waiting_list?
+            'waiting_list'
+          elsif pending?
+            'pending'
+          else
+            'explanation'
+          end
 
     t("event.participations.cancel_application.#{key}")
   end
@@ -61,7 +61,7 @@ class Event::ParticipationBanner
         confirm: t('event.participations.cancel_application.confirmation'),
         method: :delete
       },
-      class: "ms-2"
+      class: 'ms-2'
     )
   end
 

--- a/app/helpers/filter_navigation/people.rb
+++ b/app/helpers/filter_navigation/people.rb
@@ -39,7 +39,7 @@ module FilterNavigation
       Role::Kinds.each do |kind|
         name = if group.archived?
                  I18n.t('activerecord.attributes.role.class.archived',
-                      role_kind: I18n.t("activerecord.attributes.role.class.kind.#{kind}.other"))
+                        role_kind: I18n.t("activerecord.attributes.role.class.kind.#{kind}.other"))
                else
                  I18n.t("activerecord.attributes.role.class.kind.#{kind}.other")
                end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -73,8 +73,8 @@ module FormHelper
     end
   end
 
-  def form_buttons(form, submit_label: ti(:"button.save"), cancel_url: nil, toolbar_class: nil,
-                          add_another: false, add_another_label: ti(:"button.add_another"))
+  def form_buttons(form, submit_label: ti(:'button.save'), cancel_url: nil, toolbar_class: nil,
+                   add_another: false, add_another_label: ti(:'button.add_another'))
     button_toolbar(form, toolbar_class: toolbar_class) do
       content = submit_button(form, submit_label)
       content << add_another_button(form, add_another_label) if add_another.present?
@@ -94,17 +94,17 @@ module FormHelper
   def submit_button(form, label, options = {})
     if options[:display_as_link]
       form.button(label, options.merge(class: 'btn btn-sm btn-link',
-                    data: { disable_with: label }))
+                                       data: { turbo_submits_with: label }))
     else
       content_tag(:div, class: 'btn-group') do
         form.button(label, options.merge(class: 'btn btn-sm btn-primary mt-2',
-                    data: { disable_with: label }))
+                                         data: { turbo_submits_with: label }))
       end
     end
   end
 
   def cancel_link(url)
-    link_to(ti(:"button.cancel"), url, class: 'link cancel')
+    link_to(ti(:'button.cancel'), url, class: 'link cancel')
   end
 
   def spinner(visible = false)
@@ -122,7 +122,11 @@ module FormHelper
   # 3. Use polymorphic_path(object)
   def get_cancel_url(object, options)
     if params[:return_url].present?
-      url = URI.parse(params[:return_url]).path rescue nil
+      url = begin
+        URI.parse(params[:return_url]).path
+      rescue
+        nil
+      end
       return url if url
     end
 

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -90,7 +90,7 @@ module NavigationHelper
     end
     content_tag(:li, class: classes) do
       navigation_text = icon(icon_name) + label
-      concat(link_to(navigation_text, url, data: { disable_with: navigation_text }))
+      concat(link_to(navigation_text, url, data: { turbo_submits_with: navigation_text }))
       yield if block_given? && active
     end
   end
@@ -103,7 +103,7 @@ module NavigationHelper
   # link url equals the request url.
   def section_active?(url, active_for = [], inactive_for = [])
     current_page?(url) ||
-      Array(active_for).any? { |p| request.path =~ %r{/?#{p}/?} } &&
-      Array(inactive_for).none? { |p| request.path =~ %r{/?#{p}/?} }
+      (Array(active_for).any? { |p| request.path =~ %r{/?#{p}/?} } &&
+      Array(inactive_for).none? { |p| request.path =~ %r{/?#{p}/?} })
   end
 end

--- a/app/helpers/sheet/group.rb
+++ b/app/helpers/sheet/group.rb
@@ -58,10 +58,10 @@ module Sheet
     end
 
     tab 'groups.tabs.logs',
-      :group_log_path,
-      if: (lambda do |view, group|
-        view.can?(:log, group)
-      end)
+        :group_log_path,
+        if: (lambda do |view, group|
+          view.can?(:log, group)
+        end)
 
     tab 'groups.tabs.deleted',
         :deleted_subgroups_group_path,
@@ -103,7 +103,7 @@ module Sheet
 
     def breadcrumbs
       entry.parent.hierarchy.collect do |g|
-        link_to(g.to_s, group_path(g), data: { disable_with: g.to_s })
+        link_to(g.to_s, group_path(g), data: { turbo_submits_with: g.to_s })
       end
     end
 
@@ -116,7 +116,7 @@ module Sheet
     end
 
     def belongs_to
-      translate(:belongs_to).html_safe + # rubocop:disable Rails/OutputSafety
+      translate(:belongs_to).html_safe +
         FormatHelper::EMPTY_STRING +
         FormatHelper::EMPTY_STRING
     end

--- a/app/helpers/sheet/group/nav_left.rb
+++ b/app/helpers/sheet/group/nav_left.rb
@@ -103,7 +103,7 @@ module Sheet
         group_name   = sanitize(decorated.to_s, tags: %w(i))
 
         li + link_to(display_name, active_path(group),
-                     title: group_name, data: { disable_with: display_name })
+                     title: group_name, data: { turbo_submits_with: display_name })
       end
 
       def render_deleted_people_link
@@ -123,7 +123,7 @@ module Sheet
             l.use_hierarchy_from_parent(layer)
             content_tag(:li, class: l.archived_class) do
               link_to(l.display_name, active_path(l),
-                      title: l.to_s, data: { disable_with: l.display_name })
+                      title: l.to_s, data: { turbo_submits_with: l.display_name })
             end
           end
         end

--- a/app/helpers/sheet/tab.rb
+++ b/app/helpers/sheet/tab.rb
@@ -65,7 +65,7 @@ module Sheet
 
       def render(active = false)
         content_tag(:li,
-                    link_to(label, path, data: { disable_with: label }),
+                    link_to(label, path, data: { turbo_submits_with: label }),
                     class: active ? 'active' : nil)
       end
 

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,0 +1,9 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+
+// Configure Stimulus development experience
+application.debug = false
+window.Stimulus   = application
+
+export { application }

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.textContent = "Hello World!"
+  }
+}

--- a/app/javascript/javascripts/modules/auto_submit.js.coffee
+++ b/app/javascript/javascripts/modules/auto_submit.js.coffee
@@ -3,7 +3,7 @@
 $(document).on('change', '[data-submit]', (e) ->
   form = $(this).closest('form')
   if form.attr('method') == 'get'
-    Turbolinks.visit("#{form.attr('action')}?#{form.serialize()}", action: 'replace')
+    Turbo.visit("#{form.attr('action')}?#{form.serialize()}", action: 'replace')
   else
     form.submit()
 )

--- a/app/javascript/javascripts/modules/clear_input.js.coffee
+++ b/app/javascript/javascripts/modules/clear_input.js.coffee
@@ -21,5 +21,5 @@ class ClearInput
 
 new ClearInput().bind()
 
-$(document).on 'turbolinks:load', ->
+$(document).on 'turbo:load', ->
   $('.has-clear input').each((i, e) -> new ClearInput().toggleHide($(e)))

--- a/app/javascript/javascripts/modules/collapse_overflow_fix.js.coffee
+++ b/app/javascript/javascripts/modules/collapse_overflow_fix.js.coffee
@@ -1,4 +1,4 @@
-$(document).on('turbolinks:load', ->
+$(document).on('turbo:load', ->
   $('.collapse.in').addClass('shown')
 
   $('.collapse').on 'shown', () ->

--- a/app/javascript/javascripts/modules/element_swapper.js.coffee
+++ b/app/javascript/javascripts/modules/element_swapper.js.coffee
@@ -39,7 +39,7 @@ $(document).on('click', 'a[data-swap], button[data-swap]', new app.ElementSwappe
 # additional custom swap actions
 $(document).on('click', 'a[data-swap="person-fields"]', new app.ElementSwapper().resetRolePersonId)
 
-$(document).on 'turbolinks:load', ->
+$(document).on 'turbo:load', ->
   document.querySelectorAll('a[data-swap="person-fields"]').forEach (link) ->
     swapClass = link.dataset.swap
     hidden = link.closest('.' + swapClass + '[style*="display: none"], .' + swapClass + '[style*="display:none"]')

--- a/app/javascript/javascripts/modules/element_toggler.js.coffee
+++ b/app/javascript/javascripts/modules/element_toggler.js.coffee
@@ -37,7 +37,7 @@ $(document).on('change', 'input[data-hide]', (e) -> new app.ElementToggler(this)
 $(document).on('change', 'input[data-show]', (e) -> new app.ElementToggler(this).show())
 $(document).on('click', 'a[data-hide]', (e) -> new app.ElementToggler(this).toggle(e))
 
-$(document).on('turbolinks:load', ->
+$(document).on('turbo:load', ->
   # initialize visibility of checkbox controlled elements
   $('input[data-hide]').each((index, element) -> new app.ElementToggler(element).hide())
   $('input[data-show]').each((index, element) -> new app.ElementToggler(element).show())

--- a/app/javascript/javascripts/modules/events/course_description_handler.js.coffee
+++ b/app/javascript/javascripts/modules/events/course_description_handler.js.coffee
@@ -56,6 +56,6 @@ app.EventDescription = {
 
 $(document).on('change', 'select#event_kind_id', app.EventDescription.changeEventKind)
 $(document).on('click', '.standard-description-link', app.EventDescription.insertDescription)
-$(document).on('turbolinks:load', ->
+$(document).on('turbo:load', ->
   $('select#event_kind_id').each((i, e) ->
     app.EventDescription.enableDefaultLink($(e).val())))

--- a/app/javascript/javascripts/modules/help_texts.js.coffee
+++ b/app/javascript/javascripts/modules/help_texts.js.coffee
@@ -21,6 +21,6 @@ app.HelpTextForm = {
 $(document).on 'click', '.help-text-trigger', app.HelpTextToggler.toggle
 $(document).on 'change', '#help_text_context', app.HelpTextForm.syncSelectFields
 
-$(document).on 'turbolinks:load', () ->
+$(document).on 'turbo:load', () ->
   app.HelpTextToggler.hideAll()
   app.HelpTextForm.syncSelectFields()

--- a/app/javascript/javascripts/modules/input_enabler.js.coffee
+++ b/app/javascript/javascripts/modules/input_enabler.js.coffee
@@ -23,7 +23,7 @@ class app.InputEnabler
 $(document).on('change', 'input[data-disable]', (e) -> new app.InputEnabler(this).disable())
 $(document).on('change', 'input[data-enable]', (e) -> new app.InputEnabler(this).enable())
 
-$(document).on('turbolinks:load', ->
+$(document).on('turbo:load', ->
   # initialize disabled state of checkbox controlled elements
   $('input[data-disable]').each((index, element) -> new app.InputEnabler(element).disable())
   $('input[data-enable]').each((index, element) -> new app.InputEnabler(element).enable())

--- a/app/javascript/javascripts/modules/multiselect.js.coffee
+++ b/app/javascript/javascripts/modules/multiselect.js.coffee
@@ -27,7 +27,7 @@ app.Multiselect = {
 }
 
 $(document).on('change', 'table[data-checkable=true] input[type=checkbox]', app.Multiselect.toggleActions)
-$(document).on('turbolinks:load', ->
+$(document).on('turbo:load', ->
   app.Multiselect.toggleActions
 )
 

--- a/app/javascript/javascripts/modules/notes.js.coffee
+++ b/app/javascript/javascripts/modules/notes.js.coffee
@@ -28,7 +28,7 @@ app.Notes = {
 }
 
 
-$(document).on('turbolinks:load', ->
+$(document).on('turbo:load', ->
   $('#notes-new-button').on('click', app.Notes.focus)
   $('#notes-form .cancel').on('click', new app.ElementSwapper().swap)
   $('#notes-form .cancel').on('click', ->

--- a/app/javascript/javascripts/modules/on_page_load.js.coffee
+++ b/app/javascript/javascripts/modules/on_page_load.js.coffee
@@ -1,6 +1,6 @@
 # trigger remote elements on page load
 
-$(document).on('turbolinks:load', ->
+$(document).on('turbo:load', ->
   document.querySelectorAll('[data-remote][data-on-page-load]').forEach (elem) ->
     $.rails.handleRemote($(elem))
 )

--- a/app/javascript/javascripts/modules/people/people_filter_role_toggle.js.coffee
+++ b/app/javascript/javascripts/modules/people/people_filter_role_toggle.js.coffee
@@ -34,7 +34,7 @@ $(document).on('change', 'input#range_deep', (e) -> showAllGroups(e.target))
 $(document).on('change', 'input#range_layer', (e) -> showSameLayerGroups(e.target))
 $(document).on('change', 'input#range_group', (e) -> showSameGroup(e.target))
 
-$(document).on('turbolinks:load', ->
+$(document).on('turbo:load', ->
   $('input#range_deep').each((i, e) -> showAllGroups(e))
   $('input#range_layer').each((i, e) -> showSameLayerGroups(e))
   $('input#range_group').each((i, e) -> showSameGroup(e))

--- a/app/javascript/javascripts/modules/remote_autocomplete.js
+++ b/app/javascript/javascripts/modules/remote_autocomplete.js
@@ -173,7 +173,7 @@ import { mark } from "@tarekraafat/autocomplete.js/src/helpers/io";
     return nel;
   };
 
-  $(document).on("turbolinks:load", function() {
+  $(document).on("turbo:load turbo:frame-load", function() {
     app.setupQuicksearch();
     $("[data-provide=entity]").each(app.setupEntityTypeahead);
     $("[data-provide=typeahead]").each(app.setupStaticTypeahead);
@@ -181,5 +181,6 @@ import { mark } from "@tarekraafat/autocomplete.js/src/helpers/io";
       return $(this).attr("autocomplete", "off");
     });
   });
+
 
 }).call(this);

--- a/app/javascript/javascripts/modules/tom_select.js
+++ b/app/javascript/javascripts/modules/tom_select.js
@@ -33,7 +33,7 @@
     return element.nodeName === "INPUT" || element.nodeName === "SELECT" && element.getAttribute("multiple")
   }
 
-  $(document).on('turbolinks:load', function() {
+  $(document).on('turbo:load', function() {
     // enable tom-select
     document.querySelectorAll(".tom-select").forEach(app.activateTomSelect);
   });

--- a/app/javascript/javascripts/modules/tooltips.js.coffee
+++ b/app/javascript/javascripts/modules/tooltips.js.coffee
@@ -3,8 +3,8 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
-# only bind events for non-document elements in turbolinks:load
-$(document).on('turbolinks:load', ->
+# only bind events for non-document elements in turbo:load
+$(document).on('turbo:load', ->
   # wire up tooltips
-  $(document).tooltip({ selector: '[rel^=tooltip]', placement: 'right' })
+  # $(document).tooltip({ selector: '[rel^=tooltip]', placement: 'right' })
 )

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -23,9 +23,7 @@ import 'regenerator-runtime/runtime';
  */
 import 'jquery';
 import Rails from 'jquery-ujs';
-// Rails.start();
 import 'moment'; // used by events/date_period_validator.js.coffee
-import 'jquery.turbolinks/vendor/assets/javascripts/jquery.turbolinks';
 
 // jQuery UI
 import 'jquery-ui/ui/widgets/datepicker';
@@ -41,7 +39,7 @@ import 'bootstrap/js/src/button'
 import 'bootstrap/js/src/collapse'
 import 'bootstrap/js/src/dropdown'
 import 'bootstrap/js/src/modal'
-import 'bootstrap/js/src/popover'
+import  Popover  from 'bootstrap/js/src/popover'
 import 'bootstrap/js/src/scrollspy'
 import 'bootstrap/js/src/tab'
 // import 'bootstrap/js/src/toast'
@@ -64,9 +62,16 @@ import "controllers";
 
 // Custom scripts from all wagons
 import '../javascripts/wagons';
+import '@hotwired/turbo-rails';
 
-import * as turbolinks from 'turbolinks';
-turbolinks.start();
+import { Application } from "@hotwired/stimulus"
+import { Turbo } from "@hotwired/turbo-rails"
+
+const application = Application.start()
+// application.debug = true
+window.Stimulus   = application
+window.Popover = Popover
+
 
 /**
  * Images

--- a/app/javascript/stylesheets/hitobito/_main.scss
+++ b/app/javascript/stylesheets/hitobito/_main.scss
@@ -36,7 +36,7 @@
 @import "./modules/profil";
 @import "./modules/step_wizard";
 @import "./modules/totp";
-@import "./modules/turbolink_progress_bar";
+@import "./modules/turbo_progress_bar";
 @import "./modules/ui-datepicker";
 @import "./modules/typeahead";
 @import "./modules/well";

--- a/app/javascript/stylesheets/hitobito/modules/_turbo_progress_bar.scss
+++ b/app/javascript/stylesheets/hitobito/modules/_turbo_progress_bar.scss
@@ -1,5 +1,5 @@
 
-html.turbolinks-progress-bar::before {
+.turbo-progress-bar {
   background-color: $body-background !important;
   height: 2px !important;
 }

--- a/app/views/devise/sessions/_form.html.haml
+++ b/app/views/devise/sessions/_form.html.haml
@@ -6,9 +6,9 @@
 - form_url = params[:oauth] == 'true' ? person_session_path(oauth: true) : person_session_path
 - autofocus_login = true if autofocus_login.nil?
 
-= standard_form(resource, {url: form_url, stacked: true}) do |f|
+= standard_form(resource, {url: form_url, stacked: true, data: { turbo: false }}) do |f|
   = f.error_messages
-  = f.labeled_input_field(:login_identity, autocomplete: "login", autofocus: autofocus_login, label: t('.login_identity'), class: 'mw-100 mw-md-60ch ')
+  = f.labeled_input_field(:login_identity, autocomplete: "login", autofocus: autofocus_login, label: t('.login_identity'), class: 'mw-100 mw-md-60ch')
   = f.labeled_input_field(:password)
   = f.labeled_boolean_field(:remember_me)
   = f.indented(submit_button(f, t('.sign_in')))

--- a/app/views/event/application_market/_waiting_list_link.html.haml
+++ b/app/views/event/application_market/_waiting_list_link.html.haml
@@ -11,5 +11,5 @@
 
   - else
     .popover-small
-      %a{ title: t('.title_inactive'), data: { bs_toggle: 'popover', bs_content: render('popover_waiting_list', p: p).to_str.html_safe }}
+      %a{ title: t('.title_inactive'), data: { bs_toggle: 'popover', bs_content: render('popover_waiting_list', p: p).to_str.html_safe, bs_html: 'true' }}
         = "#{icon(:minus)}&nbsp; #{t('.label')}".html_safe

--- a/app/views/event/application_market/index.html.haml
+++ b/app/views/event/application_market/index.html.haml
@@ -18,7 +18,7 @@
   .col-3
     %span#booking_info= event.booking_info
 
-#main.row
+#main.row{data: { turbo: 'false' }}
   %article.col-6
     %h2= t('.assigned_participants')
     %p.pt-1.mb-3

--- a/app/views/event/lists/_nav_left_events.html.haml
+++ b/app/views/event/lists/_nav_left_events.html.haml
@@ -2,4 +2,4 @@
   - @grouped_events.keys.collect(&:split).group_by(&:last).each do |year, months|
     %li.divider= year
     - months.each do |month, year|
-      %li= link_to(month, "##{"#{month} #{year}".parameterize}", data: { turbolinks: false })
+      %li= link_to(month, "##{"#{month} #{year}".parameterize}", data: { turbo: false })

--- a/app/views/event/qualifications/index.html.haml
+++ b/app/views/event/qualifications/index.html.haml
@@ -12,4 +12,4 @@
   .btn-group
     = button_tag(t('event.qualifications.index.save'),
                  class: 'btn btn-sm btn-primary',
-                 data: { disable_with: t('event.qualifications.index.save') })
+                 data: { turbo_submits_with: t('event.qualifications.index.save') })

--- a/app/views/events/courses/_nav_left.html.haml
+++ b/app/views/events/courses/_nav_left.html.haml
@@ -3,23 +3,23 @@
     - if kind_categories_used?
       - @categories.each do |category|
         %li
-          = link_to(category.to_s, set_filter(category: category.id), data: { turbolinks: false })
+          = link_to(category.to_s, set_filter(category: category.id), data: { turbo: false })
 
           - if @kind_category_id == category.id.to_s
             %ul
               - category.kinds.each do |kind|
-                %li= link_to(kind.label, set_filter(category: category.id, anchor: kind.label.parameterize), data: { turbolinks: false })
+                %li= link_to(kind.label, set_filter(category: category.id, anchor: kind.label.parameterize), data: { turbo: false })
       %li
-        = link_to(t('event.lists.courses.no_category'), set_filter(category: 0), data: { turbolinks: false })
+        = link_to(t('event.lists.courses.no_category'), set_filter(category: 0), data: { turbo: false })
 
         - if @kind_category_id == '0'
           %ul
             - @kinds_without_category.each do |kind|
-              %li= link_to(kind.label, set_filter(category: 0, anchor: kind.label.parameterize), data: { turbolinks: false })
+              %li= link_to(kind.label, set_filter(category: 0, anchor: kind.label.parameterize), data: { turbo: false })
 
     - else
       - @grouped_events.keys.each do |kind|
-        %li= link_to(kind, "##{kind.parameterize}", data: { turbolinks: false })
+        %li= link_to(kind, "##{kind.parameterize}", data: { turbo: false })
   - else
     = render 'event/lists/nav_left_events'
 

--- a/app/views/groups/self_registration/_form.html.haml
+++ b/app/views/groups/self_registration/_form.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito_sac_cas.
 
-= standard_form(entry, url: group_self_registration_path) do |f|
+= standard_form(entry, url: group_self_registration_path, data: { turbo: 'false' }) do |f|
   = render 'fields', f: f
 
 - if entry.first_step?

--- a/app/views/invoices/_actions_index.html.haml
+++ b/app/views/invoices/_actions_index.html.haml
@@ -7,7 +7,7 @@
 - if entries.present?
   .mt-3
     = invoice_sending_dropdown
-    = action_button(t('invoices.cancel'), group_invoice_list_path(group, invoice_list_id: invoice_list&.id), :'trash-alt', method: :delete, data: { checkable: true })
+    = action_button(t('invoices.cancel'), group_invoice_list_path(group, invoice_list_id: invoice_list&.id), :'trash-alt', 'data-method': :delete, data: { checkable: true })
     = invoices_export_dropdown
     = invoices_print_dropdown
 

--- a/app/views/invoices/_actions_show.html.haml
+++ b/app/views/invoices/_actions_show.html.haml
@@ -11,5 +11,4 @@
 
 - if entry.payable?
   = action_button(t('crud.new.title', model: Payment.model_name.human),
-    '#', :plus, { data: { turbolinks: false, bs_toggle: 'collapse', bs_target: '#payment' } })
-
+    '#', :plus, { data: { turbo: false, toggle: 'collapse', target: '#payment' } })

--- a/app/views/layouts/_file_download.html.haml
+++ b/app/views/layouts/_file_download.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-#file-download-spinner.d-none{"data-turbolinks-permanent" => ""}
+#file-download-spinner.hidden{"data-turbo-permanent" => ""}
   .info-bar
     .alert.alert-info
       = image_pack_tag('spinner.gif', size: '16x16', class: 'spinner')

--- a/app/views/layouts/_languages.html.haml
+++ b/app/views/layouts/_languages.html.haml
@@ -1,7 +1,7 @@
 - languages = Settings.application.languages.to_hash
 - if languages.size > 1
-  -# no turbolinks to switch lang attribute in html tag
-  .lang{'data-no-turbolink' => true}
+  -# no turbo to switch lang attribute in html tag
+  .lang{'data-no-turbo' => true}
     - languages.each do |lang, label|
       = link_to lang.upcase,
                 url_for(params.to_unsafe_h.merge(locale: lang, only_path: true)),

--- a/app/views/layouts/_nav.html.haml
+++ b/app/views/layouts/_nav.html.haml
@@ -17,4 +17,4 @@
       %li= link_to current_user, person_home_path(current_user)
       %li.divider
       = render 'layouts/languages'
-      %li= link_to t('.sign_out'), sign_out_path, method: "delete"
+      %li= link_to t('.sign_out'), sign_out_path, 'data-method': :delete

--- a/app/views/layouts/_synchronization.html.haml
+++ b/app/views/layouts/_synchronization.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-#synchronization-spinner.d-none{"data-turbolinks-permanent" => ""}
+#synchronization-spinner.hidden{"data-turbo-permanent" => ""}
   .info-bar
     .alert.alert-info
       = image_pack_tag('spinner.gif', size: '16x16', class: 'spinner')

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,16 +10,17 @@
     %meta{charset: 'utf-8'}
     %title= "#{Settings.application.name} - #{title}"
     %meta{name: 'viewport', content: 'width=device-width, initial-scale=1.0'}
-    %meta{name: 'turbolinks-cache-control', content: 'no-cache'}
+    %meta{name: 'turbo-cache-control', content: 'no-cache'}
+    %meta{name: 'turbo-prefetch', content: 'false'}
 
     = csrf_meta_tag
     = wagon_favicon_pack_tag 'favicon.ico'
 
-    = stylesheet_pack_tag 'application', media: 'screen', 'data-turbolinks-track': true
+    = stylesheet_pack_tag 'application', media: 'screen', 'data-turbo-track': true
     = stylesheet_pack_tag 'print', media: 'print'
     - if Rails.env.test?
       = stylesheet_pack_tag 'disable_animations'
-    = javascript_pack_tag 'application', 'data-turbolinks-track': true
+    = javascript_pack_tag 'application', 'data-turbo-track': true
 
     = yield(:head)
 
@@ -47,7 +48,7 @@
             - else
               = render 'layouts/languages'
             = link_to current_user, person_home_path(current_user), class: 'd-none d-md-block'
-            = link_to t('layouts.nav.sign_out'), sign_out_path, method: "delete", class: 'd-none d-md-block'
+            = link_to t('layouts.nav.sign_out'), sign_out_path, 'data-method': :delete, class: 'd-none d-md-block'
           - elsif current_user.nil? # nil without login, false on error
             = render 'layouts/unauthorized'
 

--- a/app/views/layouts/oauth.html.haml
+++ b/app/views/layouts/oauth.html.haml
@@ -5,15 +5,15 @@
     %meta{charset: 'utf-8'}
     %title= "#{Settings.application.name} - #{title}"
     %meta{name: 'viewport', content: 'width=device-width, initial-scale=1.0'}
-    %meta{name: 'turbolinks-cache-control', content: 'no-cache'}
+    %meta{name: 'turbo-cache-control', content: 'no-cache'}
 
     = csrf_meta_tag
     = wagon_favicon_pack_tag 'favicon.ico'
 
-    = stylesheet_pack_tag 'oauth', media: 'screen', 'data-turbolinks-track': true
+    = stylesheet_pack_tag 'oauth', media: 'screen', 'data-turbo-track': true
     - if Rails.env.test?
       = stylesheet_pack_tag 'disable_animations'
-    = javascript_pack_tag 'application', 'data-turbolinks-track': true
+    = javascript_pack_tag 'application', 'data-turbo-track': true
 
     = yield(:head)
 

--- a/app/views/people/_actions_show.html.haml
+++ b/app/views/people/_actions_show.html.haml
@@ -20,5 +20,5 @@
   = action_button(t('.impersonate_user'),
                   group_person_impersonate_path(parent, entry),
                   nil,
-                  method: :post,
+                  data: { method: :post },
                   title: t('.impersonate_user_tooltip'))

--- a/app/views/person/security_tools/index.html.haml
+++ b/app/views/person/security_tools/index.html.haml
@@ -140,7 +140,7 @@
   = spinner(true)
 
 :javascript
-  $(document).ready(function() {
+  $(document).on('turbo:load', () => {
     $('#roles-that-see-me-spinner').hide()
     $('#roles-that-see-me-load-button').on('click', (e) => {
       $(e.target).hide()

--- a/app/views/person/tags/_tag.html.haml
+++ b/app/views/person/tags/_tag.html.haml
@@ -3,7 +3,6 @@
   - if can?(:manage_tags, person)
     = link_to icon(:times),
               group_person_tags_path(person_id: person.id, name: tag.name),
-              method: :delete,
-              data: { tag_id: tag.id },
+              data: { tag_id: tag.id, method: :delete },
               remote: true,
               class: 'person-tag-remove'

--- a/app/views/public_events/show.html.haml
+++ b/app/views/public_events/show.html.haml
@@ -5,7 +5,7 @@
 
 - title entry.to_s
 
-#main
+#main{data: { turbo: 'false' }}
   .row
     %article.col-lg-7
       = render 'attrs_primary'

--- a/app/views/second_factor_authentication/_form.html.haml
+++ b/app/views/second_factor_authentication/_form.html.haml
@@ -3,7 +3,7 @@
 -# or later. See the COPYING file at the top-level directory or at
 -# https ://github.com/hitobito/hitobito.
 
-= form_with url: users_second_factor_path(second_factor: authentication_factor), method: :post, class: 'form-horizontal' do |f|
+= form_with url: users_second_factor_path(second_factor: authentication_factor), data: { turbo: false }, method: :post, class: 'form-horizontal' do |f|
   .control-group.required
     = f.label :second_factor_code, t('.totp_code'), class: 'control-label col-2'
     %div.col-sm-8.col-md-7.col-lg-6.col-xl-5.col-xxl-3

--- a/app/views/table_displays/create.js.haml
+++ b/app/views/table_displays/create.js.haml
@@ -1,1 +1,1 @@
-Turbolinks.visit(window.location.pathname + window.location.search);
+Turbo.visit(window.location.pathname + window.location.search);

--- a/config/application.rb
+++ b/config/application.rb
@@ -99,6 +99,9 @@ module Hitobito
       config.logger = ActiveSupport::TaggedLogging.new(logger)
     end
 
+    config.responders.error_status = :unprocessable_entity
+    config.responders.redirect_status = :see_other
+
     config.generators do |g|
       g.test_framework :rspec, fixture: true
     end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,6 @@
 development:
-  adapter: async
+  adapter: redis
+  url: redis://localhost:6379/1
 
 test:
   adapter: test

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,6 +8,8 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
@@ -283,13 +285,6 @@ Devise.setup do |config|
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
-
-  # ==> Turbolinks configuration
-  # If your app is using Turbolinks, Turbolinks::Controller needs to be included to make redirection work correctly:
-  #
-  # ActiveSupport.on_load(:devise_failure_app) do
-  #   include Turbolinks::Controller
-  # end
 
   # ==> Configuration for :registerable
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.14.0",
+    "@hotwired/stimulus": "^3.2.2",
+    "@hotwired/turbo-rails": "^8.0.2",
     "@popperjs/core": "^2.11.6",
     "@rails/actiontext": "^6.0.3-3",
     "@rails/webpacker": "5.4.3",
@@ -19,7 +21,6 @@
     "jquery": "~1.12.4",
     "jquery-ui": "~1.13.2",
     "jquery-ujs": "~1.2.2",
-    "jquery.turbolinks": "~2.1.0",
     "js-cookie": "~2.2.0",
     "moment": "~2.29.4",
     "rails-erb-loader": "^5.5.2",
@@ -27,8 +28,7 @@
     "sass": "^1.49.7",
     "stimulus": "^3.2.2",
     "tom-select": "^2.2.2",
-    "trix": "^1.2.0",
-    "turbolinks": "~5.0.1"
+    "trix": "^1.2.0"
   },
   "devDependencies": {
     "@webpack-cli/serve": "^1.6.1",

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -951,7 +951,7 @@ describe PeopleController do
 
       it 'can delete person' do
         delete :destroy, params: { group_id: member.primary_group.id, id: member.id }
-        expect(response.status).to eq(302)
+        expect(response).to redirect_to(group_people_path(member.primary_group_id, returning: true))
       end
 
       it 'deletes person' do

--- a/spec/controllers/person_duplicates/ignore_controller_spec.rb
+++ b/spec/controllers/person_duplicates/ignore_controller_spec.rb
@@ -45,7 +45,7 @@ describe PersonDuplicates::IgnoreController do
       it 'ignores duplicate entry' do
         sign_in(layer_leader)
 
-        post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id }
+        post :create, params: { group_id: layer.id, id: duplicate_entry.id }
 
         expect(response).to redirect_to(group_person_duplicates_path(layer))
 

--- a/spec/controllers/person_duplicates/merge_controller_spec.rb
+++ b/spec/controllers/person_duplicates/merge_controller_spec.rb
@@ -40,7 +40,7 @@ describe PersonDuplicates::MergeController do
       it 'merges duplicate entry' do
         sign_in(layer_leader)
 
-        post :create, xhr: true, params: { group_id: layer.id, id: duplicate_entry.id, person_duplicate: { dst_person: 'person_2' }}
+        post :create, params: { group_id: layer.id, id: duplicate_entry.id, person_duplicate: { dst_person: 'person_2' }}
 
         expect(PersonDuplicate.where(id: duplicate_entry.id)).not_to exist
         expect(Person.where(id: person_1.id)).not_to exist

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -353,7 +353,7 @@ describe RolesController do
         expect do
           put :update, params: { group_id: group.id, id: role.id, role: { delete_on: yesterday } }
         end.to change { Role.count }.by(-1)
-        expect(response).to redirect_to(person_path(person))
+        expect(response).to redirect_to(person_path(person, format: :html))
         expect(flash[:notice]).to eq "Rolle <i>Member (bis #{yesterday.strftime('%d.%m.%Y')})</i> für <i>#{person}</i> in <i>TopGroup</i> wurde erfolgreich gelöscht."
       end
 

--- a/spec/features/email_verification_spec.rb
+++ b/spec/features/email_verification_spec.rb
@@ -40,6 +40,7 @@ describe 'Email verification', js: true do
       fill_in 'E-Mail', with: 'test@example.com'
       expect do
         first(:button, 'Speichern').click
+        expect(page).to have_content 'Person Bottom Member wurde erfolgreich aktualisiert.'
       end.to change { person.reload.email }.to('test@example.com')
       is_expected.not_to have_text('E-Mail-Adresse muss noch bestätigt werden')
     end
@@ -81,8 +82,8 @@ describe 'Email verification', js: true do
       fill_in 'E-Mail', with: 'test@example.com'
       expect do
         first(:button, 'Speichern').click
+        is_expected.to have_text('E-Mail-Adresse muss noch bestätigt werden')
       end.not_to change { person.reload.email }
-      is_expected.to have_text('E-Mail-Adresse muss noch bestätigt werden')
     end
   end
 
@@ -99,7 +100,6 @@ describe 'Email verification', js: true do
       fill_in 'person_login_identity', with: person.email
       fill_in 'person_password', with: password
       click_button 'Anmelden'
-
       is_expected.to have_text('Du musst Deinen Account bestätigen, bevor Du fortfahren kannst.')
     end
   end
@@ -119,6 +119,7 @@ describe 'Email verification', js: true do
         fill_in 'Neues Passwort', with: password
         fill_in 'Neues Passwort bestätigen', with: password
         click_button 'Passwort ändern'
+        expect(page).to have_content 'Dein Passwort wurde geändert.'
       end.to change { person.reload.confirmed_at }.from(nil)
     end
 
@@ -130,6 +131,7 @@ describe 'Email verification', js: true do
         fill_in 'Neues Passwort', with: password
         fill_in 'Neues Passwort bestätigen', with: password
         click_button 'Passwort ändern'
+        expect(page).to have_content 'Dein Passwort wurde geändert.'
       end.not_to change { person.reload.confirmed_at }.from(nil)
     end
   end
@@ -148,6 +150,7 @@ describe 'Email verification', js: true do
         fill_in 'Neues Passwort', with: password
         fill_in 'Neues Passwort bestätigen', with: password
         click_button 'Passwort ändern'
+        expect(page).to have_content 'Dein Passwort wurde geändert.'
       end.to change { person.reload.confirmed_at }.from(nil)
     end
 
@@ -165,6 +168,7 @@ describe 'Email verification', js: true do
         fill_in 'Neues Passwort', with: password
         fill_in 'Neues Passwort bestätigen', with: password
         click_button 'Passwort ändern'
+        expect(page).to have_content 'Dein Passwort wurde geändert.'
       end.not_to change { person.reload.confirmed_at }.from(nil)
     end
   end
@@ -191,6 +195,7 @@ describe 'Email verification', js: true do
         fill_in 'Neues Passwort', with: password
         fill_in 'Neues Passwort bestätigen', with: password
         click_button 'Passwort ändern'
+        expect(page).to have_content 'Dein Passwort wurde geändert.'
       end.not_to change { person.reload.email }
     end
 
@@ -213,6 +218,7 @@ describe 'Email verification', js: true do
         fill_in 'Neues Passwort', with: password
         fill_in 'Neues Passwort bestätigen', with: password
         click_button 'Passwort ändern'
+        expect(page).to have_content 'Dein Passwort wurde geändert.'
       end.not_to change { person.reload.email }
     end
   end

--- a/spec/features/event/application_market_controller_spec.rb
+++ b/spec/features/event/application_market_controller_spec.rb
@@ -180,6 +180,7 @@ describe Event::ApplicationMarketController do
 
           find('#waiting_list').set(true)
           click_button('Aktualisieren')
+          expect(page).to have_css('#applications tr', count: 2)
 
           participants = find('#participants').text
           applications = find('#applications').text
@@ -272,6 +273,7 @@ describe Event::ApplicationMarketController do
     it 'may be closed with cancel link' do
       sign_in
       visit group_event_application_market_index_path(group.id, event.id)
+      sleep 0.1 # wait for popover to be setup
 
       appl1_id = "event_participation_#{appl_prio_1.id}"
       expect(page).to have_selector("#applications ##{appl1_id} td .fa-minus")

--- a/spec/features/invoice_lists/destroys_controller_spec.rb
+++ b/spec/features/invoice_lists/destroys_controller_spec.rb
@@ -43,8 +43,8 @@ describe InvoiceLists::DestroysController, js: true do
 
       expect do
         modal.find('button[type="submit"]').click
+        expect(page).to have_css('#flash .alert-success', text: "Sammelrechnung membership fee wurde erfolgreich gelöscht.")
       end.to change { InvoiceList.count }.by(-1)
-      expect(page).to have_css('#flash .alert-success', text: "Sammelrechnung membership fee wurde erfolgreich gelöscht.")
     end
   end
 

--- a/spec/features/messages_spec.rb
+++ b/spec/features/messages_spec.rb
@@ -88,6 +88,7 @@ describe :messages, js: true do
       fill_in_trix_editor 'message_body', with: Faker::Lorem.sentences.join
       expect do
         click_button('Speichern')
+        expect(page).to have_content 'Letter with love wurde erfolgreich erstellt.'
       end.to change { Message::Letter.count }.by(1)
 
       is_expected.to have_selector('a', text: 'Druckauftrag erstellen')
@@ -98,6 +99,7 @@ describe :messages, js: true do
       fill_in 'Beschreibung', with: 'Paper: A4, portrait, extra thick'
       expect do
         all('button', text: 'Speichern').first.click
+        expect(page).to have_content 'Print print print! wurde erfolgreich erstellt.'
       end.to change { printer.assignments.count }.by(1)
 
       is_expected.to have_selector('a', text: 'Anhang')

--- a/spec/features/roles/future_roles_spec.rb
+++ b/spec/features/roles/future_roles_spec.rb
@@ -49,12 +49,11 @@ describe 'Future Roles behaviour', js: :true do
       fill_in 'Bis', with: yesterday
       expect do
         first(:button, 'Speichern').click
+        expect(page).to have_content "Rolle Member (bis #{I18n.l(yesterday)}) für Bottom Member in " \
+          'Bottom One wurde erfolgreich gelöscht.'
       end.to change { bottom_member.roles.with_deleted.count }.by(1)
-      expect(page).to have_content "Rolle Member (bis #{I18n.l(yesterday)}) für Bottom Member in " \
-        'Bottom One wurde erfolgreich gelöscht.'
     end
   end
-
 
   describe 'group bottom_members list' do
     it 'hides pill if no future roles exist' do
@@ -172,6 +171,8 @@ describe 'Future Roles behaviour', js: :true do
       fill_in 'Von', with: tomorrow
       expect do
         first(:button, 'Speichern').click
+        expect(page).to have_content "Rolle Member (ab #{I18n.l(tomorrow)}) für Bottom Member in " \
+          'Bottom One wurde erfolgreich erstellt.'
       end.to change { bottom_member.roles.count }.by(1)
 
       role = bottom_member.roles.last
@@ -203,6 +204,7 @@ describe 'Future Roles behaviour', js: :true do
       expect do
         click_on 'Speichern'
         expect(page).not_to have_css '.popover'
+        expect(page).to have_text 'Leader (ab'
       end.to change { existing_role_attrs[:convert_to] }
         .from(role_type).to('Group::TopGroup::Leader')
         .and(not_change { existing_role_attrs[:convert_on] })

--- a/spec/features/roles_controller_spec.rb
+++ b/spec/features/roles_controller_spec.rb
@@ -30,7 +30,7 @@ describe RolesController, js: true do
 
     before do
       sign_in(top_leader)
-      visit group_person_path(bottom_layer, bottom_member)
+      visit group_person_path(group_id: bottom_layer.id, id: bottom_member.id)
       click_on 'Rolle hinzufügen'
       choose_role 'Member'
     end
@@ -40,9 +40,9 @@ describe RolesController, js: true do
       fill_in 'Bis', with: yesterday
       expect do
         first(:button, 'Speichern').click
+        expect(page).to have_content "Rolle Member (bis #{I18n.l(yesterday)}) für Bottom Member in " \
+          'Bottom One wurde erfolgreich gelöscht.'
       end.to change { bottom_member.roles.with_deleted.count }.by(1)
-      expect(page).to have_content "Rolle Member (bis #{I18n.l(yesterday)}) für Bottom Member in " \
-        'Bottom One wurde erfolgreich gelöscht.'
     end
 
     it 'hard deletes role if bis in the past and not valid for archive' do
@@ -135,9 +135,8 @@ describe RolesController, js: true do
       page.find('ul[role="listbox"] li[role="option"]').click
 
       all('form .btn-group').first.click_button 'Speichern'
-
-      expect(current_path).to eq(group_people_path(group))
       is_expected.to have_content 'Rolle Leader für Top Leader in TopGroup wurde erfolgreich erstellt.'
+      expect(current_path).to eq(group_people_path(group))
     end
   end
 
@@ -214,8 +213,8 @@ describe RolesController, js: true do
       # save
       all('form .btn-group').first.click_button 'Speichern'
 
-      expect(current_path).to eq(group_people_path(groups(:toppers)))
       is_expected.to have_content 'Rolle Member für Top Leader in Toppers wurde erfolgreich erstellt.'
+      expect(current_path).to eq(group_people_path(groups(:toppers)))
     end
   end
 

--- a/spec/features/subscriber_lists_controller_spec.rb
+++ b/spec/features/subscriber_lists_controller_spec.rb
@@ -35,6 +35,7 @@ describe Subscriber::SubscriberListsController, js: true do
 
     expect do
       find('button', text: 'Hinzufügen').click
+      expect(page).to have_content "2 Personen wurden erfolgreich zum Abo 'Newsletter' hinzugefügt"
     end.to change { Subscription.count }.by(2)
 
     is_expected.to have_text("2 Personen wurden erfolgreich zum Abo 'Newsletter' hinzugefügt")

--- a/spec/regressions/roles_controller_spec.rb
+++ b/spec/regressions/roles_controller_spec.rb
@@ -113,7 +113,7 @@ describe RolesController, type: :controller do
         role: { group_id: group.id, person_id: person.id }
       }
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:unprocessable_entity)
       is_expected.to render_template('create')
       expect(response.body).to include('alert')
     end

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,6 +925,19 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
   integrity sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==
 
+"@hotwired/turbo-rails@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-8.0.2.tgz#c43d54d9346bcf14c897166556bfed92ed4c1d17"
+  integrity sha512-j+6THPc+CsaUdUXZTg6wQ+YcStO9kn6CuGzElqFxUmV/vyd1Jfm0RLZMIbaY8w9Qse7u6JBcrm4AcRxhIhYmaQ==
+  dependencies:
+    "@hotwired/turbo" "^8.0.2"
+    "@rails/actioncable" "^7.0"
+
+"@hotwired/turbo@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.2.tgz#c31cdadfe66b98983066a94073b26fc7e15835f0"
+  integrity sha512-3K6QZkwWfosAV8zuM5bY+kKF02jp1lMQGsWfSE6wXdZBRBP3ah+Vj26YNqYtkEomBwRWA0QKhZgyJP7xOQkVEg==
+
 "@npmcli/fs@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.1.0.tgz#bec1d1b89c170d40e1b73ad6c943b0b75e7d2951"
@@ -957,6 +970,11 @@
   version "2.11.6"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
+
+"@rails/actioncable@^7.0":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.1.3.tgz#4db480347775aeecd4dde2405659eef74a458881"
+  integrity sha512-ojNvnoZtPN0pYvVFtlO7dyEN9Oml1B6IDM+whGKVak69MMYW99lC2NOWXWeE3bmwEydbP/nn6ERcpfjHVjYQjA==
 
 "@rails/actiontext@^6.0.3-3":
   version "6.1.4"
@@ -3911,11 +3929,6 @@ jquery-ujs@~1.2.2:
   resolved "https://registry.yarnpkg.com/jquery-ujs/-/jquery-ujs-1.2.3.tgz#dcac6026ab7268e5ee41faf9d31c997cd4ddd603"
   integrity sha512-59wvfx5vcCTHMeQT1/OwFiAj+UffLIwjRIoXdpO7Z7BCFGepzq9T9oLVeoItjTqjoXfUrHJvV7QU6pUR+UzOoA==
 
-jquery.turbolinks@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/jquery.turbolinks/-/jquery.turbolinks-2.1.0.tgz#36036bb997c48d53bceb345521fbdf7da887a62c"
-  integrity sha1-NgNruZfEjVO86zRVIfvffaiHpiw=
-
 "jquery@>=1.8.0 <4.0.0", jquery@~1.12.4:
   version "1.12.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
@@ -6720,11 +6733,6 @@ tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
-
-turbolinks@~5.0.1:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.0.3.tgz#c8ce128cfc9be1d691a1e41ffa858a5a5ee86a02"
-  integrity sha1-yM4SjPyb4daRoeQf+oWKWl7oagI=
 
 type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
Gems und node packages sind aktualisiert, das binding an die events anpepasst. 

Wir verwenden weiterhin jquery/ujs, das erlaubt und weiterhin rjs (js.haml) format sowie die alten data attributes (`data-remote`, `data-method`) zu verwenden. 

Die Erwartung ist, dass Turbo grundsätzlich aktiviert ist, und bei Bedarf abgeschalten wird (`data-turbo: false`) und somit der code weitestgehend wie bisher weiterverwendet werden kann, wir allerdings die möglichkeit haben, weiter turbo features (frames, streams) zu verwenden.

Behobene Problemstellen

- [x] tags (Invalid authenticity token via entfernen von `remote: true` behoben)
- [x] Flash message bei login ohne PW  (via devise upgrade behoben)
- [x] haushalte
- [x] Rollen popovers bei der personen Liste (sollte wahrscheinlich als js behandelt werden)
- [x] Merge (Missing request format)
- [x] multiselect bei personen liste
- [x] Volltext suche
- [x] Rechnungen (gesamt beträge rechnen)
- [x] Kurszuteilung (application market)
