### PR TITLE
Make better_errors/binding_of_caller dev only dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,8 +107,6 @@ gem 'active_storage_validations' # validate filesize, dimensions and content-typ
 gem 'active_storage_variant' # variants for Rails < 7
 
 group :development, :test do
-  gem 'better_errors'
-  gem 'binding_of_caller'
   gem 'graphiti_spec_helpers'
   gem 'parallel_tests'
   gem 'pry-byebug'
@@ -117,6 +115,8 @@ group :development, :test do
 end
 
 group :development do
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'bullet'
   gem 'listen'
   gem 'redcarpet'

--- a/spec/requests/generic_oauth_index_spec.rb
+++ b/spec/requests/generic_oauth_index_spec.rb
@@ -116,11 +116,12 @@ scopes.each do |scope|
     end
 
     context 'with an unacceptable scope in token' do
-      scopes.reject{ |s| s == scope }.each do |invalid_scope|
+      scopes.reject { |s| s == scope }.each do |invalid_scope|
         it "fails for #{invalid_scope} scope" do
           token = Fabricate(:access_token, application: application, scopes: invalid_scope, resource_owner_id: user.id)
-          get url, headers: { 'Authorization': 'Bearer ' + token.token }
-          expect(response).not_to have_http_status(:success)
+          expect do
+            get url, headers: { Authorization: 'Bearer ' + token.token }
+          end.to raise_error(CanCan::AccessDenied)
         end
       end
     end

--- a/spec/requests/generic_oauth_show_spec.rb
+++ b/spec/requests/generic_oauth_show_spec.rb
@@ -101,11 +101,13 @@ scopes.each do |scope|
     end
 
     context 'with an unacceptable scope in token' do
-      scopes.reject{ |s| s == scope }.each do |invalid_scope|
+      scopes.reject { |s| s == scope }.each do |invalid_scope|
         it "fails for #{invalid_scope} scope" do
-          token = Fabricate(:access_token, application: application, scopes: invalid_scope, resource_owner_id: user.id)
-          get url, headers: { 'Authorization': 'Bearer ' + token.token }
-          expect(response).not_to have_http_status(:success)
+          token = Fabricate(:access_token, application: application,
+                            scopes: invalid_scope, resource_owner_id: user.id)
+          expect do
+            get url, headers: { Authorization: 'Bearer ' + token.token }
+          end.to raise_error(CanCan::AccessDenied)
         end
       end
     end


### PR DESCRIPTION
When running tests there is no need for them and they slow down specs.

Non scientific benchmark, running `rspec spec/features/` in hitobito_sac_cas:

Before:
```
Finished in 3 minutes 41.8 seconds (files took 5.14 seconds to load)
140 examples
```
After
```
Finished in 3 minutes 5.7 seconds (files took 3.95 seconds to load)
140 examples
```