### PR TITLE
Restrict Language Filter

### DIFF
--- a/app/views/people_filters/_form.html.haml
+++ b/app/views/people_filters/_form.html.haml
@@ -23,8 +23,9 @@
     = render(layout: 'filter', locals: { type: :attributes }) do
       = render 'attributes', f: f
 
-    = render(layout: 'filter', locals: { type: :language }) do
-      = render 'language', f: f
+    - FeatureGate.if('person_language') do
+      = render(layout: 'filter', locals: { type: :language }) do
+        = render 'language', f: f
 
     = render(layout: 'filter', locals: { type: :tag }) do
       .label-columns

--- a/app/views/people_filters/_language.html.haml
+++ b/app/views/people_filters/_language.html.haml
@@ -8,5 +8,5 @@
 - Person::LANGUAGES.map do |language_value, language_name|
   - id = "filters_language_allowed_values_#{language_value}"
   = label_tag(nil, class: 'checkbox ', for: id) do
-    = check_box_tag("filters[language][allowed_values][]", language_value, filter&.allowed_values&.include?(language_value.to_s), id: id) 
+    = check_box_tag("filters[language][allowed_values][]", language_value, filter&.allowed_values&.include?(language_value.to_s), id: id)
     = language_name

--- a/app/views/subscriber/filter/_form.html.haml
+++ b/app/views/subscriber/filter/_form.html.haml
@@ -5,7 +5,7 @@
 
 - title t('subscriber.filter.show.title')
 
-= entry_form(url: group_mailing_list_filter_path(@group, @mailing_list), 
+= entry_form(url: group_mailing_list_filter_path(@group, @mailing_list),
              method: :PATCH,
              stacked: true,
              buttons_bottom: false,

--- a/app/views/subscriber/filter/_form.html.haml
+++ b/app/views/subscriber/filter/_form.html.haml
@@ -15,5 +15,6 @@
     = render(layout: 'people_filters/filter', locals: { entry: @mailing_list, type: :attributes }) do
       = render 'people_filters/attributes', f: f, entry: @mailing_list
 
-    = render(layout: 'people_filters/filter', locals: { type: :language }) do
-      = render 'people_filters/language', f: f, entry: @mailing_list
+    - FeatureGate.if('person_language') do
+      = render(layout: 'people_filters/filter', locals: { type: :language }) do
+        = render 'people_filters/language', f: f, entry: @mailing_list


### PR DESCRIPTION
The filter for the core-attribute `language` is always shown. This PR restricts the filter to wagons that use the field. 

See #2620 

