### PR TITLE
Handle missing encrypted value better

### DIFF
--- a/app/models/concerns/encryptable.rb
+++ b/app/models/concerns/encryptable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2021, CVP Schweiz. This file is part of
+#  Copyright (c) 2021-2024, CVP Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -9,19 +9,19 @@ module Encryptable
   extend ActiveSupport::Concern
 
   class_methods do
-    def attr_encrypted(*attributes)
+    def attr_encrypted(*attributes) # rubocop:disable Metrics/MethodLength
       attributes.each do |attribute|
-        define_method("#{attribute}=".to_sym) do |value|
-          return if value.blank? || value == self.send(attribute)
+        define_method(:"#{attribute}=") do |value|
+          return if value.blank? || value == send(attribute)
 
-          self.send(
-            "encrypted_#{attribute}=".to_sym,
+          send(
+            :"encrypted_#{attribute}=",
             EncryptionService.encrypt(value)
           )
         end
 
         define_method(attribute) do
-          data = self.send("encrypted_#{attribute}".to_sym)
+          data = send(:"encrypted_#{attribute}")
           return '' if data.blank?
 
           encrypted_value = data[:encrypted_value]

--- a/app/models/concerns/encryptable.rb
+++ b/app/models/concerns/encryptable.rb
@@ -22,7 +22,7 @@ module Encryptable
 
         define_method(attribute) do
           data = self.send("encrypted_#{attribute}".to_sym)
-          return '' if data.nil?
+          return '' if data.blank?
 
           encrypted_value = data[:encrypted_value]
           iv = data[:iv]

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -782,6 +782,15 @@ describe Group do
 
   end
 
+  context 'encrypted attributes' do
+    it 'can be blank' do
+      group = groups(:top_layer)
+      group.encrypted_text_message_username = ''
+
+      expect(group.text_message_username).to be_empty
+    end
+  end
+
   context 'name' do
     let(:group) { groups(:bottom_layer_one) }
 

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.


### PR DESCRIPTION
In essence, I changed the guard-condition from `data.nil?` to `data.blank?`. While at it, I added a small spec for this exact case and formatted the file according to rubocop's rules.

The original specs for this are lost, most likely when moving from the separate `GroupSettings`-model to attributes directly on the `Group`.

See https://sentry.puzzle.ch/pitc/hitobito-backend/issues/66965 for stacktrace and such.