### PR TITLE
Revert "Fix seeding by using safe access in Group::Types#set_layer_group_id (#2648)"

### DIFF
--- a/app/models/group/types.rb
+++ b/app/models/group/types.rb
@@ -54,7 +54,7 @@ module Group::Types
   end
 
   def set_layer_group_id
-    layer_id = self.class.layer ? id : parent&.layer_group_id
+    layer_id = self.class.layer ? id : parent.layer_group_id
     unless layer_id == layer_group_id
       self_and_descendants.
         where(layer_group_id: layer_group_id).


### PR DESCRIPTION
This reverts commit 8b9c1e6af01ea4a156efc53c35f5cecb006f1bc4.