### PR TITLE
Fix seeding by using safe access in Group::Types#set_layer_group_id

### DIFF
--- a/app/models/group/types.rb
+++ b/app/models/group/types.rb
@@ -54,7 +54,7 @@ module Group::Types
   end
 
   def set_layer_group_id
-    layer_id = self.class.layer ? id : parent.layer_group_id
+    layer_id = self.class.layer ? id : parent&.layer_group_id
     unless layer_id == layer_group_id
       self_and_descendants.
         where(layer_group_id: layer_group_id).


### PR DESCRIPTION
During seeding I got the following error:

      TRANSACTION (10.7ms)  ROLLBACK
    undefined method `layer_group_id' for nil:NilClass excluded from capture: DSN not set
    rails aborted!
    NoMethodError: undefined method `layer_group_id' for nil:NilClass (NoMethodError)

        layer_id = self.class.layer ? id : parent.layer_group_id
                                                 ^^^^^^^^^^^^^^^
    /usr/src/app/hitobito/app/models/group/types.rb:57:in `set_layer_group_id'
    Tasks: TOP => wagon:seed

By using the safe access seeds went through.