### PR TITLE
Replace Faker::Internet.safe_email with email

### DIFF
--- a/db/seeds/support/group_seeder.rb
+++ b/db/seeds/support/group_seeder.rb
@@ -9,7 +9,7 @@ class GroupSeeder
       housenumber: Faker::Address.building_number,
       zip_code: Faker::Address.zip_code[0..3],
       town: Faker::Address.city,
-      email: Faker::Internet.safe_email
+      email: Faker::Internet.email
     }.then do |attrs|
       attrs[:address_care_of] = Faker::Address.secondary_address if (1..10).to_a.shuffle == 1
       attrs[:postbox] = Faker::Address.mail_box if (1..10).to_a.shuffle == 1
@@ -38,7 +38,7 @@ class GroupSeeder
     AdditionalEmail.seed(:contactable_id, :contactable_type, :email,
       { contactable_id:   group.id,
         contactable_type: 'Group',
-        email:            Faker::Internet.safe_email,
+        email:            Faker::Internet.email,
         label:            Settings.additional_email.predefined_labels.first,
         public:           true }
     )

--- a/db/seeds/support/person_seeder.rb
+++ b/db/seeds/support/person_seeder.rb
@@ -132,7 +132,7 @@ class PersonSeeder
   def seed_additional_emails(person, shuffle = false)
     seed_account(person,
                  AdditionalEmail,
-                 { email: Faker::Internet.safe_email,
+                 { email: Faker::Internet.email,
                    mailings: [true, false].shuffle.first },
                  Settings.additional_email.predefined_labels,
                  shuffle)


### PR DESCRIPTION
`Faker::Internet.safe_email` has been deprecated in 3.2.0 and removed in 3.2.3.

See https://github.com/faker-ruby/faker/blob/main/CHANGELOG.md#v320-2023-04-14