### PR TITLE
Fix deprectation warning

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,7 +76,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  config.action_view.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.


### PR DESCRIPTION
`DEPRECATION WARNING: action_view.raise_on_missing_translations is deprecated and will be removed in Rails 7.0. Set i18n.raise_on_missing_translations instead. Note that this new setting also affects how missing translations are handled in controllers.`