### PR TITLE
stop delayed job from reloading whole rails app all 5 seconds

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -7,3 +7,11 @@ Rails.application.reloader.to_prepare do
   Delayed::Worker.max_attempts = 10
   Delayed::Worker.plugins << BackgroundJobs::Logging
 end
+
+# ActiveJob will reload codes if necessary. DelayedJob consumes CPU and memory for reloading on every 5 secs.
+# TODO: https://github.com/collectiveidea/delayed_job/issues/776#issuecomment-307161178
+Delayed::Worker.instance_exec do
+  def self.reload_app?
+    false
+  end
+end


### PR DESCRIPTION
`delayed_job` hat die gesamte Rails App alle 5 Sekunden neu initialisiert. Dies verbraucht viele Ressourcen.

```
  Delayed::Backend::ActiveRecord::Job Update All (0.3ms)  UPDATE `delayed_jobs` SET `delayed_jobs`.`locked_at` = '2024-07-08 13:47:45', `delayed_jobs`.`locked_by` = 'host:598ed481adca pid:1' WHERE (((run_at <= '2024-07-08 13:47:45.424631' AND (locked_at IS NULL OR locked_at < '2024-07-08 09:47:45.424644')) OR locked_by = 'host:598ed481adca pid:1') AND failed_at IS NULL) ORDER BY priority ASC, run_at ASC LIMIT 1
Raven 3.1.2 configured not to capture errors: DSN not set
Creating scope :configured. Overwriting existing method MailingList.configured.
Creating scope :anyone. Overwriting existing method MailingList.anyone.
Creating scope :opt_out. Overwriting existing method MailingList.opt_out.
Creating scope :opt_in. Overwriting existing method MailingList.opt_in.
Creating scope :included. Overwriting existing method Subscription.included.
Creating scope :list. Overwriting existing method CostCenter.list.
Creating scope :list. Overwriting existing method CostUnit.list.
Raven 3.1.2 configured not to capture errors: DSN not set
Creating scope :with_membership_years. Overwriting existing method Role.with_membership_years.
  Delayed::Backend::ActiveRecord::Job Update All (0.4ms)  UPDATE `delayed_jobs` SET `delayed_jobs`.`locked_at` = '2024-07-08 13:47:53', `delayed_jobs`.`locked_by` = 'host:598ed481adca pid:1' WHERE (((run_at <= '2024-07-08 13:47:53.351999' AND (locked_at IS NULL OR locked_at < '2024-07-08 09:47:53.352010')) OR locked_by = 'host:598ed481adca pid:1') AND failed_at IS NULL) ORDER BY priority ASC, run_at ASC LIMIT 1
```

Nach der Änderung:

```
  Delayed::Backend::ActiveRecord::Job Update All (0.9ms)  UPDATE `delayed_jobs` SET `delayed_jobs`.`locked_at` = '2024-07-08 13:55:45', `delayed_jobs`.`locked_by` = 'host:598ed481adca pid:1' WHERE (((run_at <= '2024-07-08 13:55:45.173233' AND (locked_at IS NULL OR locked_at < '2024-07-08 09:55:45.173255')) OR locked_by = 'host:598ed481adca pid:1') AND failed_at IS NULL) ORDER BY priority ASC, run_at ASC LIMIT 1
  Delayed::Backend::ActiveRecord::Job Update All (0.6ms)  UPDATE `delayed_jobs` SET `delayed_jobs`.`locked_at` = '2024-07-08 13:55:50', `delayed_jobs`.`locked_by` = 'host:598ed481adca pid:1' WHERE (((run_at <= '2024-07-08 13:55:50.179768' AND (locked_at IS NULL OR locked_at < '2024-07-08 09:55:50.179788')) OR locked_by = 'host:598ed481adca pid:1') AND failed_at IS NULL) ORDER BY priority ASC, run_at ASC LIMIT 1
```