### PR TITLE
Fix flaky spec in household_list_spec

### DIFF
--- a/spec/domain/people/household_list_spec.rb
+++ b/spec/domain/people/household_list_spec.rb
@@ -111,13 +111,12 @@ describe People::HouseholdList do
       it "works" do
         yielded_batch = []
         subject.households_in_batches { |batch| yielded_batch = batch }
-        expect(yielded_batch.map { |household| household.map(&:id) }).to eq([
-          [person3.id,
-            person4.id, person6.id, person7.id],
+        expect(yielded_batch.map { |household| household.map(&:id) }).to contain_exactly(
+          contain_exactly(person3.id, person4.id, person6.id, person7.id),
           [person1.id],
           [person2.id],
           [person5.id]
-        ])
+        )
       end
     end
   end


### PR DESCRIPTION
Use contain_exactly to ignore the order.

Failing spec in https://github.com/hitobito/hitobito/actions/runs/10776426970/job/29883143659?pr=2832
```
1) People::HouseholdList#households_in_batches people scope with selects works
   Failure/Error:
     expect(yielded_batch.map { |household| household.map(&:id) }).to eq([
       [person3.id,
         person4.id, person6.id, person7.id],
       [person1.id],
       [person2.id],
       [person5.id]
     ])

     expected: [[572409569, 572409570, 572409572, 572409573], [572409567], [572409568], [572409571]]
          got: [[572409573, 572409569, 572409570, 572409572], [572409567], [572409568], [572409571]]
```