### PR TITLE
We do not run PHP

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -41,6 +41,7 @@ Rails.application.reloader.to_prepare do
 
     misbehaving_client_errors = [
       'ActionDispatch::Http::MimeNegotiation::InvalidType',
+      'EOFError',
     ]
 
     config.excluded_exceptions += [


### PR DESCRIPTION
The EOFError mostly happens when an PHP-error is attempted to be exploited, therefore I ignore it.

I do not know of a reason to not ignore it, but am open for discussion.