### PR TITLE
Add test to make sure openapi.yaml is kept valid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,6 +132,7 @@ group :test do
   gem 'fabrication'
   gem 'headless'
   gem 'launchy'
+  gem 'open_api-schema_validator'
   gem 'pdf-inspector', require: 'pdf/inspector'
   gem 'rails-controller-testing'
   gem 'rspec-collection_matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,6 +335,8 @@ GEM
     joiner (0.6.0)
       activerecord (>= 6.1.0)
     json (2.7.1)
+    json-schema (4.2.0)
+      addressable (>= 2.8)
     jsonapi-renderer (0.2.2)
     jsonapi-serializable (0.3.1)
       jsonapi-renderer (~> 0.2.0)
@@ -414,6 +416,8 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oat (0.6.1)
+    open_api-schema_validator (0.2.0)
+      json-schema
     orm_adapter (0.5.0)
     paper_trail (15.1.0)
       activerecord (>= 6.1)
@@ -798,6 +802,7 @@ DEPENDENCIES
   nested_form
   nokogiri
   oat
+  open_api-schema_validator
   paper_trail
   parallel_tests
   paranoia

--- a/spec/support/graphiti/shared_examples.rb
+++ b/spec/support/graphiti/shared_examples.rb
@@ -26,7 +26,7 @@ shared_examples 'jsonapi authorized requests' do
 end
 
 shared_examples 'graphiti schema file is up to date' do
-  it do
+  it 'graphiti schema file is up to date' do
     context_root = Pathname.new(Dir.pwd)
 
     # If no resources are defined, we assume the current context has no customizations
@@ -51,5 +51,17 @@ shared_examples 'graphiti schema file is up to date' do
       The schema file is outdated: #{Graphiti.config.schema_path.relative_path_from(Pathname.new(Dir.pwd).parent)}
       Please run `bundle exec rake graphiti:schema:generate` and commit the file to the git repository.
     MSG
+  end
+
+  describe 'GET /api-docs', type: :request do
+    it 'openapi spec is valid' do
+      get '/api/openapi.json'
+      json = JSON.parse(response.body)
+      expect(OpenApi::SchemaValidator.validate!(json, 3)).to be_truthy, <<~MSG
+        The generated OpenAPI specification file does not conform to the official OpenAPI 3 standard.
+        Please paste the output of /api/openapi.json or /api/openapi.yaml into
+        https://editor.swagger.io, and fix all reported errors.
+      MSG
+    end
   end
 end


### PR DESCRIPTION
The test will also be run in all wagons, to make sure that we don't break the documentation in just one wagon either.

Previously, we fixed the validity in https://github.com/hitobito/hitobito/commit/cfff477a6228478ddc72902cfa7758fc63b6ea11 and https://github.com/hitobito/hitobito/pull/2492