### PR TITLE
Switch to lenient feature-specs for wagon-test as well

### DIFF
--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -181,7 +181,7 @@ jobs:
         if: ${{ steps.check-wagon-feature-specs.outputs.feature_specs_exist }}
         working-directory: ${{ inputs.wagon_repository }}
         run: |
-          bundle exec rake app:ci:setup:rspec spec:features
+          bundle exec rake app:ci:setup:rspec app:spec:features:lenient
 
       - name: 'Make capybara output downloadable'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This should reduce (somewhat) false negatives on the dashboard or whereever you get your action-status.

Integration-proof: https://github.com/hitobito/hitobito_sac_cas/actions/runs/9969667188/job/27547055188#step:6:20