### PR TITLE
Fix charlock_holmes build on newer systems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'bleib', '~> 0.0.10'
 gem 'bootsnap', require: false
 gem 'cancancan', '< 3.2.0'
 gem 'caxlsx'
-gem 'charlock_holmes', '~> 0.7.7'
+gem 'charlock_holmes', github: 'rnestler/charlock_holmes', ref: 'remove-std-override'
 gem 'commonmarker'
 gem 'config'
 gem 'country_select'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,13 @@ GIT
       graphiti (~> 1.3.9)
       transproc
 
+GIT
+  remote: https://github.com/rnestler/charlock_holmes.git
+  revision: dff95939a325fa951ce3a9958856e94b9bdc59f1
+  ref: remove-std-override
+  specs:
+    charlock_holmes (0.7.7)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -167,7 +174,6 @@ GEM
       nokogiri (~> 1.10, >= 1.10.4)
       rubyzip (>= 1.3.0, < 3)
     cgi (0.4.1)
-    charlock_holmes (0.7.7)
     childprocess (5.0.0)
     choice (0.2.0)
     chunky_png (1.4.0)
@@ -762,7 +768,7 @@ DEPENDENCIES
   capybara
   capybara-screenshot
   caxlsx
-  charlock_holmes (~> 0.7.7)
+  charlock_holmes!
   ci_reporter_rspec
   cmdparse
   codez-tarantula


### PR DESCRIPTION
On my system charlock_holmes fails to build, since it overrides C++ compiler flags.

See https://github.com/brianmario/charlock_holmes/pull/174