### PR TITLE
Bestätigungsmail trotz automatischer Zuweisung

### DIFF
--- a/app/domain/event/participant_assigner.rb
+++ b/app/domain/event/participant_assigner.rb
@@ -113,6 +113,6 @@ class Event::ParticipantAssigner
   end
 
   def send_confirmation
-    Event::ParticipationConfirmationJob.new(participation, send_approval: false).enqueue!
+    Event::ParticipationConfirmationJob.new(participation).enqueue!
   end
 end

--- a/app/jobs/event/participation_confirmation_job.rb
+++ b/app/jobs/event/participation_confirmation_job.rb
@@ -32,7 +32,7 @@ class Event::ParticipationConfirmationJob < BaseJob
   end
 
   def send_approval
-    return unless @send_approval && participation.pending?
+    return unless @send_approval && !participation.application.approved && (participation.pending? || participation.active)
     return unless participation.event.requires_approval?
 
     recipients = approvers


### PR DESCRIPTION
@richardjubla und ich haben diskutiert, dass wir es besser finden, wenn das Aufforderung-Mail für die Scharleiter/Coach-Bestätigung immer verschickt wird. Die Markierung zum Stand der Bestätigung wird auch in jedem Fall angezeigt.

Wird das Mail immer verschickt, ist ein zusätzlicher Workflow möglich, denn wenn ich eine automatische Zuteilung ohne Bestätigung möchte, kann ich das mit der entsprechend Auswahl der Checkboxen weiterhin konfigurieren. (mit weniger verwirrender Darstellung) 

Der Commit stellt auch sicher, dass bei manueller Zuteilung nach der Coach-Freigabe die Aufforderung zur Bestätigung nicht ein noch einmal verschickt wird. (Mindestens wenn ich so spät nicht doch wieder einen Bug eingebaut habe ;-)

(Der erste Commit ist auch in https://github.com/hitobito/hitobito/pull/2482 enthalten. Dieser Pull request hier hatte möglicherweise mehr Diskussionsbedarf - und der fix für 2120 eilt.)