### PR TITLE
Prepare pagination to avoid errors with duplicate columns

### DIFF
--- a/app/controllers/event/participations_controller.rb
+++ b/app/controllers/event/participations_controller.rb
@@ -177,6 +177,11 @@ class Event::ParticipationsController < CrudController # rubocop:disable Metrics
     filter = event_participation_filter
     records = filter.list_entries.includes(person: :picture_attachment).page(params[:page])
     @counts = filter.counts
+    @pagination_options = {
+      total_pages: records.total_pages,
+      current_page: records.current_page,
+      per_page: records.limit_value
+    }
     sort_param = params[:sort]
 
     records = records.reorder(Arel.sql(sort_expression)) if sort_param && sortable?(sort_param)

--- a/app/views/event/participations/_list.html.haml
+++ b/app/views/event/participations/_list.html.haml
@@ -14,7 +14,7 @@
 - params[:q] = nil # Reset param so quicksearch filter does not get populated
 
 .pagination-bar
-  = paginate entries
+  = paginate(entries, **(@pagination_options || {}))
 
   .pagination-info
 
@@ -40,4 +40,4 @@
   = render_extensions :list, locals: { table: t }
   - render_table_display_columns(Event::Participation, t)
 
-= paginate entries
+= paginate(entries, **(@pagination_options || {}))


### PR DESCRIPTION
Otherwise, for reasons I could not debug fully, the columns person.additional_information and participation.additional_information are both requested as additional_information when counting the total pages. When requesing this information earlier, the error does not occur, therefore I do.

See: https://sentry.puzzle.ch/pitc/hitobito-backend/issues/67232