### PR TITLE
Try to use a common branch for all repos

### DIFF
--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -14,11 +14,11 @@ on:
       core_ref:
         description: Use a specific version of the core for the workflow run. Defaults to master.
         type: string
-        default: 'master'
+        default: ''
       wagon_dependency_ref:
         description: Use a specific version of the wagon dependency for the workflow run. Defaults to master.
         type: string
-        default: 'master'
+        default: ''
     secrets:
       HEARTBEAT_URL:
         description: 'URL to the heartbeat-application'
@@ -72,23 +72,29 @@ jobs:
       - name: 'Extract branch name and determine common branch'
         env:
           WAGON_DEPENDENCY_REPO: ${{ inputs.wagon_dependency_repository }}
-          INPUT_WDEP_REF: ${{ inputs.wagon_dependency_ref || 'master' }}
-          INPUT_CORE_REF: ${{ inputs.core_ref || 'master' }}
+          INPUT_WDEP_REF: ${{ inputs.wagon_dependency_ref }}
+          INPUT_CORE_REF: ${{ inputs.core_ref }}
         run: |
           current_branch_name="$(echo ${GITHUB_REF#refs/heads/})"
 
           WAGON_DEPENDENCY_REF="$INPUT_WDEP_REF"
-          if [ "${WAGON_DEPENDENCY_REPO}" != '' ]; then
+          if [ -z "${INPUT_WDEP_REF}" -a "${WAGON_DEPENDENCY_REPO}" != '' ]; then
             dependency_branch=$(git ls-remote --heads https://github.com/hitobito/${WAGON_DEPENDENCY_REPO} | cut -d/ -f3- | grep -x "$current_branch_name")
             if [ "$dependency_branch" != '' ]; then
               WAGON_DEPENDENCY_REF="$current_branch_name"
+            else
+              WAGON_DEPENDENCY_REF="master"
             fi
           fi
 
           CORE_REF="$INPUT_CORE_REF"
-          core_branch=$(git ls-remote --heads https://github.com/hitobito/hitobito | cut -d/ -f3- | grep -x "$current_branch_name")
-          if [ "$core_branch" != '' ]; then
-            CORE_REF="$current_branch_name"
+          if [ -z "${INPUT_WDEP_REF}" ]; then
+            core_branch=$(git ls-remote --heads https://github.com/hitobito/hitobito | cut -d/ -f3- | grep -x "$current_branch_name")
+            if [ "$core_branch" != '' ]; then
+              CORE_REF="$current_branch_name"
+            else
+              CORE_REF="master"
+            fi
           fi
 
           echo "BRANCH_NAME=$current_branch_name" >> $GITHUB_ENV

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -69,20 +69,37 @@ jobs:
           mkdir hitobito
         working-directory: .
 
-      - name: 'Extract branch name'
+      - name: 'Extract branch name and determine common branch'
+        env:
+          WAGON_DEPENDENCY_REPO: ${{ inputs.wagon_dependency_repository }}
+          INPUT_WDEP_REF: ${{ inputs.wagon_dependency_ref || 'master' }}
+          INPUT_CORE_REF: ${{ inputs.core_ref || 'master' }}
         run: |
-          echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
+          current_branch_name="$(echo ${GITHUB_REF#refs/heads/})"
 
-      - name: 'Extract wagon name'
-        run: |
-          repository=${{github.repository}}
-          echo "WAGON_NAME=${repository##*/}" >> $GITHUB_ENV
+          WAGON_DEPENDENCY_REF="$INPUT_WDEP_REF"
+          if [ "${WAGON_DEPENDENCY_REPO}" != '' ]; then
+            dependency_branch=$(git ls-remote --heads https://github.com/hitobito/${WAGON_DEPENDENCY_REPO} | cut -d/ -f3- | grep -x "$current_branch_name")
+            if [ "$dependency_branch" != '' ]; then
+              WAGON_DEPENDENCY_REF="$current_branch_name"
+            fi
+          fi
 
-      - name: 'Checkout hitobito'
+          CORE_REF="$INPUT_CORE_REF"
+          core_branch=$(git ls-remote --heads https://github.com/hitobito/hitobito | cut -d/ -f3- | grep -x "$current_branch_name")
+          if [ "$core_branch" != '' ]; then
+            CORE_REF="$current_branch_name"
+          fi
+
+          echo "BRANCH_NAME=$current_branch_name" >> $GITHUB_ENV
+          echo "WAGON_DEPENDENCY_REF=$WAGON_DEPENDENCY_REF" >> $GITHUB_ENV
+          echo "CORE_REF=$CORE_REF" >> $GITHUB_ENV
+
+      - name: 'Checkout hitobito at ${{ env.CORE_REF }}'
         uses: actions/checkout@v4
         with:
           repository: 'hitobito/hitobito'
-          ref: ${{ inputs.core_ref || 'master' }}
+          ref: ${{ env.CORE_REF }}
           path: 'hitobito'
 
       - name: 'Set up Ruby'
@@ -109,12 +126,12 @@ jobs:
         run: |
           cp -v Wagonfile.ci Wagonfile
 
-      - name: 'Checkout dependency ${{ inputs.wagon_dependency_repository }}'
+      - name: 'Checkout dependency ${{ inputs.wagon_dependency_repository }} at ${{ env.WAGON_DEPENDENCY_REF }}'
         uses: actions/checkout@v4
         if: ${{ inputs.wagon_dependency_repository != '' }}
         with:
           repository: hitobito/${{ inputs.wagon_dependency_repository }}
-          ref: ${{ inputs.wagon_dependency_ref || 'master' }}
+          ref: ${{ env.WAGON_DEPENDENCY_REF }}
           path: ${{ inputs.wagon_dependency_repository }}
 
       - name: Checkout ${{ env.WAGON_NAME }}
@@ -195,7 +212,7 @@ jobs:
   notify_statuscope:
     uses: ./.github/workflows/notify-statuscope.yml
     needs: [ build_test ]
-    if: ( success() || failure() ) && ( github.ref_name == 'master' ) && ( (inputs.core_ref || 'master') == 'master' ) && ( (inputs.wagon_dependency_ref || 'master') == 'master' )
+    if: ( success() || failure() ) && ( github.ref_name == 'master' ) && ( env.CORE_REF == 'master' ) && ( env.WAGON_DEPENDENCY_REF == 'master' )
     with:
       repository: ${{ inputs.wagon_repository }}
       test_result: ${{ needs.build_test.result == 'success' }}

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -88,7 +88,7 @@ jobs:
           fi
 
           CORE_REF="$INPUT_CORE_REF"
-          if [ -z "${INPUT_WDEP_REF}" ]; then
+          if [ -z "${INPUT_CORE_REF}" ]; then
             core_branch=$(git ls-remote --heads https://github.com/hitobito/hitobito | cut -d/ -f3- | grep -x "$current_branch_name")
             if [ "$core_branch" != '' ]; then
               CORE_REF="$current_branch_name"


### PR DESCRIPTION
When testing the wagon, it tries to find a matching branch in the core and youth-wagon.
If the feature-branch cannot be found, it should default to the value from the input, which in turn defaults to `master`.

This allows to have synced changes in the wagon and the core, just by naming the feature-branch the same.

I only tested the output of the `git ls-remote | cut | grep`-command, manually outside the action. A full integration-test is of course possible, but IMHO not worth the effort. If needed, I would revert and redo this.
