### PR TITLE
Introduce datepicker min/max Date

### DIFF
--- a/app/javascript/javascripts/modules/datepicker.js.coffee
+++ b/app/javascript/javascripts/modules/datepicker.js.coffee
@@ -22,6 +22,7 @@ class app.Datepicker
     if field.is('.icon-calendar')
       field = field.parent().siblings('.date')
     options = $.extend({ onSelect: (d, i) -> self.track(this, d, i) }, $.datepicker.regional[$('html').attr('lang')])
+    field.datepicker(({minDate: new Date(input.attributes.mindate.value) , maxDate: new Date(input.attributes.maxdate.value)  }))
     field.datepicker(options)
     field.datepicker('show')
 

--- a/app/javascript/javascripts/modules/datepicker.js.coffee
+++ b/app/javascript/javascripts/modules/datepicker.js.coffee
@@ -22,7 +22,11 @@ class app.Datepicker
     if field.is('.icon-calendar')
       field = field.parent().siblings('.date')
     options = $.extend({ onSelect: (d, i) -> self.track(this, d, i) }, $.datepicker.regional[$('html').attr('lang')])
-    field.datepicker(({minDate: new Date(input.attributes.mindate.value) , maxDate: new Date(input.attributes.maxdate.value)  }))
+
+    minDate = if input.attributes.mindate? then new Date(input.attributes.mindate.value) else null
+    maxDate = if input.attributes.maxdate? then new Date(input.attributes.maxdate.value) else null
+
+    field.datepicker(({minDate: minDate, maxDate: maxDate}))
     field.datepicker(options)
     field.datepicker('show')
 

--- a/app/javascript/javascripts/modules/datepicker.js.coffee
+++ b/app/javascript/javascripts/modules/datepicker.js.coffee
@@ -21,12 +21,13 @@ class app.Datepicker
     field = $(input)
     if field.is('.icon-calendar')
       field = field.parent().siblings('.date')
-    options = $.extend({ onSelect: (d, i) -> self.track(this, d, i) }, $.datepicker.regional[$('html').attr('lang')])
 
     minDate = if input.attributes.mindate? then new Date(input.attributes.mindate.value) else null
     maxDate = if input.attributes.maxdate? then new Date(input.attributes.maxdate.value) else null
 
-    field.datepicker(({minDate: minDate, maxDate: maxDate}))
+    options = $.extend({ onSelect: (d, i) -> self.track(this, d, i) }, minDate: minDate, maxDate: maxDate, $.datepicker.regional[$('html').attr('lang')])
+
+
     field.datepicker(options)
     field.datepicker('show')
 

--- a/app/javascript/stylesheets/hitobito/modules/_ui-datepicker.scss
+++ b/app/javascript/stylesheets/hitobito/modules/_ui-datepicker.scss
@@ -300,3 +300,8 @@
   overflow: hidden;
   background-repeat: no-repeat;
 }
+
+// hide dates, after max date or before min date
+.ui-state-disabled, .ui-datepicker-unselectable {
+  display: none;
+}

--- a/app/javascript/stylesheets/hitobito/modules/_ui-datepicker.scss
+++ b/app/javascript/stylesheets/hitobito/modules/_ui-datepicker.scss
@@ -302,6 +302,9 @@
 }
 
 // hide dates, after max date or before min date
-.ui-state-disabled, .ui-datepicker-unselectable {
-  display: none;
+:not(.ui-datepicker-other-month) {
+  &.ui-state-disabled,
+  &.ui-datepicker-unselectable {
+      display: none;
+  }
 }


### PR DESCRIPTION
Allow the UI Datepicker to set min/max dates and make it visible, so that dates outside this range are not selectable by not displaying them. Not displaying the dates, is the best styling option in my opinion, since the dates are currently already displayed in a light grey.