### PR TITLE
Fix person field for invalid forms, (#2565)

### DIFF
--- a/app/javascript/controllers/remote_autocomplete_controller.js
+++ b/app/javascript/controllers/remote_autocomplete_controller.js
@@ -1,0 +1,17 @@
+// Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+// hitobito_sac_cas and licensed under the Affero General Public License version 3
+// or later. See the COPYING file at the top-level directory or at
+// https://github.com/hitobito/hitobito
+//
+// This has been extracted from app/javascript/javascripts/modules/remote_autocomplete.js
+// and wrapped as a stimulus controller to cater for 422 responses not triggering load events
+// see https://github.com/hitobito/hitobito/issues/2565
+
+
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    window.App.setupRemoteAutocomplete();
+  }
+}

--- a/app/javascript/javascripts/modules/remote_autocomplete.js
+++ b/app/javascript/javascripts/modules/remote_autocomplete.js
@@ -186,14 +186,12 @@ import { mark } from "@tarekraafat/autocomplete.js/src/helpers/io";
     return nel;
   };
 
-  $(document).on("turbo:load turbo:frame-load", function() {
+  app.setupRemoteAutocomplete = function() {
     app.setupQuicksearch();
     $("[data-provide=entity]").each(app.setupEntityTypeahead);
     $("[data-provide=typeahead]").each(app.setupStaticTypeahead);
     return $("[data-provide]").each(function() {
       return $(this).attr("autocomplete", "off");
     });
-  });
-
-
+  };
 }).call(this);

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -24,7 +24,7 @@
 
     = yield(:head)
 
-  %body{class: ('is-logged-out' unless person_signed_in?) }
+  %body{class: ('is-logged-out' unless person_signed_in?), data: { controller: 'remote-autocomplete' } }
     #modal-placeholder
     %main
       = render 'layouts/file_download' if current_user


### PR DESCRIPTION
Wrapt den für die Personen Such relevanten Teil des Plugins in einem Stimulus Controller. Das behebt den Bug für das `people_field` auf dem StandardFormBuilder.
