### PR TITLE
Setup TOTP for local dev-admins

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -47,6 +47,8 @@ namespace :dev do
     desc 'Create a local user with admin-permissions'
     task admin: :environment do
       abort('This is for development purposes only.') unless Rails.env.development?
+      abort('This needs at least one wagon to work') if Wagons.all.blank?
+      abort('This needs a group-structure to work') if Group.subclasses.blank?
 
       username = 'tester@example.net'
       password = 'hitobito is the best software to manage people in complex group hierachies'

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2019-2023, Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2019-2024, Pfadibewegung Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_pbs.
@@ -11,7 +11,7 @@ namespace :dev do
     desc 'Obtain oauth access token'
     task :token, [:application_id, :redirect_uri, :code] => [:environment] do |_, args|
       app = Oauth::Application.find(args.fetch(:application_id))
-      sh <<-BASH.strip_heredoc
+      sh <<~BASH
         curl -v -H 'Accept: application/json' -X POST -d 'grant_type=authorization_code'  \
         -d 'client_id=#{app.uid}' -d 'client_secret=#{app.secret}' \
         -d 'redirect_uri=#{args.fetch(:redirect_uri)}' -d 'code=#{args.fetch(:code)}' \
@@ -23,7 +23,7 @@ namespace :dev do
     task :introspect, [:access_token, :token] do |_, args| # rubocop:disable Rails/RakeEnvironment
       access_token = args.fetch(:access_token)
       token = args.fetch(:token, access_token)
-      sh <<-BASH.strip_heredoc
+      sh <<~BASH
         curl -v -H 'Accept: application/json' \
         -H 'Authorization: Bearer #{access_token}' \
         -d 'token=#{token}' \
@@ -34,7 +34,7 @@ namespace :dev do
     desc 'Obtain profile information'
     task :profile, [:access_token, :scope] do |_, args| # rubocop:disable Rails/RakeEnvironment
       access_token = args.fetch(:access_token)
-      sh <<-BASH.strip_heredoc
+      sh <<~BASH
         curl -v -H 'Accept: application/json' \
         -H 'Authorization: Bearer #{access_token}' \
         -H 'X-Scope: #{args[:scope]}' \

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -114,7 +114,7 @@ namespace :dev do
           puts 'This is the QR-Code for the TOTP/2FA-Setup'
           system("kitty +kitten icat #{qr_code}")
         else
-          puts "The QR-Code for TOTP/2FA-Setup is located a #{qr_code}"
+          puts "The QR-Code for TOTP/2FA-Setup is located at #{qr_code}"
         end
 
         puts 'If you have setup 2FA for a dev-hitobito already, you may ignore this'

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -45,8 +45,10 @@ namespace :dev do
 
   namespace :local do
     desc 'Create a local user with admin-permissions'
-    task :admin, [:username] => :environment do |_, args|
-      username = args.fetch(:username, 'tester@example.net')
+    task admin: :environment do
+      abort('This is for development purposes only.') unless Rails.env.development?
+
+      username = 'tester@example.net'
       password = 'hitobito is the best software to manage people in complex group hierachies'
 
       me = Person.find_by(email: username) ||


### PR DESCRIPTION
When working in a wagon that has enforced 2FA, TOTP needs to be setup upon first login. If you create a new local admin, it most certainly has a role that needs this.

This PR set the secrets in a way that is repeatable and therefore reduces the friction when supporting organizations using such secure wagon setups. The same 2FA-setup can then be used again for development. It is not intended for production or integration setups, it should be (as before) be purely local admin.