### PR TITLE
Check for toggle state during connect

### DIFF
--- a/app/javascript/controllers/form_field_toggle_controller.js
+++ b/app/javascript/controllers/form_field_toggle_controller.js
@@ -1,11 +1,14 @@
 import { Controller } from "@hotwired/stimulus";
-import debounce from "lodash.debounce";
 
 export default class extends Controller {
-  static targets = ["toggle"];
+  static targets = ["select", "toggle"];
+
+  connect() {
+    this.toggle()
+  }
 
   toggle(event) {
-    const selected = event.target.options[event.target.options.selectedIndex];
+    const selected = this.selectTarget.options[this.selectTarget.options.selectedIndex];
 
     if (selected.dataset.visibility === "true") {
       this.toggleTarget.classList.remove("hidden");


### PR DESCRIPTION
Refs: https://github.com/hitobito/hitobito_sac_cas/issues/259#issuecomment-2003247057
Dieser Commit sorgt dafür dass bei einem Validierungsfehler das `Bis` Feld direkt angezeigt wird. Den Commit hatte ich schon bei der Umsetzung gemacht aber der war wohl irgendwo verloren gegangen


Der Maximalwert wurde vor Jahren absichtlich auf 31.12.9999 gesetzt. Finde das eigentlich voll i.O
https://github.com/hitobito/hitobito/blob/sac-master/app/models/qualification.rb#L46