### PR TITLE
[skip ci] Move ability aspects from guideless to architecture konzepte

### DIFF
--- a/app/abilities/ability_dsl/base.rb
+++ b/app/abilities/ability_dsl/base.rb
@@ -12,6 +12,7 @@ module AbilityDsl
   #
   #    permission(:group_read).may(:show).in_same_group
   #    permission(:layer_and_below_full).may(:update, :destroy).in_same_layer_or_below
+  #    general(:send_password_instructions).not_self
   #  end
   #
   # All permissions in the given block apply for a Person instance.

--- a/doc/architecture/08_konzepte.md
+++ b/doc/architecture/08_konzepte.md
@@ -2,42 +2,42 @@
 
 ### Fachliche Strukturen
 
-Diese Sicht zeigt die Hauptmodelle in hitobito. Ein vollständiges und aktuelles Datenmodell kann mit 
+Diese Sicht zeigt die Hauptmodelle in hitobito. Ein vollständiges und aktuelles Datenmodell kann mit
 dem Befehl `rake erd` generiert werden.
 
 ![Fachliches Modell](diagrams/fachmodell.svg)
 
-**Group**: Modelliert die Baumstruktur der Gruppen eines Verbandes. Die konkreten Gruppentypen 
-werden als Subklassen von den jeweiligen Verbandsplugins definiert und mittels 
-[Single Table Inheritance](http://api.rubyonrails.org/classes/ActiveRecord/Inheritance.html) 
-persistiert. Verschiedene Klassenattribute können zur Spezifizierung eines Gruppentyps herangezogen 
-werden, wie beispielsweise die jeweils erlaubten Rollentypen. Die Baumstruktur ist als 
-[Nested Set](http://de.wikipedia.org/wiki/Nested_Sets) persistiert. Es wird unterschieden zwischen 
+**Group**: Modelliert die Baumstruktur der Gruppen eines Verbandes. Die konkreten Gruppentypen
+werden als Subklassen von den jeweiligen Verbandsplugins definiert und mittels
+[Single Table Inheritance](http://api.rubyonrails.org/classes/ActiveRecord/Inheritance.html)
+persistiert. Verschiedene Klassenattribute können zur Spezifizierung eines Gruppentyps herangezogen
+werden, wie beispielsweise die jeweils erlaubten Rollentypen. Die Baumstruktur ist als
+[Nested Set](http://de.wikipedia.org/wiki/Nested_Sets) persistiert. Es wird unterschieden zwischen
 einfachen Gruppen und Ebenen/Layer. Ebenen bilden jeweils einen Berechtigungsbereich.
 
-**Person**: Eine Person kann mehrere Rollen in mehreren Gruppen haben (via `Role`), an verschiedenen 
+**Person**: Eine Person kann mehrere Rollen in mehreren Gruppen haben (via `Role`), an verschiedenen
 Events teilnehmen (via `Event::Participation`) und bei mehreren `MailingLists` angemeldet sein (via
-`Subscription`). Jede Person kann ein Login haben, die Rollen bestimmen ihre Berechtigungen. 
-Änderungen an personenspezifischen Daten werden mit 
-[Paper Trail](https://github.com/airblade/paper_trail) aufgezeichnet. Personen können sowohl 
+`Subscription`). Jede Person kann ein Login haben, die Rollen bestimmen ihre Berechtigungen.
+Änderungen an personenspezifischen Daten werden mit
+[Paper Trail](https://github.com/airblade/paper_trail) aufgezeichnet. Personen können sowohl
 natürliche wie auch juristische (Firmen) sein.
 
 **Event**: Ein einfacher Anlass, ein Kurs oder beliebiger weiterer verbandspezifischer Event. Dieser
-kann von mehreren Gruppen durchgeführt werden. Die Eventtypen werden wie die Gruppen über 
-Klassenattribute spezifiziert und mittels 
-[Single Table Inheritance](http://api.rubyonrails.org/classes/ActiveRecord/Inheritance.html) 
-persistiert. Kurse verfügen darüber hinaus noch über eine Kursart und damit über 
+kann von mehreren Gruppen durchgeführt werden. Die Eventtypen werden wie die Gruppen über
+Klassenattribute spezifiziert und mittels
+[Single Table Inheritance](http://api.rubyonrails.org/classes/ActiveRecord/Inheritance.html)
+persistiert. Kurse verfügen darüber hinaus noch über eine Kursart und damit über
 Qualifikationseigenschaften.
 
-**MailingList**: Jede Gruppe kann beliebig viele Abos haben, welche optional eine E-Mail Adresse 
-haben und dadurch ebenfalls als E-Mail Liste verwendet werden können. Einzelne Personen, jedoch auch 
+**MailingList**: Jede Gruppe kann beliebig viele Abos haben, welche optional eine E-Mail Adresse
+haben und dadurch ebenfalls als E-Mail Liste verwendet werden können. Einzelne Personen, jedoch auch
 bestimmte Rollen einer Gruppe oder Teilnehmende eines Events können Abonnenten sein.
 
 ### Wagons
 
-Die Applikation ist aufgeteilt in Core (generischer Teil) und Wagons (Verbandsspezifische 
-Erweiterungen). Zur Funktionsweise von Wagons allgemein siehe auch 
-[wagons](http://github.com/codez/wagons). Falls die Applikation für weitere Verbände customized 
+Die Applikation ist aufgeteilt in Core (generischer Teil) und Wagons (Verbandsspezifische
+Erweiterungen). Zur Funktionsweise von Wagons allgemein siehe auch
+[wagons](http://github.com/codez/wagons). Falls die Applikation für weitere Verbände customized
 werden soll, können einfach weitere Wagons erstellt werden.
 
 In einem Wagon können Tabellen um weitere Attribute ergänzt werden, Funktionalitäten, Berechtigungen
@@ -88,7 +88,7 @@ This includes all subgroups of that group. Unless they are declared as layers th
 
       children Group::Layer, Group::Board, Group::Basic
 
-This assigns all allowed subgroups (`Group::Layer, Group::Board, Group::Basic`). 
+This assigns all allowed subgroups (`Group::Layer, Group::Board, Group::Basic`).
 You will only be able to create this type of group under the `Group::Layer`.
 As you can see in this example, group types can be organized recursively.
 
@@ -100,7 +100,7 @@ Whenever a group of this type is created, it automatically creates groups from t
         self.permissions = [:layer_full, :contact_data]
       end
 
-Role types can be declared directly in the Group class. They belong to the class `Role`. 
+Role types can be declared directly in the Group class. They belong to the class `Role`.
 Every Role Type has a list of permissions (`self.permissions = [:layer_full, :contact_data]`).
 All the actions a User can do will be derived from these role permissions, depending on where a user is assigned in which role will give him the associated permissions.
 
@@ -113,7 +113,7 @@ All the actions a User can do will be derived from these role permissions, depen
 Permission can also be empty, but a user will always be able to change his own contact details.
 
 You can reduce the visiblity of roles from layers above by using `self.visible_from_above = false`.
-This means that this role is not visible to peple from above layers, 
+This means that this role is not visible to peple from above layers,
 even if they have the general permission to see people from layer below them.
 
 A Roletype can additional be of a specific kind `self.kind = :external` which is used in certain views to differentiate between different kinds of role. The core defines the following kinds: `[:member, :passive, :external]`. But this has no influence on permissions.
@@ -126,33 +126,34 @@ After the declaration of the Roles, you can select one to be automatically selec
 
 Define which roles are actually available to be assigned.
 
+
 ### Berechtigungen
 
-Das Berechtigungssystem definiert, ob ein Benutzer eine spezifische Aktion aufrufen darf oder nicht. 
-Dafür sind die jeweiligen Rollen sowie deren zugeordnete Grundberechtigungen / Permissions relevant. 
-Diese sind allgemeine Angaben für ein Was und Wo, auf welchen die konkreten Berechtigungen aufbauen. 
-Eine Permission soll immer einen ganzen Bereich von Aktionen abdecken, nie nur eine einzelne. 
+Das Berechtigungssystem definiert, ob ein Benutzer eine spezifische Aktion aufrufen darf oder nicht.
+Dafür sind die jeweiligen Rollen sowie deren zugeordnete Grundberechtigungen / Permissions relevant.
+Diese sind allgemeine Angaben für ein Was und Wo, auf welchen die konkreten Berechtigungen aufbauen.
+Eine Permission soll immer einen ganzen Bereich von Aktionen abdecken, nie nur eine einzelne.
 
 Folgende Permissions existieren momentan:
 
 **admin**: Administration von applikationsweiten Einstellungen wie Kursarten oder Etikettenformate.
 
-**layer_and_below_full**: Alles Lesen und Schreiben auf dieser Ebene und allen darunter liegenden 
+**layer_and_below_full**: Alles Lesen und Schreiben auf dieser Ebene und allen darunter liegenden
 Ebenen. Erstellen von Anlässen und Abos (Mailinglisten) auf dieser Ebene.
 
 **layer_and_below_read**: Alles Lesen auf dieser Ebene und allen darunter liegenden Ebenen.
 
-**layer_full**: Alles Lesen und Schreiben auf dieser Ebene. Erstellen von Anlässen und Abos 
+**layer_full**: Alles Lesen und Schreiben auf dieser Ebene. Erstellen von Anlässen und Abos
 (Mailinglisten) auf dieser Ebene.
 
 **layer_read**: Alles Lesen auf dieser Ebene.
 
-**group_and_below_full**: Lesen und Schreiben auf dieser und allen darunter liegenden Gruppen (ohne 
+**group_and_below_full**: Lesen und Schreiben auf dieser und allen darunter liegenden Gruppen (ohne
 Ebenen). Inkl. Erstellen von Anlässen und Abos (Mailinglisten).
 
 **group_and_below_read**: Lesen auf dieser und allen darunter liegenden Gruppen (ohne Ebenen).
 
-**group_full**: Lesen und Schreiben nur auf dieser Gruppe. Erstellen von Anlässen und Abos 
+**group_full**: Lesen und Schreiben nur auf dieser Gruppe. Erstellen von Anlässen und Abos
 (Mailinglisten) auf der Gruppe.
 
 **group_read**: Lesen nur auf dieser Gruppe.
@@ -165,107 +166,122 @@ Ebenen). Inkl. Erstellen von Anlässen und Abos (Mailinglisten).
 
 **finance**: Erlaubt auf der eigenen Ebene Rechnungen zu erstellen und einzusehen.
 
-**see_invisible_from_above**: Kann Accounts in tieferen Ebenen verwalten, welche sonst für den Benutzer unsichtbar wären.
+**see_invisible_from_above**: Kann Accounts in tieferen Ebenen verwalten, welche sonst für den
+Benutzer unsichtbar wären.
 
-Die Definition von Berchtigungen geschieht in sogenannten _Abilities_. Diese verknüpfen ein Modell 
-sowie die zugehörigen Aktionen mit den entsprechenden Permissions, wobei durch sogenannte 
-_Constraints_ alle Details geregelt werden. Constraints sind nichts anderes als sprechende Methoden, 
-welche aufgrund Modelleigenschaften und Benutzerrollen die genauen Bedingungen der Berechtigung 
-festlegen. Dies sieht wie folgt aus:
+Die Definition von Berechtigungen geschieht in sogenannten _Abilities_. Diese verknüpfen ein Modell
+sowie die zugehörigen Aktionen mit den entsprechenden Permissions, wobei durch sogenannte
+_Constraints_ alle Details geregelt werden. Constraints sind nichts anderes als sprechende Methoden,
+welche aufgrund Modelleigenschaften und Benutzerrollen die genauen Bedingungen der Berechtigung
+festlegen.
+
+Dies sieht wie folgt aus:
 
     on(Person) do
       permission(:group_full).may(:update).in_same_group
     end
-    
+
     def in_same_group
       roles_with_permission = user.roles.select {|r| r.permissions.include?(permission) }
       (roles_with_permission.collect(&:group_id) & subject.group_ids).present?
     end
 
-Diese Deklaration erteilt einer Rolle mit der Permission `:group_full` die Berechtigung, die 
-`update` Aktion auf einer `Person` auszuführen, falls diese `in_same_group` ist. Hier prüft z.B. die 
-Constraint `in_same_group`, dass die Person (`subject`) in der selben Gruppe wie die Benutzerrolle 
-mit der zugehörigen Permission sein muss. Zur Deklaration von Berechtigungen sind zusätzlich die 
-beiden abstrakten Permissions `any` und `general` verfügbar. `any` trifft auf alle Benutzenden 
-unabhängig ihrer Permissions zu. Damit können für alle Benutzer geltende Berechtigungen definiert 
-werden oder, in der Constraint, Einschränkungen nach spezifischen Rollentypen unabhängig ihrer 
-Permissions vorgenommen werden. Die abstrakte Permission `general` wird _zusätzlich_ zu allen 
-anderen Berechtigungsdeklarationen dieser Aktion ebenfalls geprüft. Die Aktionen entsprechen 
-denjenigen von [CanCanCan](https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities), 
-Aliase wie `manage` oder `read` sind ebenfalls möglich. Von allen definierten Berechtigungen muss 
-mindestens eine Constraint erfüllt sein, damit ein Benutzer die gewünschte Aktion ausführen kann.
+Diese Deklaration erteilt einer Rolle mit der Permission `:group_full` die Berechtigung, die
+`update` Aktion auf einer `Person` auszuführen, falls diese `in_same_group` ist. Hier prüft z.B. die
+Constraint `in_same_group`, dass die Person (`subject`) in der selben Gruppe wie die Benutzerrolle
+mit der zugehörigen Permission sein muss. Zur Deklaration von Berechtigungen sind zusätzlich die
+beiden abstrakten Permissions `any` und `general` verfügbar.
 
-Jede neu implementierte Aktion erfordert in der Regel eine neue Berechtiungsdeklaration. Diese 
-sollte möglichst auf den bestehenden Constraints und Permissions aufbauen. Ansonsten können neue 
-Constraints dafür definiert werden, neue Permissions sind äusserst zurückhaltend einzuführen.
+Abilities basieren immer auf einer Instanz (`subject`). Falls eine Action nicht auf einer Instanz
+agiert, sind `class_side` Abilities zu definieren. Constraints sind unique für ein (Permission,
+Subject, Action) Tupel und dürfen im Wagon neu definiert (= überschrieben) werden.
+
+Die abstrakte Permission `any` trifft auf alle Benutzenden unabhängig ihrer Permissions zu. Damit
+können für alle Benutzer geltende Berechtigungen definiert werden oder, in der Constraint,
+Einschränkungen nach spezifischen Rollentypen unabhängig ihrer Permissions vorgenommen werden.
+
+Die abstrakte Permission `general` wird _zusätzlich_ zu allen anderen Berechtigungsdeklarationen
+dieser Aktion ebenfalls geprüft und wird für Permissions unabhängige allgemeine Einschränkungen
+verwendet.
+
+
+Die Aktionen entsprechen denjenigen von
+[CanCanCan](https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities), Aliase wie
+`manage` oder `read` sind ebenfalls möglich. Von allen definierten Berechtigungen muss mindestens
+eine Constraint erfüllt sein, damit ein Benutzer die gewünschte Aktion ausführen kann.
+
+Jede neu implementierte Aktion erfordert in der Regel eine neue Berechtigungsdeklaration. Diese
+sollte möglichst auf den bestehenden Constraints und Permissions aufbauen und nur in Ausnahmen auf
+konkreten Rollen. Ansonsten können neue Constraints dafür definiert werden. Neue Permissions sind
+äusserst zurückhaltend einzuführen.
 
 Folgende zwei Rake Tasks helfen bei der Dokumentation der Rollen und Berechtigungen:
 
     rake hitobito:roles
 
-Gibt alle Gruppen und zugehörigen Rollen und deren Grundberechtigungen aus. Strukturierung nach 
-Ebene, Gruppen, Rollen und Permissions. Globale Gruppen können bei jeder Gruppe als Untergruppe 
+Gibt alle Gruppen und zugehörigen Rollen und deren Grundberechtigungen aus. Strukturierung nach
+Ebene, Gruppen, Rollen und Permissions. Globale Gruppen können bei jeder Gruppe als Untergruppe
 erstellt werden, Globale Rollen (Global Global) sind bei allen Gruppen verfügbar.
 
     rake hitobito:abilities
 
-Gibt alle Berechtigungen entsprechend den Permissions aus. Übersicht über die Definition der 
-Berechtigungen, welche ein Benutzer benötigt, um eine bestimmte Aktion auf einem bestimmten Modell 
-auszuführen.
+Gibt alle Berechtigungen entsprechend den Permissions aus und lieft somit eine Übersicht über die
+Definition der Berechtigungen, welche ein Benutzer benötigt, um eine bestimmte Aktion auf einem
+bestimmten Modell auszuführen.
 
-Lesebeispiel am Beispiel Jubla: _Kann ein Mitglied der Bundesleitung einen Anlass einer Schar 
+Lesebeispiel am Beispiel Jubla: _Kann ein Mitglied der Bundesleitung einen Anlass einer Schar
 bearbeiten?_
 
-* Ein Mitglied der Bundesleitung hat die Permissions `[:admin, :layer_and_below_full, 
+* Ein Mitglied der Bundesleitung hat die Permissions `[:admin, :layer_and_below_full,
 :contact_data]`.
-* Bearbeiten (`update`) eines Events erfordert `any/for_leaded_events`, `group_full/in_same_group`, 
-`layer_and_below_full/in_same_layer_or_below` sowie die allgemeine Constraint 
+* Bearbeiten (`update`) eines Events erfordert `any/for_leaded_events`, `group_full/in_same_group`,
+`layer_and_below_full/in_same_layer_or_below` sowie die allgemeine Constraint
 `at_least_one_group_not_deleted_and_not_closed_or_admin`.
-* Der Anlass einer Schar ist unterhalb der Ebene Bund des Bulei Mitglieds, somit kommt 
+* Der Anlass einer Schar ist unterhalb der Ebene Bund des Bulei Mitglieds, somit kommt
 `layer_and_below_full/in_same_layer_or_below` zum Zug.
-* Die allgemeine Constraint wirkt in jedem Fall. Falls die Schar also nicht gelöscht ist 
-(`at_least_one_group_not_deleted_and_not_closed_or_admin`), kann dieser Benutzer den Anlass 
+* Die allgemeine Constraint wirkt in jedem Fall. Falls die Schar also nicht gelöscht ist
+(`at_least_one_group_not_deleted_and_not_closed_or_admin`), kann dieser Benutzer den Anlass
 bearbeiten. (Das `not_closed_..` trifft nur auf Kurse zu).
 
 
 ### Anlässe und Kurse
 
-Anlässe sind ähnlich wie Gruppen immer von einem bestimmten Anlasstyp. Jeder Gruppentyp definiert, 
-welche Anlasstypen in einer jeweiligen Gruppe erstellt werden können. Ein Anlass kann neben 
-Grundinformationen mehrere Daten (`Event::Date`) und beliebige Zusatzangaben (`Event::Question`) 
-definieren, welche die Teilnehmenden bei der Anmeldung angeben müssen (`Event::Answer`). Eine 
-Person, welche an einem Anlass teilnimmt (`Event::Participation`), kann dort mehrere Rollen 
-(`Event::Role`) inhaben. 
+Anlässe sind ähnlich wie Gruppen immer von einem bestimmten Anlasstyp. Jeder Gruppentyp definiert,
+welche Anlasstypen in einer jeweiligen Gruppe erstellt werden können. Ein Anlass kann neben
+Grundinformationen mehrere Daten (`Event::Date`) und beliebige Zusatzangaben (`Event::Question`)
+definieren, welche die Teilnehmenden bei der Anmeldung angeben müssen (`Event::Answer`). Eine
+Person, welche an einem Anlass teilnimmt (`Event::Participation`), kann dort mehrere Rollen
+(`Event::Role`) inhaben.
 
-Der Anlasstyp bestimmt die möglichen Rollentypen, welche die Teilnehmenden eines Anlasses haben 
-können. 
+Der Anlasstyp bestimmt die möglichen Rollentypen, welche die Teilnehmenden eines Anlasses haben
+können.
 
-Ein Anlass-Rollentyp definiert ähnlich wie ein Gruppen-Rollentyp Grundberechtigungen 
-(`permissions`), allerdings nur spezifisch für den jeweiligen Anlass. Folgende sind in hitobito 
+Ein Anlass-Rollentyp definiert ähnlich wie ein Gruppen-Rollentyp Grundberechtigungen
+(`permissions`), allerdings nur spezifisch für den jeweiligen Anlass. Folgende sind in hitobito
 definiert:
 
 **event_full**: Darf den Anlass bearbeiten.
 
-**participations_full**: Sieht alle Informationen der Teilnehmenden und darf die Teilnahmedaten 
+**participations_full**: Sieht alle Informationen der Teilnehmenden und darf die Teilnahmedaten
 bearbeiten.
 
 **participations_read**: Sieht die öffentlichen Informationen der Teilnehmenden.
 
 **qualify**: Darf den Teilnehmenden eines Kurses die definierten Qualifikationen vergeben.
 
-Ein Rollentyp ist von einer spezifischen Art, welche an gibt, was die Funktion im Anlass ist. 
-Hitobito definiert die Arten Leiter/-in, Helfer/-in und Teilnehmer/-in. Die Art wird unter anderem 
-verwendet bei der Unterteilung in Leitungsteam und Teilnehmende und hat keinen Einfluss auf die 
+Ein Rollentyp ist von einer spezifischen Art, welche an gibt, was die Funktion im Anlass ist.
+Hitobito definiert die Arten Leiter/-in, Helfer/-in und Teilnehmer/-in. Die Art wird unter anderem
+verwendet bei der Unterteilung in Leitungsteam und Teilnehmende und hat keinen Einfluss auf die
 Berechtigungen.
 
-Ein Anlass kann selber auch von einer spezifischen Art sein. Dies wird bei den Kursen verwendet, 
-welche einer bestimmten Kursart (`Event::Kind`) zugeordnet sind. Über die Kursart werden 
-Aufnahmebedingungen sowie die erteilten und verlängerten Qualifikationsarten (`QualificationKind`) 
+Ein Anlass kann selber auch von einer spezifischen Art sein. Dies wird bei den Kursen verwendet,
+welche einer bestimmten Kursart (`Event::Kind`) zugeordnet sind. Über die Kursart werden
+Aufnahmebedingungen sowie die erteilten und verlängerten Qualifikationsarten (`QualificationKind`)
 definiert.
 
-Weiter kann konfigurativ definiert werden, ob ein Anlass Anmeldungen unterstützt. Damit kommt die 
-Möglichkeit, Personen zuzuweisen oder abzulehnen sowie an andere, ähnliche Anlässe zu verweisen. 
-Falls Anmeldungen unterstützt werden, kann eine Teilnahme (`Event::Participation`) aktiviert sein 
+Weiter kann konfigurativ definiert werden, ob ein Anlass Anmeldungen unterstützt. Damit kommt die
+Möglichkeit, Personen zuzuweisen oder abzulehnen sowie an andere, ähnliche Anlässe zu verweisen.
+Falls Anmeldungen unterstützt werden, kann eine Teilnahme (`Event::Participation`) aktiviert sein
 oder nicht. Sonst ist sie immer aktiv.
 
 
@@ -275,10 +291,10 @@ siehe [Mailing Listen / Abos](https://github.com/hitobito/hitobito/tree/master/d
 
 ### Single Table Inheritance
 
-Verschiedene Modelle in hitobito verwenden 
-[Single Table Inheritance](http://api.rubyonrails.org/classes/ActiveRecord/Inheritance.html), z.B. 
-`Group`, `Role` und `Event`. Dabei werden verschiedene Ruby Klassen, welche alle von der selben 
-Hauptklasse erben, in einer Tabelle gespeichert. Nicht alle Subklassen müssen dabei alle in der 
-Tabelle vorhandenen Spalten verwenden. Zur Dokumentation wie auch zum Bestimmen, welche Attribute 
-angezeigt werden sollen, werden die verwendeten Spalten in der jeweiligen Klassenvariable 
+Verschiedene Modelle in hitobito verwenden
+[Single Table Inheritance](http://api.rubyonrails.org/classes/ActiveRecord/Inheritance.html), z.B.
+`Group`, `Role` und `Event`. Dabei werden verschiedene Ruby Klassen, welche alle von der selben
+Hauptklasse erben, in einer Tabelle gespeichert. Nicht alle Subklassen müssen dabei alle in der
+Tabelle vorhandenen Spalten verwenden. Zur Dokumentation wie auch zum Bestimmen, welche Attribute
+angezeigt werden sollen, werden die verwendeten Spalten in der jeweiligen Klassenvariable
 `used_attributes` angegeben.

--- a/doc/development/03_guidelines.md
+++ b/doc/development/03_guidelines.md
@@ -1,5 +1,8 @@
 ## Entwicklungs Guidelines
 
+Für Dokumentation von ArchitekturKonzepten (Fachliche Strukturen, Rolle, Anlässe, Kurse, Abilities
+..) siehe [doc/architectur/08_kozepte.md](doc/architectur/08_kozepte.md).
+
 ### Code Conventions
 
 Die Code Conventions werden mit Rubocop überprüft und sind in `.rubocop.yml` definiert.
@@ -17,21 +20,14 @@ Das selbe gilt für Warnungen, welche im CI auftreten (Brakeman, ...).
 
 Allgemeine Konventionen und Erklärungen für spezifische Bereiche.
 
-* Für jeden Link in den View mit `can?` prüfen, ob die Action auch erlaubt ist.
-* Permissions definieren grobe Bereiche, Constraints die Bedingungen für konkrete Aktionen. Eine
-Aktion entspricht in der Regel einer Controller Action und wird durch ein spezifisches Verb
-repräsentiert. Constraints sollen wenn möglich auf den bestehenden Permissions aufbauen und nur in
-Ausnahmen auf konkreten Rollen. Neue Permissions dürfen nur äusserts zurückhaltend und sehr gut
-begründet eingeführt werden.
-* Beim Überprüfen von Berechtigungen mit `can?` immer eine Action (bzw. das Symbol, welches die
-Aktion widerspiegelt) entspreched der jeweiligen Aktion verwenden. Negativbeispiel: Die Anzeige
-gewisser Attribute mit `can?(:update, entry)` überprüfen. Besser spezifisches Symbol einführen,
-falls noch nicht vorhanden, z.B. `can?(:show_sensitive_data, entry)`. Natürlich dürfen die gleichen
-Constraints wieder verwendet werden.
-* Abilities basieren immer auf einer Instanz (`subject`). Falls eine Action nicht auf einer Instanz
-agiert, sind `class_side` abilities zu definieren.
+* Commits immer mit dem Github Ticket versehen (#123).
 * Controller Specs rendern NIE eine View. Dafür sind die Regression Specs da.
-* Commits immer mit dem Redmine/Github Ticket versehen (fixes/refs #123).
+* Beim Überprüfen von Berechtigungen mit `can?` immer eine Action (bzw. das Symbol, welches die
+  Aktion widerspiegelt) entsprechend der jeweiligen Aktion verwenden. Negativbeispiel: Die Anzeige
+  gewisser Attribute mit `can?(:update, entry)` überprüfen. Besser spezifisches Symbol einführen,
+  falls noch nicht vorhanden, z.B. `can?(:show_sensitive_data, entry)`. Natürlich dürfen die
+  gleichen Constraints wieder verwendet werden.
+
 
 #### Durchklicken!
 
@@ -82,9 +78,10 @@ Ein beispielhafte Anleitung, wie in einem Wagon Attribute hinzugefügt werden k�
 * CSV Export (Adressexport? Voller Export?)
 * Log (Papertrail)
 
-#### Rollen umbennen / entfernen
+#### Rollen umbenennen / entfernen
 
 * Migration aller betroffenen `Role` Instanzen (`with_deleted`!).
+* Migration aller betroffenen `FutureRole` Instanzen.
 * Migration aller betroffenen `RelatedRoleType` Instanzen.
 * Migration aller Papertrail Versionen (`#object` und `#object_changes`).
 


### PR DESCRIPTION
Wie etwas funktioniert sollte in der architektur dokumentation und nicht in den guidelines beschrieben sein. 