### PR TITLE
Exclude `data_quality` in `validates_by_schema`

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -264,10 +264,10 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   ### VALIDATIONS
 
   if FeatureGate.disabled?("structured_addresses")
-    validates_by_schema except: [:email, :address]
+    validates_by_schema except: [:email, :address, :data_quality]
     validates :address, length: {allow_nil: true, maximum: 1024}
   else
-    validates_by_schema except: [:email]
+    validates_by_schema except: [:email, :data_quality]
   end
   validates :email, length: {allow_nil: true, maximum: 255} # other email validations by devise
   validates :company_name, presence: {if: :company?}

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -264,6 +264,7 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   ### VALIDATIONS
 
   if FeatureGate.disabled?("structured_addresses")
+    # data_quality is an enum; it's excluded to prevent the error `data_quality is not a number`
     validates_by_schema except: [:email, :address, :data_quality]
     validates :address, length: {allow_nil: true, maximum: 1024}
   else


### PR DESCRIPTION
Required for https://github.com/hitobito/hitobito_sac_cas/pull/864 ([failing ci](https://github.com/hitobito/hitobito_sac_cas/actions/runs/10487966679/job/29049457501?pr=864))

wenn :data_quality nicht existiert, wird es ignoriert. ist für andere wagons also kein problem.