### PR TITLE
Update Nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -412,7 +412,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.0)
-    nokogiri (1.16.2)
+    nokogiri (1.16.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oat (0.6.1)


### PR DESCRIPTION
This addresses CVE-2024-25062 in the bundled libxml2. To my understanding, we are not vulnerable because we do not use the related features. Still no reason not to update.