### PR TITLE
UI improvements in subscribers/group/roles filtering

### DIFF
--- a/app/javascript/stylesheets/hitobito/_form.scss
+++ b/app/javascript/stylesheets/hitobito/_form.scss
@@ -435,7 +435,7 @@ td.issue, td.revoke {
   }
 }
 
-.filter_toggle {
+.filter_toggle, .filter-toggle {
    cursor: pointer;
    cursor: hand;
 }

--- a/app/javascript/stylesheets/hitobito/_modal.scss
+++ b/app/javascript/stylesheets/hitobito/_modal.scss
@@ -14,9 +14,6 @@
   }
 
   .checkboxes {
-    .filter-toggle {
-      cursor: pointer;
-    }
     .available-role-type,
     .available-tag {
       margin-left: 10px;

--- a/app/views/subscriber/group/_roles.html.haml
+++ b/app/views/subscriber/group/_roles.html.haml
@@ -5,9 +5,9 @@
 
 - if @role_types
   - @role_types.each do |layer, groups|
-    %h4.filter-toggle=layer
+    %h3.filter-toggle.mt-4=layer if groups.any?
     - groups.each do |group, role_types|
-      .control-group
+      .control-group.mt-1
         = label_tag(nil, group, class: 'control-label filter-toggle')
         .controls
           - role_types.each do |role_type|

--- a/app/views/subscriber/group/_tags.html.haml
+++ b/app/views/subscriber/group/_tags.html.haml
@@ -3,9 +3,9 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-%p= t('.only_add_persons_with_tags')
+%p.mb-2= t('.only_add_persons_with_tags')
 
-.shown
+.shown.mb-4
   = f.collection_select(:included_subscription_tags_ids,
                         @possible_tags,
                         :third,
@@ -16,9 +16,9 @@
                           data: { chosen_no_results: t('global.chosen_no_results'),
                                   placeholder: ' ' } })
 
-%p= t('.exclude_persons_with_tags')
+%p.mb-2= t('.exclude_persons_with_tags')
 
-.shown
+.shown.mb-4
   = f.collection_select(:excluded_subscription_tags_ids,
                         @possible_tags,
                         :third,

--- a/spec/features/subscriber/group_controller_spec.rb
+++ b/spec/features/subscriber/group_controller_spec.rb
@@ -35,7 +35,7 @@ describe Subscriber::GroupController, js: true do
       expect(find('#subscription_subscriber_id', visible: false).value).to eq subscriber_id.to_s
 
       expect(find('#roles')).to have_selector('input[type=checkbox]', count: 9) # roles
-      expect(find('#roles')).to have_selector('h4', count: 2) # layers
+      expect(find('#roles')).to have_selector('h3', count: 2) # layers
 
       # check role and submit
       check('subscription_role_types_group::bottomgroup::leader')


### PR DESCRIPTION
- bigger group names
- visually separate groups
- do not render layer without subgroups