### PR TITLE
Disable turbo on OAuth-forms

### DIFF
--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -24,7 +24,7 @@
   <% end %>
 
   <div class="actions row">
-    <%= form_tag oauth_authorization_path, method: :post, class: 'col-6' do %>
+    <%= form_tag oauth_authorization_path, method: :post, class: 'col-6', data: { turbo: false } do %>
       <%= hidden_field_tag :client_id, @pre_auth.client.uid %>
       <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri %>
       <%= hidden_field_tag :state, @pre_auth.state %>
@@ -35,7 +35,7 @@
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method %>
       <%= submit_tag t('doorkeeper.authorizations.buttons.authorize'), class: "btn btn-sm btn-success btn-lg btn-block w-100" %>
     <% end %>
-    <%= form_tag oauth_authorization_path, method: :delete, class: 'col-6' do %>
+    <%= form_tag oauth_authorization_path, method: :delete, class: 'col-6', data: { turbo: false } do %>
       <%= hidden_field_tag :client_id, @pre_auth.client.uid %>
       <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri %>
       <%= hidden_field_tag :state, @pre_auth.state %>


### PR DESCRIPTION
With forms pointing back and forth across the internet, Turbo does not make sense and - in this case - even breaks the whole OAuth-Flow.

Fixes #2476 