### PR TITLE
Run wagon specs in parallel

### DIFF
--- a/.github/actions/core-ci-setup/action.yml
+++ b/.github/actions/core-ci-setup/action.yml
@@ -4,7 +4,7 @@ description: 'DRY yaml setup setup steps which are used multiple times in the co
 inputs:
   migrations:
     description: Unless set to false, migrations will be run as part of the setup.
-    default: true
+    default: 'true'
 
 runs:
   using: composite
@@ -71,7 +71,7 @@ runs:
       shell: bash
 
     - name: 'Run db migrations'
-      if: inputs.migrations
+      if: inputs.migrations == 'true'
       run: |
         bundle exec rake db:migrate
       shell: bash

--- a/.github/actions/wagon-ci-setup/action.yml
+++ b/.github/actions/wagon-ci-setup/action.yml
@@ -4,7 +4,7 @@ description: 'DRY yaml setup setup steps which are used multiple times in the wa
 inputs:
   migrations:
     description: Unless set to false, migrations will be run as part of the setup.
-    default: true
+    default: 'true'
   wagon_repository:
     description: "Wagon repository, e.g. hitobito_pbs"
   wagon_dependency_repository:
@@ -199,6 +199,7 @@ runs:
       shell: bash
 
     - name: 'Create DB'
+      if: inputs.migrations == 'true'
       run: |
         bundle exec rake db:create
       working-directory: hitobito
@@ -211,13 +212,14 @@ runs:
       shell: bash
 
     - name: 'Run core migrations'
+      if: inputs.migrations == 'true'
       run: |
         bundle exec rake db:migrate
       working-directory: hitobito
       shell: bash
 
     - name: 'Run wagon migrations'
-      if: inputs.migrations
+      if: inputs.migrations == 'true'
       run: |
         bundle exec rake wagon:migrate
       working-directory: hitobito

--- a/.github/actions/wagon-ci-setup/action.yml
+++ b/.github/actions/wagon-ci-setup/action.yml
@@ -1,0 +1,224 @@
+name: 'Setup steps for wagon CI'
+description: 'DRY yaml setup setup steps which are used multiple times in the wagon CI workflow'
+
+inputs:
+  migrations:
+    description: Unless set to false, migrations will be run as part of the setup.
+    default: true
+  wagon_repository:
+    description: "Wagon repository, e.g. hitobito_pbs"
+  wagon_dependency_repository:
+    description: A wagon this wagon depends on, e.g. hitobito_youth
+    required: false
+    default: ''
+  core_ref:
+    description: Use a specific version of the core for the workflow run. Defaults to master.
+    default: ''
+  wagon_dependency_ref:
+    description: Use a specific version of the wagon dependency for the workflow run. Defaults to master.
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: 'Determine common branch and set branch name for core'
+      if: github.event_name != 'pull_request'
+      env:
+        INPUT_CORE_REF: ${{ inputs.core_ref }}
+      run: |
+        CORE_REF="$INPUT_CORE_REF"
+        if [ -z "$INPUT_CORE_REF" ]; then
+          CORE_REF=$(git ls-remote --heads https://github.com/hitobito/hitobito | cut -d/ -f3- | grep -x "${{github.ref_name}}" || echo 'master')
+          # core_branch=$(git ls-remote --heads https://github.com/hitobito/hitobito | cut -d/ -f3- | grep -x "${{github.ref_name}}")
+          # if [ "$core_branch" != '' ]; then
+          #   CORE_REF="${{github.ref_name}}"
+          # else
+          #   CORE_REF="master"
+          # fi
+        fi
+
+        echo "CORE_REF=$CORE_REF" >> $GITHUB_ENV
+      shell: bash
+
+    - name: 'Determine common branch and set branch name for dependency repo'
+      if: (github.event_name != 'pull_request') && (inputs.wagon_dependency_repository != '')
+      env:
+        WAGON_DEPENDENCY_REPO: ${{ inputs.wagon_dependency_repository }}
+        INPUT_WDEP_REF: ${{ inputs.wagon_dependency_ref }}
+      run: |
+        WAGON_DEPENDENCY_REF="$INPUT_WDEP_REF"
+        if [ -z "$INPUT_WDEP_REF" ] && [ "$WAGON_DEPENDENCY_REPO" != '' ]; then
+          WAGON_DEPENDENCY_REF=$(git ls-remote --heads https://github.com/hitobito/$WAGON_DEPENDENCY_REPO | cut -d/ -f3- | grep -x "${{github.ref_name}}" || echo 'master')
+          # dependency_branch=$(git ls-remote --heads https://github.com/hitobito/$WAGON_DEPENDENCY_REPO | cut -d/ -f3- | grep -x "${{github.ref_name}}")
+          # if [ "$dependency_branch" != '' ]; then
+          #   WAGON_DEPENDENCY_REF="${{github.ref_name}}"
+          # else
+          #   WAGON_DEPENDENCY_REF="master"
+          # fi
+        fi
+
+        echo "WAGON_DEPENDENCY_REF=$WAGON_DEPENDENCY_REF" >> $GITHUB_ENV
+      shell: bash
+
+    - name: 'Set branch name'
+      if: github.event_name == 'pull_request'
+      env:
+        WAGON_DEPENDENCY_REPO: ${{ inputs.wagon_dependency_repository }}
+        INPUT_WDEP_REF: ${{ inputs.wagon_dependency_ref }}
+        INPUT_CORE_REF: ${{ inputs.core_ref }}
+      run: |
+        WAGON_DEPENDENCY_REF="$INPUT_WDEP_REF"
+        if [ -z "${INPUT_WDEP_REF}" ] && [ "${WAGON_DEPENDENCY_REPO}" != '' ]; then
+          WAGON_DEPENDENCY_REF="master"
+        fi
+
+        CORE_REF="$INPUT_CORE_REF"
+        if [ -z "${INPUT_CORE_REF}" ]; then
+          CORE_REF="master"
+        fi
+
+        echo "WAGON_DEPENDENCY_REF=$WAGON_DEPENDENCY_REF" >> $GITHUB_ENV
+        echo "CORE_REF=$CORE_REF" >> $GITHUB_ENV
+      shell: bash
+
+    - name: 'Checkout hitobito at ${{ env.CORE_REF }}'
+      uses: actions/checkout@v4
+      with:
+        repository: 'hitobito/hitobito'
+        ref: ${{ env.CORE_REF }}
+        path: 'hitobito'
+
+    - name: 'Set up Ruby'
+      env:
+        ImageOS: ubuntu20
+      uses: ruby/setup-ruby@v1
+      with:
+        working-directory: hitobito
+
+    - name: 'Set up Node'
+      uses: actions/setup-node@v4
+      with:
+        node-version: '14'
+
+    - name: 'Setup OS'
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install sphinxsearch
+        echo "ruby version: $(ruby -v)"
+        echo "node version: $(node -v)"
+        echo "yarn version: $(yarn -v)"
+      working-directory: hitobito
+      shell: bash
+
+    - name: 'Copy Wagonfile.ci'
+      run: |
+        cp -v Wagonfile.ci Wagonfile
+      working-directory: hitobito
+      shell: bash
+
+    - name: 'Checkout dependency ${{ inputs.wagon_dependency_repository }} at ${{ env.WAGON_DEPENDENCY_REF }}'
+      uses: actions/checkout@v4
+      if: ${{ inputs.wagon_dependency_repository != '' }}
+      with:
+        repository: hitobito/${{ inputs.wagon_dependency_repository }}
+        ref: ${{ env.WAGON_DEPENDENCY_REF }}
+        path: ${{ inputs.wagon_dependency_repository }}
+
+    - name: Checkout ${{ inputs.wagon_repository }}
+      uses: actions/checkout@v4
+      with:
+        path: ${{ inputs.wagon_repository }}
+
+    - name: 'Create cache key'
+      run: cp Gemfile.lock Gemfile.lock.backup
+      working-directory: hitobito
+      shell: bash
+
+    - uses: actions/cache@v4
+      with:
+        path: hitobito/vendor/bundle
+        key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
+        restore-keys: |
+          ${{ runner.os }}-ruby-bundle-
+
+    - uses: actions/cache@v4
+      if: ${{ inputs.wagon_dependency_repository != '' }}
+      with:
+        path: ${{ inputs.wagon_dependency_repository }}/vendor/bundle
+        key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
+        restore-keys: |
+          ${{ runner.os }}-ruby-bundle-
+
+    - uses: actions/cache@v4
+      with:
+        path: ${{ inputs.wagon_repository }}/vendor/bundle
+        key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
+        restore-keys: |
+          ${{ runner.os }}-ruby-bundle-
+
+    - name: 'Bundle install core'
+      run: |
+        bundle install --jobs 4 --retry 3 --path vendor/bundle
+      working-directory: hitobito
+      shell: bash
+
+    - name: 'Make changes to Gemfile.lock transparent'
+      run: |
+        git diff Gemfile.lock || true
+      working-directory: hitobito
+      shell: bash
+
+    - name: 'Bundle install wagons'
+      run: |
+        hitobito_dir=$(realpath ./)
+        for d in $hitobito_dir/../hitobito_*; do
+          cd $d
+          cp -v $hitobito_dir/Gemfile.lock ./
+          bundle install --jobs 4 --retry 3 --path vendor/bundle
+        done
+      working-directory: hitobito
+      shell: bash
+
+    - uses: actions/cache@v4
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-node_modules-
+
+    - name: 'Yarn install'
+      run: |
+        yarn install --frozen-lockfile
+      working-directory: hitobito
+      shell: bash
+
+    - name: 'Run Webpacker'
+      run: |
+        bundle exec rake webpacker:compile
+      working-directory: hitobito
+      shell: bash
+
+    - name: 'Create DB'
+      run: |
+        bundle exec rake db:create
+      working-directory: hitobito
+      shell: bash
+
+    - name: 'Clear logs'
+      run: |
+        bundle exec rake log:clear
+      working-directory: hitobito
+      shell: bash
+
+    - name: 'Run core migrations'
+      run: |
+        bundle exec rake db:migrate
+      working-directory: hitobito
+      shell: bash
+
+    - name: 'Run wagon migrations'
+      if: inputs.migrations
+      run: |
+        bundle exec rake wagon:migrate
+      working-directory: hitobito
+      shell: bash

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -43,6 +43,7 @@ jobs:
       RAILS_DB_PASSWORD: hitobito
       RAILS_DB_NAME: hitobito_test
       RAILS_TEST_DB_NAME: hitobito_test
+      RAILS_ENV: test
 
     services:
       mysql:
@@ -230,12 +231,85 @@ jobs:
 
       - name: 'Run Webpacker'
         run: |
-          RAILS_ENV=test bundle exec rake webpacker:compile
+          bundle exec rake webpacker:compile
 
-      - name: 'Run wagon lint and tests'
-        id: tests
+      - name: 'Create DB'
         run: |
-          bundle exec rake db:create ci:wagon
+          bundle exec rake db:create
+
+      - name: 'Clear logs'
+        run: |
+          bundle exec rake log:clear
+
+      - name: 'Run core migrations'
+        run: |
+          bundle exec rake db:migrate
+
+      - name: 'Run wagon migrations'
+        run: |
+          bundle exec rake wagon:migrate
+
+      - name: ${{ inputs.wagon_dependency_repository || 'Dependency wagon' }} rubocop
+        if: ${{ inputs.wagon_dependency_repository != '' }}
+        working-directory: ${{ inputs.wagon_dependency_repository }}
+        run: |
+          bundle exec rake app:rubocop
+
+      - name: Setup ${{ inputs.wagon_dependency_repository || 'dependency wagon' }} specs
+        if: ${{ inputs.wagon_dependency_repository != '' }}
+        working-directory: ${{ inputs.wagon_dependency_repository }}
+        run: |
+          bundle exec rake app:ci:setup:rspec
+
+      - name: Check if there are any feature specs in ${{ inputs.wagon_dependency_repository || 'dependency wagon' }}
+        if: ${{ inputs.wagon_dependency_repository != '' }}
+        id: check-dependency-wagon-feature-specs
+        working-directory: ${{ inputs.wagon_dependency_repository }}
+        run: |
+          if [ -d "spec/features" ]; then
+            echo "feature_specs_exist=1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run ${{ inputs.wagon_dependency_repository || 'dependency wagon' }} feature specs
+        if: ${{ inputs.wagon_dependency_repository != '' && steps.check-dependency-wagon-feature-specs.outputs.feature_specs_exist }}
+        working-directory: ${{ inputs.wagon_dependency_repository }}
+        run: |
+          bundle exec rake spec:features
+
+      - name: Run ${{ inputs.wagon_dependency_repository || 'dependency wagon' }} specs
+        if: ${{ inputs.wagon_dependency_repository != '' }}
+        working-directory: ${{ inputs.wagon_dependency_repository }}
+        run: |
+          bundle exec rake spec
+
+      - name: ${{ inputs.wagon_repository }} rubocop
+        working-directory: ${{ inputs.wagon_repository }}
+        run: |
+          bundle exec rake app:rubocop
+
+      - name: Setup ${{ inputs.wagon_repository }} specs
+        working-directory: ${{ inputs.wagon_repository }}
+        run: |
+          bundle exec rake app:ci:setup:rspec
+
+      - name: Check if there are any feature specs in ${{ inputs.wagon_repository }}
+        id: check-wagon-feature-specs
+        working-directory: ${{ inputs.wagon_repository }}
+        run: |
+          if [ -d "spec/features" ]; then
+            echo "feature_specs_exist=1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run ${{ inputs.wagon_repository }} feature specs
+        if: ${{ steps.check-wagon-feature-specs.outputs.feature_specs_exist }}
+        working-directory: ${{ inputs.wagon_repository }}
+        run: |
+          bundle exec rake spec:features
+
+      - name: Run ${{ inputs.wagon_repository }} specs
+        working-directory: ${{ inputs.wagon_repository }}
+        run: |
+          bundle exec rake spec
 
       - name: 'Make capybara output downloadable'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -65,189 +65,22 @@ jobs:
         ports: [ '11211:11211' ]
 
     steps:
-      - name: 'Create default (hitobito) dir'
-        run: |
-          mkdir hitobito
-        working-directory: .
-
-      - name: 'Set wagon name'
-        run: |
-          repository="${{github.repository}}"
-          echo "WAGON_NAME=${repository##*/}" >> $GITHUB_ENV
-
-      - name: 'Determine common branch and set branch name for core'
-        if: github.event_name != 'pull_request'
-        env:
-          INPUT_CORE_REF: ${{ inputs.core_ref }}
-        run: |
-          CORE_REF="$INPUT_CORE_REF"
-          if [ -z "$INPUT_CORE_REF" ]; then
-            CORE_REF=$(git ls-remote --heads https://github.com/hitobito/hitobito | cut -d/ -f3- | grep -x "${{github.ref_name}}" || echo 'master')
-            # core_branch=$(git ls-remote --heads https://github.com/hitobito/hitobito | cut -d/ -f3- | grep -x "${{github.ref_name}}")
-            # if [ "$core_branch" != '' ]; then
-            #   CORE_REF="${{github.ref_name}}"
-            # else
-            #   CORE_REF="master"
-            # fi
-          fi
-
-          echo "CORE_REF=$CORE_REF" >> $GITHUB_ENV
-
-      - name: 'Determine common branch and set branch name for dependency repo'
-        if: (github.event_name != 'pull_request') && (inputs.wagon_dependency_repository != '')
-        env:
-          WAGON_DEPENDENCY_REPO: ${{ inputs.wagon_dependency_repository }}
-          INPUT_WDEP_REF: ${{ inputs.wagon_dependency_ref }}
-        run: |
-          WAGON_DEPENDENCY_REF="$INPUT_WDEP_REF"
-          if [ -z "$INPUT_WDEP_REF" ] && [ "$WAGON_DEPENDENCY_REPO" != '' ]; then
-            WAGON_DEPENDENCY_REF=$(git ls-remote --heads https://github.com/hitobito/$WAGON_DEPENDENCY_REPO | cut -d/ -f3- | grep -x "${{github.ref_name}}" || echo 'master')
-            # dependency_branch=$(git ls-remote --heads https://github.com/hitobito/$WAGON_DEPENDENCY_REPO | cut -d/ -f3- | grep -x "${{github.ref_name}}")
-            # if [ "$dependency_branch" != '' ]; then
-            #   WAGON_DEPENDENCY_REF="${{github.ref_name}}"
-            # else
-            #   WAGON_DEPENDENCY_REF="master"
-            # fi
-          fi
-
-          echo "WAGON_DEPENDENCY_REF=$WAGON_DEPENDENCY_REF" >> $GITHUB_ENV
-
-      - name: 'Set branch name'
-        if: github.event_name == 'pull_request'
-        env:
-          WAGON_DEPENDENCY_REPO: ${{ inputs.wagon_dependency_repository }}
-          INPUT_WDEP_REF: ${{ inputs.wagon_dependency_ref }}
-          INPUT_CORE_REF: ${{ inputs.core_ref }}
-        run: |
-          WAGON_DEPENDENCY_REF="$INPUT_WDEP_REF"
-          if [ -z "${INPUT_WDEP_REF}" ] && [ "${WAGON_DEPENDENCY_REPO}" != '' ]; then
-            WAGON_DEPENDENCY_REF="master"
-          fi
-
-          CORE_REF="$INPUT_CORE_REF"
-          if [ -z "${INPUT_CORE_REF}" ]; then
-            CORE_REF="master"
-          fi
-
-          echo "WAGON_DEPENDENCY_REF=$WAGON_DEPENDENCY_REF" >> $GITHUB_ENV
-          echo "CORE_REF=$CORE_REF" >> $GITHUB_ENV
-
-      - name: 'Checkout hitobito at ${{ env.CORE_REF }}'
+      - name: Check out the core, which contains the shared setup action
         uses: actions/checkout@v4
         with:
-          repository: 'hitobito/hitobito'
-          ref: ${{ env.CORE_REF }}
-          path: 'hitobito'
+          repository: hitobito/hitobito
+          ref: ${{ inputs.core_ref }}
+          path: .hitobito_core_repo
+          fetch-depth: 1
 
-      - name: 'Set up Ruby'
-        env:
-          ImageOS: ubuntu20
-        uses: ruby/setup-ruby@v1
+      - name: 'Prepare'
+        uses: ./.hitobito_core_repo/.github/actions/wagon-ci-setup
         with:
-          working-directory: hitobito
-
-      - name: 'Set up Node'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '14'
-
-      - name: 'Setup OS'
-        run: |
-          sudo apt-get -qq update
-          sudo apt-get install sphinxsearch
-          echo "ruby version: $(ruby -v)"
-          echo "node version: $(node -v)"
-          echo "yarn version: $(yarn -v)"
-
-      - name: 'Copy Wagonfile.ci'
-        run: |
-          cp -v Wagonfile.ci Wagonfile
-
-      - name: 'Checkout dependency ${{ inputs.wagon_dependency_repository }} at ${{ env.WAGON_DEPENDENCY_REF }}'
-        uses: actions/checkout@v4
-        if: ${{ inputs.wagon_dependency_repository != '' }}
-        with:
-          repository: hitobito/${{ inputs.wagon_dependency_repository }}
-          ref: ${{ env.WAGON_DEPENDENCY_REF }}
-          path: ${{ inputs.wagon_dependency_repository }}
-
-      - name: Checkout ${{ env.WAGON_NAME }}
-        uses: actions/checkout@v4
-        with:
-          path: ${{ env.WAGON_NAME }}
-
-      - name: 'Create cache key'
-        run: cp Gemfile.lock Gemfile.lock.backup
-
-      - uses: actions/cache@v4
-        with:
-          path: hitobito/vendor/bundle
-          key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
-          restore-keys: |
-            ${{ runner.os }}-ruby-bundle-
-
-      - uses: actions/cache@v4
-        if: ${{ inputs.wagon_dependency_repository != '' }}
-        with:
-          path: ${{ inputs.wagon_dependency_repository }}/vendor/bundle
-          key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
-          restore-keys: |
-            ${{ runner.os }}-ruby-bundle-
-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ env.WAGON_NAME }}/vendor/bundle
-          key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
-          restore-keys: |
-            ${{ runner.os }}-ruby-bundle-
-
-      - name: 'Bundle install core'
-        run: |
-          bundle install --jobs 4 --retry 3 --path vendor/bundle
-
-      - name: 'Make changes to Gemfile.lock transparent'
-        run: |
-          git diff Gemfile.lock || true
-
-      - name: 'Bundle install wagons'
-        run: |
-          hitobito_dir=$(realpath ./)
-          for d in $hitobito_dir/../hitobito_*; do
-            cd $d
-            cp -v $hitobito_dir/Gemfile.lock ./
-            bundle install --jobs 4 --retry 3 --path vendor/bundle
-          done
-
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node_modules-
-
-      - name: 'Yarn install'
-        run: |
-          yarn install --frozen-lockfile
-
-      - name: 'Run Webpacker'
-        run: |
-          bundle exec rake webpacker:compile
-
-      - name: 'Create DB'
-        run: |
-          bundle exec rake db:create
-
-      - name: 'Clear logs'
-        run: |
-          bundle exec rake log:clear
-
-      - name: 'Run core migrations'
-        run: |
-          bundle exec rake db:migrate
-
-      - name: 'Run wagon migrations'
-        run: |
-          bundle exec rake wagon:migrate
+          migrations: true
+          wagon_repository: ${{ inputs.wagon_repository }}
+          wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
+          core_ref: ${{ inputs.core_ref }}
+          wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
 
       - name: ${{ inputs.wagon_dependency_repository || 'Dependency wagon' }} rubocop
         if: ${{ inputs.wagon_dependency_repository != '' }}

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -32,7 +32,60 @@ defaults:
     working-directory: hitobito
 
 jobs:
-  build_test:
+  wagon_rubocop:
+    runs-on: 'ubuntu-20.04'
+
+    steps:
+      - name: Check out core with shared setup action
+        uses: actions/checkout@v4
+        with:
+          repository: hitobito/hitobito
+          ref: ${{ inputs.core_ref }}
+          path: .hitobito_core_repo
+          fetch-depth: 1
+
+      - name: 'Prepare'
+        uses: ./.hitobito_core_repo/.github/actions/wagon-ci-setup
+        with:
+          migrations: false
+          wagon_repository: ${{ inputs.wagon_repository }}
+          wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
+          core_ref: ${{ inputs.core_ref }}
+          wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
+
+      - name: ${{ inputs.wagon_repository }} rubocop
+        working-directory: ${{ inputs.wagon_repository }}
+        run: |
+          bundle exec rake app:rubocop
+
+  wagon_dependency_rubocop:
+    if: ${{ inputs.wagon_dependency_repository != '' }}
+    runs-on: 'ubuntu-20.04'
+
+    steps:
+      - name: Check out core with shared setup action
+        uses: actions/checkout@v4
+        with:
+          repository: hitobito/hitobito
+          ref: ${{ inputs.core_ref }}
+          path: .hitobito_core_repo
+          fetch-depth: 1
+
+      - name: 'Prepare'
+        uses: ./.hitobito_core_repo/.github/actions/wagon-ci-setup
+        with:
+          migrations: false
+          wagon_repository: ${{ inputs.wagon_repository }}
+          wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
+          core_ref: ${{ inputs.core_ref }}
+          wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
+
+      - name: ${{ inputs.wagon_dependency_repository || 'Dependency wagon' }} rubocop
+        working-directory: ${{ inputs.wagon_dependency_repository }}
+        run: |
+          bundle exec rake app:rubocop
+
+  wagon_specs:
     runs-on: 'ubuntu-20.04'
     env:
       HEADLESS: true
@@ -76,54 +129,119 @@ jobs:
       - name: 'Prepare'
         uses: ./.hitobito_core_repo/.github/actions/wagon-ci-setup
         with:
-          migrations: true
           wagon_repository: ${{ inputs.wagon_repository }}
           wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
           core_ref: ${{ inputs.core_ref }}
           wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
 
-      - name: ${{ inputs.wagon_dependency_repository || 'Dependency wagon' }} rubocop
-        if: ${{ inputs.wagon_dependency_repository != '' }}
-        working-directory: ${{ inputs.wagon_dependency_repository }}
+      - name: Run ${{ inputs.wagon_repository }} specs
+        working-directory: ${{ inputs.wagon_repository }}
         run: |
-          bundle exec rake app:rubocop
+          bundle exec rake app:ci:setup:rspec spec
 
-      - name: Setup ${{ inputs.wagon_dependency_repository || 'dependency wagon' }} specs
-        if: ${{ inputs.wagon_dependency_repository != '' }}
-        working-directory: ${{ inputs.wagon_dependency_repository }}
-        run: |
-          bundle exec rake app:ci:setup:rspec
+  wagon_dependency_specs:
+    if: ${{ inputs.wagon_dependency_repository != '' }}
+    runs-on: 'ubuntu-20.04'
+    env:
+      HEADLESS: true
+      RAILS_DB_ADAPTER: mysql2
+      RAILS_DB_HOST: 127.0.0.1
+      RAILS_DB_PORT: 33066
+      RAILS_DB_USERNAME: hitobito
+      RAILS_DB_PASSWORD: hitobito
+      RAILS_DB_NAME: hitobito_test
+      RAILS_TEST_DB_NAME: hitobito_test
+      RAILS_ENV: test
 
-      - name: Check if there are any feature specs in ${{ inputs.wagon_dependency_repository || 'dependency wagon' }}
-        if: ${{ inputs.wagon_dependency_repository != '' }}
-        id: check-dependency-wagon-feature-specs
-        working-directory: ${{ inputs.wagon_dependency_repository }}
-        run: |
-          if [ -d "spec/features" ]; then
-            echo "feature_specs_exist=1" >> "$GITHUB_OUTPUT"
-          fi
+    services:
+      mysql:
+        image: 'mysql:5.7'
+        env:
+          MYSQL_USER: 'hitobito'
+          MYSQL_PASSWORD: 'hitobito'
+          MYSQL_DATABASE: 'hitobito_test'
+          MYSQL_ROOT_PASSWORD: 'root'
+        ports:
+          - '33066:3306'
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 10
+      memcached:
+        image: 'memcached'
+        ports: [ '11211:11211' ]
 
-      - name: Run ${{ inputs.wagon_dependency_repository || 'dependency wagon' }} feature specs
-        if: ${{ inputs.wagon_dependency_repository != '' && steps.check-dependency-wagon-feature-specs.outputs.feature_specs_exist }}
-        working-directory: ${{ inputs.wagon_dependency_repository }}
-        run: |
-          bundle exec rake spec:features
+    steps:
+      - name: Check out core with shared setup action
+        uses: actions/checkout@v4
+        with:
+          repository: hitobito/hitobito
+          ref: ${{ inputs.core_ref }}
+          path: .hitobito_core_repo
+          fetch-depth: 1
+
+      - name: 'Prepare'
+        uses: ./.hitobito_core_repo/.github/actions/wagon-ci-setup
+        with:
+          wagon_repository: ${{ inputs.wagon_repository }}
+          wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
+          core_ref: ${{ inputs.core_ref }}
+          wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
 
       - name: Run ${{ inputs.wagon_dependency_repository || 'dependency wagon' }} specs
-        if: ${{ inputs.wagon_dependency_repository != '' }}
         working-directory: ${{ inputs.wagon_dependency_repository }}
         run: |
-          bundle exec rake spec
+          bundle exec rake app:ci:setup:rspec spec
 
-      - name: ${{ inputs.wagon_repository }} rubocop
-        working-directory: ${{ inputs.wagon_repository }}
-        run: |
-          bundle exec rake app:rubocop
+  wagon_feature_specs:
+    runs-on: 'ubuntu-20.04'
+    env:
+      HEADLESS: true
+      RAILS_DB_ADAPTER: mysql2
+      RAILS_DB_HOST: 127.0.0.1
+      RAILS_DB_PORT: 33066
+      RAILS_DB_USERNAME: hitobito
+      RAILS_DB_PASSWORD: hitobito
+      RAILS_DB_NAME: hitobito_test
+      RAILS_TEST_DB_NAME: hitobito_test
+      RAILS_ENV: test
 
-      - name: Setup ${{ inputs.wagon_repository }} specs
-        working-directory: ${{ inputs.wagon_repository }}
-        run: |
-          bundle exec rake app:ci:setup:rspec
+    services:
+      mysql:
+        image: 'mysql:5.7'
+        env:
+          MYSQL_USER: 'hitobito'
+          MYSQL_PASSWORD: 'hitobito'
+          MYSQL_DATABASE: 'hitobito_test'
+          MYSQL_ROOT_PASSWORD: 'root'
+        ports:
+          - '33066:3306'
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 10
+      memcached:
+        image: 'memcached'
+        ports: [ '11211:11211' ]
+
+    steps:
+      - name: Check out core with shared setup action
+        uses: actions/checkout@v4
+        with:
+          repository: hitobito/hitobito
+          ref: ${{ inputs.core_ref }}
+          path: .hitobito_core_repo
+          fetch-depth: 1
+
+      - name: 'Prepare'
+        uses: ./.hitobito_core_repo/.github/actions/wagon-ci-setup
+        with:
+          wagon_repository: ${{ inputs.wagon_repository }}
+          wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
+          core_ref: ${{ inputs.core_ref }}
+          wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
 
       - name: Check if there are any feature specs in ${{ inputs.wagon_repository }}
         id: check-wagon-feature-specs
@@ -137,24 +255,91 @@ jobs:
         if: ${{ steps.check-wagon-feature-specs.outputs.feature_specs_exist }}
         working-directory: ${{ inputs.wagon_repository }}
         run: |
-          bundle exec rake spec:features
-
-      - name: Run ${{ inputs.wagon_repository }} specs
-        working-directory: ${{ inputs.wagon_repository }}
-        run: |
-          bundle exec rake spec
+          bundle exec rake app:ci:setup:rspec spec:features
 
       - name: 'Make capybara output downloadable'
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: capybara-output
+          name: capybara-output-wagon
+          path: |
+            hitobito/tmp/capybara
+
+  wagon_dependency_feature_specs:
+    if: ${{ inputs.wagon_dependency_repository != '' }}
+    runs-on: 'ubuntu-20.04'
+    env:
+      HEADLESS: true
+      RAILS_DB_ADAPTER: mysql2
+      RAILS_DB_HOST: 127.0.0.1
+      RAILS_DB_PORT: 33066
+      RAILS_DB_USERNAME: hitobito
+      RAILS_DB_PASSWORD: hitobito
+      RAILS_DB_NAME: hitobito_test
+      RAILS_TEST_DB_NAME: hitobito_test
+      RAILS_ENV: test
+
+    services:
+      mysql:
+        image: 'mysql:5.7'
+        env:
+          MYSQL_USER: 'hitobito'
+          MYSQL_PASSWORD: 'hitobito'
+          MYSQL_DATABASE: 'hitobito_test'
+          MYSQL_ROOT_PASSWORD: 'root'
+        ports:
+          - '33066:3306'
+        options: >-
+          --health-cmd "mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 10
+      memcached:
+        image: 'memcached'
+        ports: [ '11211:11211' ]
+
+    steps:
+      - name: Check out core with shared setup action
+        uses: actions/checkout@v4
+        with:
+          repository: hitobito/hitobito
+          ref: ${{ inputs.core_ref }}
+          path: .hitobito_core_repo
+          fetch-depth: 1
+
+      - name: 'Prepare'
+        uses: ./.hitobito_core_repo/.github/actions/wagon-ci-setup
+        with:
+          wagon_repository: ${{ inputs.wagon_repository }}
+          wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
+          core_ref: ${{ inputs.core_ref }}
+          wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
+
+      - name: Check if there are any feature specs in ${{ inputs.wagon_dependency_repository || 'dependency wagon' }}
+        id: check-wagon-dependency-feature-specs
+        working-directory: ${{ inputs.wagon_dependency_repository }}
+        run: |
+          if [ -d "spec/features" ]; then
+            echo "feature_specs_exist=1" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run ${{ inputs.wagon_dependency_repository || 'dependency wagon' }} feature specs
+        if: ${{ steps.check-wagon-dependency-feature-specs.outputs.feature_specs_exist }}
+        working-directory: ${{ inputs.wagon_dependency_repository }}
+        run: |
+          bundle exec rake app:ci:setup:rspec spec:features
+
+      - name: 'Make capybara output downloadable'
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: capybara-output-wagon-dependency
           path: |
             hitobito/tmp/capybara
 
   notify_statuscope:
     uses: ./.github/workflows/notify-statuscope.yml
-    needs: [ build_test ]
+    needs: [ wagon_rubocop, wagon_dependency_rubocop, wagon_specs, wagon_dependency_specs, wagon_feature_specs, wagon_dependency_feature_specs ]
     if: ( success() || failure() ) && ( github.ref_name == 'master' ) && ( (inputs.core_ref || 'master') == 'master' ) && ( (inputs.wagon_dependency_ref || 'master') == 'master' )
     with:
       repository: ${{ inputs.wagon_repository }}

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -33,6 +33,7 @@ defaults:
 
 jobs:
   wagon_rubocop:
+    name: ${{ inputs.wagon_repository }} rubocop
     runs-on: 'ubuntu-20.04'
 
     steps:
@@ -59,6 +60,7 @@ jobs:
           bundle exec rake app:rubocop
 
   wagon_dependency_rubocop:
+    name: ${{ inputs.wagon_dependency_repository }} rubocop
     if: ${{ inputs.wagon_dependency_repository != '' }}
     runs-on: 'ubuntu-20.04'
 
@@ -86,6 +88,7 @@ jobs:
           bundle exec rake app:rubocop
 
   wagon_specs:
+    name: ${{ inputs.wagon_repository }} specs
     runs-on: 'ubuntu-20.04'
     env:
       HEADLESS: true
@@ -140,6 +143,7 @@ jobs:
           bundle exec rake app:ci:setup:rspec spec
 
   wagon_dependency_specs:
+    name: ${{ inputs.wagon_dependency_repository }} specs
     if: ${{ inputs.wagon_dependency_repository != '' }}
     runs-on: 'ubuntu-20.04'
     env:
@@ -195,6 +199,7 @@ jobs:
           bundle exec rake app:ci:setup:rspec spec
 
   wagon_feature_specs:
+    name: ${{ inputs.wagon_repository }} feature specs
     runs-on: 'ubuntu-20.04'
     env:
       HEADLESS: true
@@ -266,6 +271,7 @@ jobs:
             hitobito/tmp/capybara
 
   wagon_dependency_feature_specs:
+    name: ${{ inputs.wagon_dependency_repository }} feature specs
     if: ${{ inputs.wagon_dependency_repository != '' }}
     runs-on: 'ubuntu-20.04'
     env:

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Run ${{ inputs.wagon_repository }} specs
         working-directory: ${{ inputs.wagon_repository }}
         run: |
-          bundle exec rake app:ci:setup:rspec spec
+          bundle exec rake app:ci:setup:rspec spec:without_features
 
   wagon_dependency_specs:
     name: ${{ inputs.wagon_dependency_repository }} specs
@@ -196,7 +196,7 @@ jobs:
       - name: Run ${{ inputs.wagon_dependency_repository || 'dependency wagon' }} specs
         working-directory: ${{ inputs.wagon_dependency_repository }}
         run: |
-          bundle exec rake app:ci:setup:rspec spec
+          bundle exec rake app:ci:setup:rspec spec:without_features
 
   wagon_feature_specs:
     name: ${{ inputs.wagon_repository }} feature specs

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -59,34 +59,6 @@ jobs:
         run: |
           bundle exec rake app:rubocop
 
-  wagon_dependency_rubocop:
-    name: ${{ inputs.wagon_dependency_repository }} rubocop
-    if: ${{ inputs.wagon_dependency_repository != '' }}
-    runs-on: 'ubuntu-20.04'
-
-    steps:
-      - name: Check out core with shared setup action
-        uses: actions/checkout@v4
-        with:
-          repository: hitobito/hitobito
-          ref: ${{ inputs.core_ref }}
-          path: .hitobito_core_repo
-          fetch-depth: 1
-
-      - name: 'Prepare'
-        uses: ./.hitobito_core_repo/.github/actions/wagon-ci-setup
-        with:
-          migrations: false
-          wagon_repository: ${{ inputs.wagon_repository }}
-          wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
-          core_ref: ${{ inputs.core_ref }}
-          wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
-
-      - name: ${{ inputs.wagon_dependency_repository || 'Dependency wagon' }} rubocop
-        working-directory: ${{ inputs.wagon_dependency_repository }}
-        run: |
-          bundle exec rake app:rubocop
-
   wagon_specs:
     name: ${{ inputs.wagon_repository }} specs
     runs-on: 'ubuntu-20.04'
@@ -345,7 +317,7 @@ jobs:
 
   notify_statuscope:
     uses: ./.github/workflows/notify-statuscope.yml
-    needs: [ wagon_rubocop, wagon_dependency_rubocop, wagon_specs, wagon_dependency_specs, wagon_feature_specs, wagon_dependency_feature_specs ]
+    needs: [ wagon_rubocop, wagon_specs, wagon_dependency_specs, wagon_feature_specs, wagon_dependency_feature_specs ]
     if: ( success() || failure() ) && ( github.ref_name == 'master' ) && ( (inputs.core_ref || 'master') == 'master' ) && ( (inputs.wagon_dependency_ref || 'master') == 'master' )
     with:
       repository: ${{ inputs.wagon_repository }}

--- a/lib/templates/wagon/lib/tasks/spec.rake
+++ b/lib/templates/wagon/lib/tasks/spec.rake
@@ -9,12 +9,18 @@ if Rake::Task.task_defined?('spec:features')
       t.rspec_opts = '--tag type:feature'
     end
 
-    task all: ['spec:features', 'spec']
+    RSpec::Core::RakeTask.new(:without_features) do |t|
+      t.pattern = './spec/**/*_spec.rb'
+      t.rspec_opts = '--tag ~type:feature'
+    end
+
+    task all: ['spec:features', 'spec:without_features']
   end
 
 else
   # we do NOT have feature specs in this wagon.
   namespace :spec do
     task all: 'spec'
+    task without_features: 'spec'
   end
 end


### PR DESCRIPTION
Fixes #2588 

Beispiel Runs des Workflows:
Generic Wagon (kein dritter Wagon, keine Feature Specs): https://github.com/hitobito/hitobito_generic/actions/runs/9383854180
SAC Wagon (inkl. youth Wagon, inkl. Wagon-Feature-Specs): https://github.com/hitobito/hitobito_sac_cas/actions/runs/9383912986

Mögliche weitere Verbesserungen:
- [x] Im Dependency Wagon Rubocop gar nicht laufen lassen? Wenn das Wagon CI getriggert wird, hat man ja dabei den Dependency Wagon eigentlich gar nicht angefasst (ausser natürlich man verwendet einen anderen Dependency Wagon Branch als master, aber auch dann wäre es vielleicht eher angebracht, Rubocop nur im Dependency Wagon laufen zu lassen).
- [ ] In der Setup Action optional Webpacker ausschaltbar machen. Für Rubocop und normale Specs (?) sollte der nicht nötig sein. Könnte man vermutlich sogar auch analog im Core Specs Workflow machen.
- [ ] Bereits früher im Workflow erkennen wenn der Wagon oder der Dependency Wagon keine Feature Specs haben, und dann dies entsprechenden Feature Spec Jobs ganz skippen.
- [ ] Schönere Job-Namen für den Fall dass keine Wagon Dependency vorhanden ist
- [ ] Via Branch Protection Rules z.B. die Rubocop Jobs vor einem Merge zwingend machen (aber vielleicht erst wenn sie wirklich sehr schnell durchlaufen, aktuell dauert es noch ca. 2min30)