### PR TITLE
Fix/properly size datetime fields

### DIFF
--- a/app/controllers/person/history_controller.rb
+++ b/app/controllers/person/history_controller.rb
@@ -16,6 +16,7 @@ class Person::HistoryController < ApplicationController
     @future_roles = fetch_roles(:future)
     @inactive_roles = fetch_roles(:inactive)
     @participations_by_event_type = participations_by_event_type
+    @qualifications = Qualifications::List.new(entry).qualifications
   end
 
   private

--- a/app/domain/qualifications/list.rb
+++ b/app/domain/qualifications/list.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Qualifications
+  class List
+
+    def initialize(person)
+      @person = person
+    end
+
+    def qualifications
+      @qualification ||= prepare
+    end
+
+    private
+
+    def prepare
+      list = load_qualifications
+      by_kind = list.group_by(&:qualification_kind_id)
+      list.each do |item|
+        item.first_of_kind = true if first?(item, by_kind)
+      end
+    end
+
+    def load_qualifications
+      @person.qualifications.order_by_date.includes(:qualification_kind)
+    end
+
+    def first?(quali, by_kind)
+      by_kind[quali.qualification_kind_id].first == quali
+    end
+  end
+end

--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -198,7 +198,7 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
     html_options[:class] += ' is-invalid' if errors_on?(attr)
 
     content_tag(:div, class: 'd-flex align-items-center') do
-      content_tag(:div, class: 'col-2 me-1') { date_field("#{attr}_date") } +
+      content_tag(:div, class: 'col-4 me-1') { date_field("#{attr}_date") } +
         hours_select("#{attr}_hour") +
         content_tag(:div) { ':' } +
         minutes_select("#{attr}_min")

--- a/app/javascript/stylesheets/hitobito/_form.scss
+++ b/app/javascript/stylesheets/hitobito/_form.scss
@@ -270,8 +270,7 @@ select {
 }
 
 select.time {
-  width: 80px;
-  height: 30px;
+  width: 4rem;
   margin: 0 4px 0 4px;
 }
 

--- a/app/javascript/stylesheets/hitobito/_typography.scss
+++ b/app/javascript/stylesheets/hitobito/_typography.scss
@@ -166,7 +166,8 @@ div.table {
     padding-top: 30px;
 
     h2 {
-      margin-bottom: 0;
+      margin-left: -8px;
+      color: $black;
     }
   }
 }

--- a/app/views/person/history/_qualifications.html.haml
+++ b/app/views/person/history/_qualifications.html.haml
@@ -1,0 +1,16 @@
+- # frozen_string_literal: true
+-
+- #  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+- #  hitobito_sac_cas and licensed under the Affero General Public License version 3
+- #  or later. See the COPYING file at the top-level directory or at
+- #  https://github.com/hitobito/hitobito.
+
+- if qualifications.present?
+  %h2.mt-4=Qualification.model_name.human(count: 2)
+  = table(qualifications, class: 'table table-striped table-fixed') do |t|
+    - t.attr(:qualification_kind) do |q|
+      - if q.first_reactivateable?
+        %strong= q.qualification_kind
+      - else
+        = q.qualification_kind
+    - t.attrs(:origin, :start_at, :finish_at, :reactivateable_until)

--- a/app/views/person/history/_roles_table.html.haml
+++ b/app/views/person/history/_roles_table.html.haml
@@ -4,7 +4,7 @@
 -# https://github.com/hitobito/hitobito
 
 - if roles.present?
-  %h2=title
+  %h2.mt-2=title
 
   = table(roles, class: 'table table-striped table-fixed') do |t|
     - t.col(Group.model_name.human) do |r|

--- a/app/views/person/history/index.html.haml
+++ b/app/views/person/history/index.html.haml
@@ -6,12 +6,12 @@
 = render_extensions :index_notice
 
 = render "roles_table", title: Role.model_name.human(count: 2), roles: @roles
-= render("roles_table", title: FutureRole.model_name.human(count: 2), roles: @future_roles)
-= render("roles_table", title: t('.inactive_roles_title'), roles: @inactive_roles)
+= render "roles_table", title: FutureRole.model_name.human(count: 2), roles: @future_roles
+= render "roles_table", title: t('.inactive_roles_title'), roles: @inactive_roles
 
 = render_extensions :history_members_form
 
-%events
+#events.mt-2
   = render(layout: 'shared/grouped_table',
            locals: { grouped_lists: @participations_by_event_type,
                      column_count: 3 }) do |participation|

--- a/app/views/person/history/index.html.haml
+++ b/app/views/person/history/index.html.haml
@@ -5,9 +5,9 @@
 
 = render_extensions :index_notice
 
-= render "roles_table", title: Role.model_name.human(count: 2), roles: @roles
-= render "roles_table", title: FutureRole.model_name.human(count: 2), roles: @future_roles
-= render "roles_table", title: t('.inactive_roles_title'), roles: @inactive_roles
+= render 'roles_table', title: Role.model_name.human(count: 2), roles: @roles
+= render 'roles_table', title: FutureRole.model_name.human(count: 2), roles: @future_roles
+= render 'roles_table', title: t('.inactive_roles_title'), roles: @inactive_roles
 
 = render_extensions :history_members_form
 
@@ -19,3 +19,5 @@
       %strong= participation.event.labeled_link
     %td= participation.list_roles
     %td= participation.event.dates_full
+
+= render 'qualifications', qualifications: @qualifications

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -725,6 +725,8 @@ de:
         qualification_kind_id: Qualifikation
         start_at: Seit
         origin: Ursprung
+        finish_at: Bis
+        reactivateable_until: Reaktiviert bis
         string: '%{kind}'
         string_with_origin: '%{kind} (von %{origin})'
         string_with_finish_at: '%{kind} (bis %{finish_at})'

--- a/spec/controllers/person/history_controller_spec.rb
+++ b/spec/controllers/person/history_controller_spec.rb
@@ -34,6 +34,31 @@ describe Person::HistoryController do
       end
     end
 
+
+    context 'qualifications' do
+      render_views
+
+      let(:body) { Capybara::Node::Simple.new(response.body) }
+      let(:sl_leader) { qualification_kinds(:sl_leader) }
+      let(:gl) { qualification_kinds(:gl) }
+
+      it 'does not render qualifications if no qualifications exist' do
+        get :index, params: { group_id: groups(:top_group).id, id: top_leader.id }
+        expect(body).not_to have_css 'h2.mt-4', text: 'Qualifikationen'
+      end
+
+      it 'lists and marks first qualifications of kind' do
+        Fabricate(:qualification, person: top_leader, qualification_kind: gl, finish_at: 1.year.ago.to_date)
+        Fabricate(:qualification, person: top_leader, qualification_kind: sl_leader)
+
+        get :index, params: { group_id: groups(:top_group).id, id: top_leader.id }
+        expect(body).to have_css 'h2.mt-4', text: 'Qualifikationen'
+        expect(body).to have_css 'tbody td strong', text: sl_leader.to_s
+        expect(body).to have_css 'tbody td', text: gl.to_s
+        expect(body).not_to have_css 'tbody td strong', text: gl.to_s
+      end
+    end
+
   end
 
 end

--- a/spec/domain/qualifications/list_spec.rb
+++ b/spec/domain/qualifications/list_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+describe Qualifications::List do
+  let(:person) { Fabricate.build(:person) }
+
+  let(:sl) { qualification_kinds(:sl) }
+  let(:sl_leader) { qualification_kinds(:sl_leader) }
+  let(:gl_leader) { qualification_kinds(:gl_leader) }
+
+  subject(:list) { described_class.new(person) }
+
+  describe '#qualifications' do
+    it 'loads qualifications with kinds ordered by date' do
+      expect(person).to receive_message_chain(:qualifications, :order_by_date, { includes: :qualification_kind })
+        .and_return([])
+      expect(list.qualifications).to be_empty
+    end
+
+    it 'marks first if of kind if it is reactivateable' do
+      allow(list).to receive(:load_qualifications).and_return([
+        Qualification.new(qualification_kind: sl_leader),
+      ])
+      expect(list.qualifications[0]).to be_first_reactivateable
+    end
+
+    it 'does not mark second of kind' do
+      allow(list).to receive(:load_qualifications).and_return([
+        Qualification.new(qualification_kind: sl_leader),
+        Qualification.new(qualification_kind: sl_leader),
+      ])
+      expect(list.qualifications[0]).to be_first_reactivateable
+      expect(list.qualifications[1]).not_to be_first_reactivateable
+    end
+
+    it 'does mark first of kind qualification is active' do
+      allow(list).to receive(:load_qualifications).and_return([
+        Qualification.new(qualification_kind: sl, finish_at: 2.years.from_now.to_date),
+        Qualification.new(qualification_kind: sl, finish_at: 1.years.from_now.to_date),
+      ])
+      expect(list.qualifications[0]).to be_first_reactivateable
+      expect(list.qualifications[1]).not_to be_first_reactivateable
+    end
+
+    it 'does not mark first of kind if qualification is inactive and not reactivateable' do
+      allow(list).to receive(:load_qualifications).and_return([
+        Qualification.new(qualification_kind: sl, finish_at: 1.years.ago.to_date),
+        Qualification.new(qualification_kind: sl, finish_at: 2.years.ago.to_date),
+      ])
+      expect(list.qualifications[0]).not_to be_first_reactivateable
+      expect(list.qualifications[1]).not_to be_first_reactivateable
+    end
+  end
+end

--- a/spec/regressions/person/history_controller_spec.rb
+++ b/spec/regressions/person/history_controller_spec.rb
@@ -39,7 +39,7 @@ describe Person::HistoryController, type: :controller do
       role.destroy
       get :index, params: params
       expect(dom.all('table tbody tr').size).to eq 2
-      role_row = dom.find('div.table-responsive:last table tbody tr')
+      role_row = dom.find('div.table-responsive:nth-of-type(2) table tbody tr')
       expect(role_row.find('td:eq(1) a:eq(2)').text).to eq 'Group 11'
       expect(role_row.find('td:eq(2)').text.strip).to eq 'Member'
       expect(role_row.find('td:eq(3)').text).to be_present
@@ -61,7 +61,7 @@ describe Person::HistoryController, type: :controller do
       role.destroy
       get :index, params: params
       expect(dom.all('table tbody tr').size).to eq 2
-      role_row = dom.find('div.table-responsive:last table tbody tr')
+      role_row = dom.find('div.table-responsive:nth-of-type(2) table tbody tr')
       expect(role_row.find('td:eq(1) a:eq(2)').text).to eq 'TopGroup'
       expect(role_row.find('td:eq(4)').text).to be_present
     end
@@ -76,7 +76,7 @@ describe Person::HistoryController, type: :controller do
 
       get :index, params: { group_id: top_group.id, id: top_leader.id }
 
-      events = dom.find('events')
+      events = dom.find('#events')
 
       expect(events).to have_selector('h2', text: 'Kurse')
       expect(events).to have_selector('h2', text: 'Anlässe')


### PR DESCRIPTION
Hallo Niklas, 

ich hab auf einem anderen branch noch die datetime fields angepasst, da die bei event daten zu klein sind, als dass man da etwas sinnvoll erfassen könnte. 

Der Change steht jetzt aber im Konflikt zu deinem change dd856699c1332da3af87ffdc3786649f86f9d384, vielleicht können wir das mal zusammen anschauen