### PR TITLE
Remove unused wizard show template

### DIFF
--- a/app/views/wizards/show.html.haml
+++ b/app/views/wizards/show.html.haml
@@ -1,5 +1,0 @@
--#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of hitobito and licensed under the
--#  Affero General Public License version 3 or later. See the COPYING file at the top-level directory
--#  or at https://github.com/hitobito/hitobito.
-
-= render 'form'


### PR DESCRIPTION
The real wizard view is in https://github.com/hitobito/hitobito/blob/304772c9e773f54ba04f24a85078d69d00859fac/app/views/groups/self_registration/show.html.haml

It has been added in #2750 but doesn't seem to serve any purpose.