### PR TITLE
Remove duplicate field

### DIFF
--- a/app/views/events/_attrs_application.html.haml
+++ b/app/views/events/_attrs_application.html.haml
@@ -6,8 +6,6 @@
       = present_labeled_attr(entry, :application_opening_at)
     - entry.used?(:application_closing_at) do
       = present_labeled_attr(entry, :application_closing_at)
-    - entry.used?(:application_closing_at) do
-      = present_labeled_attr(entry, :application_closing_at)
     = labeled_attr(entry, :booking_info)
     - entry.used?(:external_applications) do
       = labeled(Event.human_attribute_name(:external_applications), entry.external_application_link(@group))


### PR DESCRIPTION
application_closing_at wird doppelt ausgegeben. Dies führt dazu, dass das Feld "Anmeldeschluss" zwei Mal im Frontend sichtbar ist und den User verwirrt.


![image](https://github.com/hitobito/hitobito/assets/95908537/23051f1c-9388-4da9-bd7e-ac50af990312)
