### PR TITLE
Changes needed for SAC family main person

### DIFF
--- a/app/models/future_role.rb
+++ b/app/models/future_role.rb
@@ -117,7 +117,7 @@ class FutureRole < Role
 
   def target_type_validations
     becoming = build_new_role
-    becoming.validate
+    becoming.validate(validation_context)
 
     becoming_errors = becoming.errors.reject do |e|
       # A FutureRole will have a convert_on date in the future, this will become the

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -389,10 +389,11 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
 
   def household_people
     Person.
-      includes(:groups).
+      where(id: household_people_ids).or(
+          Person.where.not(household_key: nil).where(household_key: household_key)
+      ).
       where.not(id: id).
-      where('id IN (?) OR (household_key IS NOT NULL AND household_key = ?)',
-            household_people_ids, household_key)
+      includes(:groups)
   end
 
   def greeting_name

--- a/app/models/self_registration/person.rb
+++ b/app/models/self_registration/person.rb
@@ -58,8 +58,11 @@ class SelfRegistration::Person
 
   delegate :gender_label, :valid_email?, to: :person
 
-  def save!
-    person.save! && role.save! && enqueue_duplicate_locator_job
+  # validation context can be provided and is forwarded to saving the person and role
+  def save!(context: nil)
+    person.save!(context: context) &&
+      role.save!(context: context) &&
+      enqueue_duplicate_locator_job
   end
 
   def person
@@ -97,7 +100,7 @@ class SelfRegistration::Person
   end
 
   def assert_role_valid
-    unless role.valid?
+    unless role.valid?(validation_context)
       role.errors.attribute_names.each do |attr|
         errors.add(attr, role.errors[attr].join(', '))
       end
@@ -105,7 +108,7 @@ class SelfRegistration::Person
   end
 
   def assert_person_valid
-    unless person.valid?
+    unless person.valid?(validation_context)
       (person.errors.attribute_names & attrs).each do |attr|
         errors.add(attr, person.errors[attr].join(', ')) unless errors.key?(attr)
       end

--- a/spec/models/future_role_spec.rb
+++ b/spec/models/future_role_spec.rb
@@ -78,9 +78,9 @@ describe FutureRole do
     context 'target_type validations' do
       before do
         stub_const('TargetRole', Class.new(Role) do
-          attr_accessor :target_type_valid
+          attr_accessor :some_attribute
 
-          validates :target_type_valid, presence: true
+          validates :some_attribute, presence: true, on: [:create, :update]
         end)
         top_group.class.role_types += [TargetRole]
       end
@@ -95,14 +95,20 @@ describe FutureRole do
         allow(role).to receive(:validate_target_type?).and_return(true)
         role.validate
 
-        expect(role.errors[:target_type_valid]).to include('muss ausgefüllt werden')
+        expect(role.errors[:some_attribute]).to include('muss ausgefüllt werden')
       end
 
       it 'are skipped if validate_target_type? returns false' do
         allow(role).to receive(:validate_target_type?).and_return(false)
         role.validate
 
-        expect(role.errors[:target_type_valid]).to be_blank
+        expect(role.errors[:some_attribute]).to be_blank
+      end
+
+      it 'can be skipped by setting non-matching validation context' do
+        allow(role).to receive(:validate_target_type?).and_return(true)
+        role.validate(:skip_target_type)
+        expect(role.errors[:some_attribute]).to be_blank
       end
     end
 


### PR DESCRIPTION
Fixes hitobito/hitobito_sac_cas#493

- **Rewrite Person#household_people as pure activerecord query without plain sql**
- **SelfRegistration::Person: allow validating/saving with custom validation context**
- **FutureRole: forward validation_context when validating target role**
