### PR TITLE
Reduce flaky specs by no altering the environment too much

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -115,7 +115,9 @@ RSpec.configure do |config|
 
   config.before(:each, :draper_with_helpers) do
     c = ApplicationController.new
-    c.request = ActionDispatch::TestRequest.new({})
+    request = ActionDispatch::TestRequest.new({})
+    request.host = "test.host" # ensure to not remove the test-host
+    c.request = request
     allow(c).to receive(:current_person) { people(:top_leader) }
     Draper::ViewContext.current = c.view_context
   end


### PR DESCRIPTION
This has been tested by running the specs in the SAC_CAS-Wagon in a certain order:

rspec ./spec/decorators/role_decorator_spec.rb ./spec/resources/group/reads_spec.rb --seed 11597

Surely, this might happen anywhere where both generated URLs and decorators with draper are being tested.