### PR TITLE
Don't run tests twice on pull-requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ name: 'Rails Lint and Test'
 on:
   workflow_dispatch:
   push:
+    branches: [ master ]
     paths-ignore:
       - 'doc/**'
       - '**.md'


### PR DESCRIPTION
When the trigger is on all branches and all pull-requests, the tests will run twice when not originating from a fork. Thus we limit it to only master.