### PR TITLE
extend range event applications are open in seeds

### DIFF
--- a/db/seeds/support/event_seeder.rb
+++ b/db/seeds/support/event_seeder.rb
@@ -29,7 +29,7 @@ class EventSeeder
       motto: Faker::Lorem.sentence,
       description: Faker::Lorem.paragraphs(number: rand(1..3)).join("\n"),
       application_opening_at: date,
-      application_closing_at: date + 60.days
+      application_closing_at: date + 300.days
     }
   end
 


### PR DESCRIPTION
Most of the time, when I try to test something in event applications, I have to edit the range of the dates for applications, I adjusted the range from 60 to 300 days, that way, the application window is more often still open per default and we still have random event, that are over or in the future :smile: 