### PR TITLE
Override case operator for Wizards::Step

### DIFF
--- a/app/models/wizards/step.rb
+++ b/app/models/wizards/step.rb
@@ -17,6 +17,14 @@ module Wizards
     end
     delegate :step_name, to: :class
 
+    def self.===(other)
+      if other.is_a?(Class)
+        self == other
+      else
+        step_name == other
+      end
+    end
+
     def initialize(wizard, **params)
       @wizard = wizard
       super(**params)

--- a/spec/models/wizards/step_spec.rb
+++ b/spec/models/wizards/step_spec.rb
@@ -33,4 +33,15 @@ describe Wizards::Step do
       expect(partial).to eq :method
     end
   end
+
+  # rubocop:disable Style/CaseEquality, Lint/BinaryOperatorWithIdenticalOperands
+  describe '#===' do
+    it 'compares to a string' do
+      expect(One === 'one').to be true
+    end
+    it 'compares to a class' do
+      expect(One === One).to be true
+    end
+  end
+  # rubocop:enable Style/CaseEquality, Lint/BinaryOperatorWithIdenticalOperands
 end


### PR DESCRIPTION
This allows to easily use case/when to implement `step_after` in wizards.