### PR TITLE
Silence low-contrast warnings by lowering our standards

### DIFF
--- a/app/javascript/packs/application.scss.erb
+++ b/app/javascript/packs/application.scss.erb
@@ -27,6 +27,7 @@ $logo-background-color: <%= Settings.application.logo.background_color %> !defau
 <% if Settings.application.page_background.try(ENV['RAILS_HOST_NAME'] || "dev") %>
   $page-background: <%= Settings.application.page_background.send(ENV['RAILS_HOST_NAME']  || "dev") %>;
 <% end %>
+$min-contrast-ratio: 2.5;
 
 // Import the wagons' specific variables or fall back to core variables
 <% absolute_wagon_file_paths(


### PR DESCRIPTION
The default contrast-ratio of 4.5:1 triggers warnings. I noticed it in the skv-wagon, I did not research any further.

Discussion welcome