### PR TITLE
SAC Household Anpassungen

### DIFF
--- a/app/models/household.rb
+++ b/app/models/household.rb
@@ -6,22 +6,27 @@
 #  https://github.com/hitobito/hitobito
 
 class Household
+
   include ActiveModel::Model
   include ActiveModel::Dirty
 
-  attr_reader :household_key, :members, :reference_person
+  attr_reader :household_key, :members, :reference_person, :warnings
 
   define_attribute_methods :members
 
   def initialize(reference_person)
     @reference_person = reference_person
-    init_defaults
+    @household_key = @reference_person.household_key
+    @warnings = ActiveModel::Errors.new(self)
+    @previously_new_record = false
 
-    if @household_key
+    if persisted?
+      # for an existing household, fetch the members
       @members = fetch_members
     else
-      @household_key = next_key
-      add(@reference_person)
+      # build a new household with the single member `reference_person`
+      @members = []
+      add(reference_person)
     end
   end
 
@@ -33,6 +38,7 @@ class Household
 
     attribute_will_change!(:members)
     members << HouseholdMember.new(person, self)
+    self
   end
 
   def remove(person)
@@ -40,29 +46,24 @@ class Household
 
     attribute_will_change!(:members)
     members.reject! { |m| m.person == person }
+    self
   end
 
   def valid?(context = :update)
     super
   end
 
-  def save!(context: :update)
-    raise "error saving household" unless save(context: context)
+  def save!(context: :update, &)
+    raise "error saving household" unless save(context:, &)
   end
 
-  def save(context: :update)
+  def save(context: :update, &)
     return false unless valid?(context)
 
     members.clear if members.size < 2
-
-    ActiveRecord::Base.transaction do
-      yield new_people, removed_people if block_given?
-      save_removed
-      save_members
-      Households::LogEntries.new(self).create!
-      changes_applied
-      true
-    end
+    save_records(&)
+    changes_applied # resolve dirty status
+    true
   end
 
   def destroy
@@ -74,7 +75,15 @@ class Household
   end
 
   def reload
-    initialize(@reference_person.reload)
+    # reload the reference person as it might have been updated on DB
+    # (e.g. by calling #remove(reference_person) on the household and saving)
+    p = reference_person.reload
+    # make sure to clear ALL instance variables as we are reusing the instance
+    instance_variables.each { remove_instance_variable(_1) }
+    # also reset dirty tracking
+    clear_changes_information
+    # re-initialize the instance with the reloaded reference person
+    initialize(p)
     self
   end
 
@@ -94,17 +103,19 @@ class Household
     (members_was - members).map(&:person)
   end
 
-  def warnings
-    @warnings ||= ActiveModel::Errors.new(self)
-  end
-
   def address_attrs
     address.attrs
   end
 
   def new_record?
-    @reference_person.household_key.nil?
+    # if the reference person has no household key, the household must be new
+    household_key.blank?
   end
+
+  def persisted?
+    !new_record?
+  end
+  alias_method :exists?, :persisted?
 
   def destroy?
     members.none?
@@ -131,33 +142,36 @@ class Household
     end
   end
 
-  def save_removed
-    Person.where(id: removed_people.map(&:id)).update_all(household_key: nil) # rubocop:disable Rails/SkipsModelValidations
-  end
-
-  def save_members
-    Person.where(id: person_ids).find_each do |p|
-      p.update!(household_attrs)
+  def save_records
+    ActiveRecord::Base.transaction do
+      save_removed
+      save_members
+      yield new_people, removed_people if block_given?
+      Households::LogEntries.new(self).create!
     end
   end
 
-  def household_attrs
-    attrs = {household_key: @household_key}
-    attrs.merge(address_attrs)
+  def save_removed
+    removed_people.each { |person| person.update!(household_key: nil) }
+  end
+
+  def save_members
+    return unless members.present? # prevents generating key for empty household
+
+    # generate a fresh key if we don't have one yet
+    @household_key ||= next_key
+    people.each { |person| person.update!(address_attrs.merge(household_key:)) }
+    # reload the reference_person as this is a different reference to the same person in `people`
+    @reference_person.reload
   end
 
   def fetch_members
-    members = Person.where(household_key: @household_key)
+    members = Person.where(household_key: reference_person.household_key)
     HouseholdMember.from(members, self)
   end
 
-  def init_defaults
-    @members = []
-    @household_key = @reference_person.household_key
-  end
-
   def validate_members
-    @members.each_with_index do |member, index|
+    members.each_with_index do |member, index|
       member.validate(validation_context)
       member.errors.each do |error|
         errors.add("members[#{index}].#{error.attribute}", error.message)
@@ -167,4 +181,5 @@ class Household
       end
     end
   end
+
 end

--- a/app/models/households/log_entries.rb
+++ b/app/models/households/log_entries.rb
@@ -6,9 +6,10 @@
 #  https://github.com/hitobito/hitobito
 
 class Households::LogEntries
-  delegate :new_record?, :destroy?, :people,
+
+  delegate :destroy?, :people,
     :new_people, :removed_people,
-    :household_label, to: "@household"
+    :household_label, to: '@household'
 
   def initialize(household)
     @household = household
@@ -44,7 +45,7 @@ class Households::LogEntries
   def create_log_entry(person, changed_person, log_event)
     PaperTrail::Version.create!(main: person,
       item: person,
-      whodunnit: whodunnit,
+      whodunnit:,
       event: log_event,
       object: changed_person&.full_name,
       object_changes: household_log_label)
@@ -52,6 +53,10 @@ class Households::LogEntries
 
   def whodunnit
     PaperTrail.request.whodunnit
+  end
+
+  def new_record?
+    @household.previously_new_record?
   end
 
   def log_events
@@ -78,4 +83,5 @@ class Households::LogEntries
       [nil]
     end
   end
+
 end

--- a/app/models/households/log_entries.rb
+++ b/app/models/households/log_entries.rb
@@ -6,14 +6,16 @@
 #  https://github.com/hitobito/hitobito
 
 class Households::LogEntries
-
   delegate :destroy?, :people,
     :new_people, :removed_people,
-    :household_label, to: '@household'
+    :household_label, to: "@household"
 
-  def initialize(household)
+  def initialize(household, new_record)
     @household = household
+    @new_record = new_record
   end
+
+  def new_record? = @new_record
 
   def create!
     return unless PaperTrail.enabled?
@@ -55,10 +57,6 @@ class Households::LogEntries
     PaperTrail.request.whodunnit
   end
 
-  def new_record?
-    @household.previously_new_record?
-  end
-
   def log_events
     return [:household_created] if new_record?
     return [:household_destroyed] if destroy?
@@ -83,5 +81,4 @@ class Households::LogEntries
       [nil]
     end
   end
-
 end


### PR DESCRIPTION
fixes hitobito/hitobito_sac_cas#570

Those changes are needed as `#save` must now yield the updated people records. This is required to make the SAC wagon changes possible which depend on the updated `household_key` on the people records.