### PR TITLE
Sort invoices by date of last payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *  Rechnungen können neu auch den Status "Teilzahlung" und "Überzahlung" haben (hitobito_sww#38)
 *  Einverständnis Erziehungsberechtigte für Selbstregistrierung (hitobito#2404)
+*  Listen von Rechnungen können nach letztem Zahlungseingang und nach insgesamt bezahltem Betrag sortiert werden (hitobito_sww#147)
 
 ## Version 2.0
 

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -15,7 +15,8 @@ class InvoicesController < CrudController
   self.nesting = Group
   self.optional_nesting = [InvoiceList]
 
-  self.sort_mappings = { recipient: Person.order_by_name_statement,
+  self.sort_mappings = { last_payment_at: Invoice.order_by_payment_statement,
+                         recipient: Person.order_by_name_statement,
                          sequence_number: Invoice.order_by_sequence_number_statement }
   self.remember_params += [:year, :state, :due_since, :invoice_list_id]
 
@@ -154,6 +155,7 @@ class InvoicesController < CrudController
   def list_entries
     scope = super.list
     scope = scope.includes(:recipient).references(:recipient)
+    scope = scope.joins(Invoice.last_payments_information)
     scope = scope.standalone if parent.is_a?(Group)
     scope = scope.page(params[:page]).per(50) unless params[:ids]
     Invoice::Filter.new(params).apply(scope)

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -16,6 +16,7 @@ class InvoicesController < CrudController
   self.optional_nesting = [InvoiceList]
 
   self.sort_mappings = { last_payment_at: Invoice.order_by_payment_statement,
+                         amount_paid: Invoice.order_by_amount_paid_statement,
                          recipient: Person.order_by_name_statement,
                          sequence_number: Invoice.order_by_sequence_number_statement }
   self.remember_params += [:year, :state, :due_since, :invoice_list_id]

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -35,6 +35,10 @@ module InvoicesHelper
     end
   end
 
+  def format_invoice_last_payment_at(invoice)
+    f(invoice.payments.last&.received_at)
+  end
+
   def invoice_state_label(invoice)
     text = invoice.state_label
     text << " (#{invoice.payment_reminders.list.last.title})" if invoice.reminded?

--- a/app/helpers/sheet/invoice.rb
+++ b/app/helpers/sheet/invoice.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
@@ -8,7 +8,6 @@
 module Sheet
   class Invoice < Base
     def title
-      title = ::Invoice.model_name.human(count: 2)
       invoice_list ? invoice_list.title : ::Invoice.model_name.human(count: 2)
     end
 

--- a/app/helpers/sheet/invoice.rb
+++ b/app/helpers/sheet/invoice.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -13,7 +13,10 @@ module Sheet
     end
 
     def parent_sheet
-      @parent_sheet ||= invoice_list ? create_parent(Sheet::InvoiceList) : nil
+      @parent_sheet ||= begin
+        parent_sheet_class = invoice_list ? Sheet::InvoiceList : Sheet::Group
+        create_parent(parent_sheet_class)
+      end
     end
 
     def invoice_list

--- a/app/helpers/sheet/invoice_list.rb
+++ b/app/helpers/sheet/invoice_list.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-#  Copyright (c) 2012-2020, CVP Schweiz. This file is part of
+#  Copyright (c) 2012-2024, CVP Schweiz. This file is part of
 #  hitobito_cvp and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_cvp.
@@ -8,6 +8,8 @@
 
 module Sheet
   class InvoiceList < Sheet::Base
+
+    self.parent_sheet = Sheet::Group
 
     def title
       if entry && !entry.receiver

--- a/app/helpers/sheet/invoice_list.rb
+++ b/app/helpers/sheet/invoice_list.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 #  Copyright (c) 2012-2024, CVP Schweiz. This file is part of
 #  hitobito_cvp and licensed under the Affero General Public License version 3

--- a/app/helpers/standard_table_builder.rb
+++ b/app/helpers/standard_table_builder.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Style/Attr
+# frozen_string_literal: true
 
 #  Copyright (c) 2012-2019, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -149,11 +149,16 @@ class Invoice < ActiveRecord::Base
       'last_payments.received_at'
     end
 
+    def order_by_amount_paid_statement
+      'last_payments.amount_paid'
+    end
+
     def last_payments_information
       <<~SQL.squish
         LEFT OUTER JOIN (
           SELECT invoice_id,
-                 MAX(received_at) AS received_at
+                 MAX(received_at) AS received_at,
+                 SUM(amount) AS amount_paid
           FROM payments
           GROUP BY invoice_id
         ) AS last_payments ON invoices.id = last_payments.invoice_id

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -113,10 +113,8 @@ class Invoice < ActiveRecord::Base
     end
 
     def draft_or_issued(from:, to:)
-      from ||= Time.zone.today.beginning_of_year
-      to ||= Time.zone.today.end_of_year
-      from = Date.parse(from) if from.is_a? String
-      to = Date.parse(to) if to.is_a? String
+      from = Date.parse(from.to_s) rescue Time.zone.today.beginning_of_year # rubocop:disable Style/RescueModifier
+      to = Date.parse(to.to_s) rescue Time.zone.today.end_of_year # rubocop:disable Style/RescueModifier
 
       condition = OrCondition.new
       condition.or('issued_at >= :from AND issued_at <= :to', from: from, to: to)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -144,6 +144,21 @@ class Invoice < ActiveRecord::Base
         "CAST(SUBSTRING_INDEX(#{field}, '-', #{index}) AS UNSIGNED)"
       end
     end
+
+    def order_by_payment_statement
+      'last_payments.received_at'
+    end
+
+    def last_payments_information
+      <<~SQL.squish
+        LEFT OUTER JOIN (
+          SELECT invoice_id,
+                 MAX(received_at) AS received_at
+          FROM payments
+          GROUP BY invoice_id
+        ) AS last_payments ON invoices.id = last_payments.invoice_id
+      SQL
+    end
   end
 
   delegate :logo_position, to: :invoice_config

--- a/app/views/invoices/_table.html.haml
+++ b/app/views/invoices/_table.html.haml
@@ -7,6 +7,7 @@
   - t.col(t.sort_header(:title)) do |invoice|
     %strong= link_to invoice.title, group_invoice_path(invoice.group_id, invoice)
   - t.sortable_attrs(:sequence_number, :state, :recipient, :issued_at, :sent_at, :due_at)
+  - t.sortable_attr(:last_payment_at)
   - t.col(t.sort_header(:amount_paid), class: 'right') { |i| i.decorate.amount_paid }
   - t.col(t.sort_header(:total), class: 'right') { |i| i.decorate.total }
 

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -1008,6 +1008,7 @@ de:
         due_at: Fällig am
         issued_at: Gestellt am
         sent_at: Verschickt am
+        last_payment_at: Zahlung am
         cost: Betrag
         total: Rechnungsbetrag
         total_inkl_vat: Total inkl. MwSt.

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -335,6 +335,30 @@ describe Invoice do
     end
   end
 
+  context 'sorting' do
+    it 'needs to know about last payments' do
+      expect(described_class.last_payments_information).to match(
+        /LEFT OUTER JOIN \(.*\) AS last_payments ON invoices.id = last_payments.invoice_id/
+      )
+
+      expect(described_class.last_payments_information)
+        .to match(/\( SELECT .* FROM payments GROUP BY invoice_id \)/)
+
+      expect(described_class.last_payments_information)
+        .to match(/invoice_id, MAX\(received_at\) AS received_at, SUM\(amount\) AS amount_paid/)
+    end
+
+    it 'supports sorting by last payment-date' do
+      expect(described_class.order_by_payment_statement)
+        .to eql 'last_payments.received_at'
+    end
+
+    it 'supports sorting by totally paid amount' do
+      expect(described_class.order_by_amount_paid_statement)
+        .to eql 'last_payments.amount_paid'
+    end
+  end
+
   private
 
   def contactables(*args)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -333,6 +333,12 @@ describe Invoice do
       filter = Invoice.draft_or_issued(from: today.beginning_of_year, to: today.end_of_year)
       expect(filter).to eq([issued])
     end
+
+    it 'does not crash with invalid dates' do
+      expect(Invoice.draft_or_issued(from: '0', to: Date.new(2019, 12, 31))).to have(2).items
+      expect(Invoice.draft_or_issued(from: Date.new(2019, 1, 1), to: nil)).to have(2).items
+      expect(Invoice.draft_or_issued(from: 'blørbaël', to: 'Zórgðœ')).to have(2).items
+    end
   end
 
   context 'sorting' do


### PR DESCRIPTION
This adds a new column "last payment at" to the invoices-tables and allows sorting by it.
It further adds the sorting for "amount paid", which has been missing (it was displayed, but did not work).
The invoice-area is now wrapped in a group-sheet to reduce the disruptive design of it. In future changes to this area, a more common navigation (tabs) might be added.

This also contains a bug fix for when invalid dates are entered into the date-range fields.

Fixes hitobito/hitobito_sww#147