### PR TITLE
Allow the left navigation for empty layer-groups

### DIFF
--- a/app/helpers/sheet/group/nav_left.rb
+++ b/app/helpers/sheet/group/nav_left.rb
@@ -43,7 +43,7 @@ module Sheet
         end
 
         results = []
-        recombine_groups(results, children_of, groups.first.parent_id)
+        recombine_groups(results, children_of, groups.first&.parent_id)
         results
       end
 
@@ -82,7 +82,7 @@ module Sheet
       def render_layer_groups
         out = ''.html_safe
         stack = []
-        groups[1..].each do |group|
+        Array(groups[1..]).each do |group|
           render_stacked_group(group, stack, out)
         end
         stack.size.times do

--- a/app/models/group/nested_set.rb
+++ b/app/models/group/nested_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2014, 2019 Pfadibewegung Schweiz. This file is part of
+#  Copyright (c) 2014-2024, 2019 Pfadibewegung Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.


### PR DESCRIPTION
Fixes an edge-case of #2673

Sometimes, layers do not have subgroups. 