### PR TITLE
Validate presence of parent in groups

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -168,7 +168,7 @@ class Group < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
 
   validates_by_schema except: [:logo]
   validates :type, uniqueness: { scope: :parent_id }, if: :static_name
-  validates :parent, presence: true, unless: -> { Group.roots.count.zero? || id == Group.root.id }
+  validates :parent, presence: true, unless: :layer?
   validates :name, presence: true, unless: :static_name
   validates :email, format: Devise.email_regexp, allow_blank: true
   validates :description, length: { allow_nil: true, maximum: (2**16) - 1 }

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -168,6 +168,7 @@ class Group < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
 
   validates_by_schema except: [:logo]
   validates :type, uniqueness: { scope: :parent_id }, if: :static_name
+  validates :parent, presence: true, unless: :root?
   validates :name, presence: true, unless: :static_name
   validates :email, format: Devise.email_regexp, allow_blank: true
   validates :description, length: { allow_nil: true, maximum: (2**16) - 1 }

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -168,7 +168,7 @@ class Group < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
 
   validates_by_schema except: [:logo]
   validates :type, uniqueness: { scope: :parent_id }, if: :static_name
-  validates :parent, presence: true, unless: :root?
+  validates :parent, presence: true, unless: -> { Group.roots.count.zero? || id == Group.root.id }
   validates :name, presence: true, unless: :static_name
   validates :email, format: Devise.email_regexp, allow_blank: true
   validates :description, length: { allow_nil: true, maximum: (2**16) - 1 }

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -168,7 +168,7 @@ class Group < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
 
   validates_by_schema except: [:logo]
   validates :type, uniqueness: { scope: :parent_id }, if: :static_name
-  validates :parent, presence: true, unless: :layer?
+  validates :parent, presence: true, unless: :no_root_group_or_is_root_group?
   validates :name, presence: true, unless: :static_name
   validates :email, format: Devise.email_regexp, allow_blank: true
   validates :description, length: { allow_nil: true, maximum: (2**16) - 1 }
@@ -399,6 +399,10 @@ class Group < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   end
 
   private
+
+  def no_root_group_or_is_root_group?
+    Group.roots.count.zero? || id == Group.root.id
+  end
 
   def layer_person_duplicates
     duplicates = PersonDuplicate.joins(person_1: :roles).joins(person_2: :roles)

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -510,7 +510,7 @@ describe Group do
   end
 
   describe 'parent validation' do
-    let(:group) { Group::BottomLayer.new(name: 'g', parent: parent) }
+    let(:group) { Group::TopGroup.new(name: 'g', parent: parent) }
 
     it 'top_layer must be valid' do
       expect(groups(:top_layer)).to be_valid
@@ -887,7 +887,7 @@ describe Group do
   end
 
   context 'addable_child_types' do
-    let(:group) { Fabricate(Group::BottomLayer.name) }
+    let(:group) { Fabricate(Group::BottomLayer.name, parent: groups(:top_layer)) }
     let(:child_type) { Group::BottomGroup }
 
     context 'with static_name=false' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -509,6 +509,33 @@ describe Group do
     end
   end
 
+  describe 'parent validation' do
+    let(:group) { Group::BottomLayer.new(name: 'g', parent: parent) }
+
+    it 'top_layer must be valid' do
+      expect(groups(:top_layer)).to be_valid
+    end
+
+    context 'with parent' do
+      let(:parent) { groups(:top_layer) }
+
+      it 'is valid' do
+        expect(group.root?).to be false
+        expect(group).to be_valid
+      end
+    end
+
+    context 'without parent' do
+      let(:parent) { nil }
+
+      it 'is invalid' do
+        # It would be a root, but that is illegal
+        expect(group.root?).to be true
+        expect(group).not_to be_valid
+      end
+    end
+  end
+
   describe 'e-mail validation' do
 
     let(:group) { groups(:top_layer) }


### PR DESCRIPTION
We noticed this while investigating the seeding failure, which was wrongly fixed in https://github.com/hitobito/hitobito/pull/2648.

Except for the `root` groups every group should have a parent.