### PR TITLE
Don't downcase async download filenames

### DIFF
--- a/app/models/async_download_file.rb
+++ b/app/models/async_download_file.rb
@@ -10,7 +10,7 @@ class AsyncDownloadFile < ApplicationRecord
     FILENAME_REGEX = /\A(.*)_(\d+)-(\d+)\z/.freeze
 
     def create_name(filename, person_id)
-      "#{filename.to_s.parameterize}_#{Time.now.to_i}-#{person_id}"
+      "#{filename.to_s.parameterize(preserve_case: true)}_#{Time.now.to_i}-#{person_id}"
     end
 
     def parse_filename(filename)


### PR DESCRIPTION
Refs hitobito/hitobito_sac_cas#271
The filename there must be like "Adressen_00001234.csv", with capital A, for maximum backwards compatibility.