### PR TITLE
Externe Registrierung für Rollen mit Contact_Data

### DIFF
--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -43,7 +43,7 @@ class GroupDecorator < ApplicationDecorator
   def allowed_roles_for_self_registration
     role_types.reject do |type|
       type.restricted? ||
-        (type.permissions - type.allowed_permissions_for_self_registration).any?
+        (type.permissions - Role::Types::AllowedPermissionsForSelfRegistration).any?
     end
   end
 

--- a/app/decorators/group_decorator.rb
+++ b/app/decorators/group_decorator.rb
@@ -41,9 +41,9 @@ class GroupDecorator < ApplicationDecorator
   end
 
   def allowed_roles_for_self_registration
-    role_types.reject do |r|
-      r.restricted? ||
-        r.permissions.any? { |p| Role::Types::WRITING_PERMISSIONS.include?(p) }
+    role_types.reject do |type|
+      type.restricted? ||
+        (type.permissions - type.allowed_permissions_for_self_registration).any?
     end
   end
 

--- a/app/helpers/roles_helper.rb
+++ b/app/helpers/roles_helper.rb
@@ -47,6 +47,15 @@ module RolesHelper
     end
   end
 
+  def format_role_type_label_with_permissions(role)
+    return role.label if role.permissions.blank?
+
+    permissions = role.permissions.map do |p|
+      t(p, scope: "activerecord.attributes.role.class.permission.description").chomp(".")
+    end
+    "#{role.label} (#{permissions.join(", ")})"
+  end
+
   def group_options_with_level(group_selection = @group_selection)
     options = []
     base_level = nil

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -191,6 +191,7 @@ class Group < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   validates :text_message_provider, inclusion: {in: PROVIDER_VALUES}, allow_nil: false
   validates :letter_address_position, inclusion: {in: ADDRESS_POSITION_VALUES}, allow_nil: false
 
+  validate :validate_self_registration_role_type
   validate :assert_valid_self_registration_notification_email
 
   validates :logo, dimension: {width: {max: 8_000}, height: {max: 8_000}},
@@ -339,6 +340,13 @@ class Group < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
     unless valid_email?(self_registration_notification_email)
       errors.add(:self_registration_notification_email, :invalid)
     end
+  end
+
+  def validate_self_registration_role_type
+    return if self_registration_role_type.blank? ||
+      decorate.allowed_roles_for_self_registration.map(&:sti_name).include?(self_registration_role_type)
+
+    errors.add(:self_registration_role_type, :inclusion)
   end
 
   def remove_privacy_policy

--- a/app/models/role/types.rb
+++ b/app/models/role/types.rb
@@ -23,6 +23,8 @@ module Role::Types
                             group_and_below_full: :group_and_below_read,
                             group_full: :group_read}
 
+  AllowedPermissionsForSelfRegistration = []
+
   Kinds = [:member, :passive, :external, :future]
 
   # All possible permissions with writing permission
@@ -40,7 +42,6 @@ module Role::Types
 
   included do
     class_attribute :permissions, :visible_from_above, :kind
-    class_attribute :allowed_permissions_for_self_registration, default: []
 
     # All permission a person with this role has on the corresponding group.
     self.permissions = []

--- a/app/models/role/types.rb
+++ b/app/models/role/types.rb
@@ -40,6 +40,7 @@ module Role::Types
 
   included do
     class_attribute :permissions, :visible_from_above, :kind
+    class_attribute :allowed_permissions_for_self_registration, default: []
 
     # All permission a person with this role has on the corresponding group.
     self.permissions = []

--- a/app/views/groups/_self_registration_fields.html.haml
+++ b/app/views/groups/_self_registration_fields.html.haml
@@ -1,9 +1,9 @@
 = field_set_tag do
-  = f.labeled(:self_registration_role_type, class: 'd-flex') do
+  = f.labeled(:self_registration_role_type) do
     = f.select(:self_registration_role_type,
-      entry.allowed_roles_for_self_registration.map { |r| [r.label, r.sti_name ] },
+      entry.allowed_roles_for_self_registration.map { |r| [format_role_type_label_with_permissions(r), r.sti_name ] },
         { include_blank: ta(:not_allowed) },
-          class: 'form-select form-select-sm')
+          class: 'form-select w-100')
     = f.help_inline(t('groups.form.hint_external_registration'))
   = f.labeled_input_fields(:custom_self_registration_title)
   = f.labeled_input_fields(:self_registration_notification_email)

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -754,7 +754,7 @@ de:
       help_contact: "Adresse und öffentliche Telefonnummern dieser Person verwenden."
       help_self_registration_require_adult_consent: Bei der Registrierung abfragen, ob die Person schon 18 Jahre ist bzw. das Einverständnis der Erziehungsberechtigten hat.
       help_main_self_registration_group: "Den Registrierungslink dieser Gruppe auf der Hauptloginseite anzeigen."
-      hint_external_registration: "Es sind keine Rollen mit Schreibrechten auswählbar"
+      hint_external_registration: "Es sind keine Rollen mit Rechten auswählbar"
     form_tabs:
       general: "Allgemein"
       messages: "Nachrichten"

--- a/lib/tasks/hitobito.rake
+++ b/lib/tasks/hitobito.rake
@@ -59,7 +59,8 @@ namespace :hitobito do
 
   desc "Check existence of needed configurations and settings"
   task check_config: [
-    "hitobito:checks:oauth"
+    "hitobito:checks:oauth",
+    "hitobito:checks:self_registration_rules"
   ]
 
   namespace :checks do
@@ -77,6 +78,53 @@ namespace :hitobito do
         MESSAGE
       else
         puts "✅ OAuth configured"
+      end
+    end
+
+    task self_registration_rules: :environment do
+      class SelfRegistrationRoleTypeChecker # rubocop:disable Lint/ConstantDefinitionInBlock
+        attr_reader :errors
+
+        def initialize(allowed_permissions = [])
+          @allowed_permissions = allowed_permissions
+          @errors = []
+        end
+
+        def check
+          offending_self_registrations.each do |group|
+            @errors << "Group ##{group.id} '#{group.name}' uses self registration with " \
+                       "#{group.self_registration_role_type} " \
+                       "(#{group.self_registration_role_type.constantize.permissions.to_sentence})"
+          end
+
+          @errors.none?
+        end
+
+        private
+
+        def allowed_role_types_by_group_type
+          Group.all_types.index_with do |group_type|
+            group_type.role_types.reject do |role_type|
+              role_type.restricted? || (role_type.permissions - @allowed_permissions).any?
+            end
+          end
+        end
+
+        def offending_self_registrations
+          allowed_role_types_by_group_type.flat_map do |group_type, allowed_role_types|
+            Group.where(type: group_type.sti_name)
+              .where.not(self_registration_role_type: allowed_role_types.map(&:sti_name) + [nil, ""])
+          end.compact
+        end
+      end
+
+      checker = SelfRegistrationRoleTypeChecker.new
+
+      if checker.check
+        puts "✅ SelfRegistrationRoleTypes configured correctly"
+      else
+        puts "❌ SelfRegistrationRoleTypes are giving to much rights"
+        puts checker.errors.join("\n")
       end
     end
   end

--- a/spec/controllers/groups/self_inscription_controller_spec.rb
+++ b/spec/controllers/groups/self_inscription_controller_spec.rb
@@ -13,7 +13,7 @@ describe Groups::SelfInscriptionController do
 
   context "with feature disabled" do
     before do
-      group.update!(self_registration_role_type: Group::TopGroup::Member.sti_name)
+      group.update!(self_registration_role_type: Role::External.sti_name)
       allow(Settings.groups.self_registration).to receive(:enabled).and_return(false)
     end
 
@@ -45,7 +45,7 @@ describe Groups::SelfInscriptionController do
     context "GET show" do
       context "when registration active" do
         before do
-          group.update(self_registration_role_type: Group::TopGroup::Member.sti_name)
+          group.update(self_registration_role_type: Role::External.sti_name)
         end
 
         context "when unautorized" do
@@ -66,7 +66,7 @@ describe Groups::SelfInscriptionController do
           end
 
           context "when already member of the group" do
-            before { Fabricate(:role, type: Group::TopGroup::Member.sti_name, person: person, group: group) }
+            before { Fabricate(:role, type: Role::External.sti_name, person: person, group: group) }
 
             it "redirects to group" do
               get :show, params: {group_id: group.id}

--- a/spec/controllers/groups/self_registration_controller_spec.rb
+++ b/spec/controllers/groups/self_registration_controller_spec.rb
@@ -13,7 +13,7 @@ describe Groups::SelfRegistrationController do
 
   context "with feature disabled" do
     before do
-      group.update!(self_registration_role_type: Group::TopGroup::Member.sti_name)
+      group.update!(self_registration_role_type: Role::External.sti_name)
       allow(Settings.groups.self_registration).to receive(:enabled).and_return(false)
     end
 
@@ -62,7 +62,7 @@ describe Groups::SelfRegistrationController do
     context "GET#show" do
       context "when registration active" do
         before do
-          group.update(self_registration_role_type: Group::TopGroup::Member.sti_name)
+          group.update(self_registration_role_type: Role::External.sti_name)
         end
 
         context "when unautorized" do
@@ -106,7 +106,7 @@ describe Groups::SelfRegistrationController do
     context "POST#create" do
       context "when registration active" do
         before do
-          group.update!(self_registration_role_type: Group::TopGroup::Member.sti_name)
+          group.update!(self_registration_role_type: Role::External.sti_name)
         end
 
         context "with privacy policies in hierarchy" do
@@ -136,7 +136,7 @@ describe Groups::SelfRegistrationController do
             expect(person.primary_group).to eq(group)
             expect(person.privacy_policy_accepted).to be_present
             expect(person.full_name).to eq("Bob Miller")
-            expect(role.type).to eq(Group::TopGroup::Member.sti_name)
+            expect(role.type).to eq(Role::External.sti_name)
             expect(role.group).to eq(group)
 
             expect(response).to redirect_to(new_person_session_path)
@@ -206,7 +206,7 @@ describe Groups::SelfRegistrationController do
 
           expect(person.primary_group).to eq(group)
           expect(person.full_name).to eq("Bob Miller")
-          expect(role.type).to eq(Group::TopGroup::Member.sti_name)
+          expect(role.type).to eq(Role::External.sti_name)
           expect(role.group).to eq(group)
 
           expect(response).to redirect_to(new_person_session_path)

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -178,7 +178,7 @@ describe GroupsController do
       end
 
       it "allows enabling #main_self_registration_group" do
-        group.update!(self_registration_role_type: "Group::TopGroup::Member")
+        group.update!(self_registration_role_type: Role::External.sti_name)
         expect do
           put :update, params: {id: group, group: {main_self_registration_group: "1"}}
         end.to change { group.reload.main_self_registration_group }.to true
@@ -192,7 +192,7 @@ describe GroupsController do
       end
 
       it "clears other groups #main_self_registration_group" do
-        group.update!(self_registration_role_type: "Group::TopGroup::Member")
+        group.update!(self_registration_role_type: Role::External.sti_name)
         groups(:bottom_group_one_two).update_column(:main_self_registration_group, true)
 
         expect do

--- a/spec/decorators/group_decorator_spec.rb
+++ b/spec/decorators/group_decorator_spec.rb
@@ -67,6 +67,7 @@ describe GroupDecorator, :draper_with_helpers do
 
   describe "allowed_roles_for_self_registration" do
     let(:group) { model }
+
     subject { decorator.allowed_roles_for_self_registration }
 
     it { is_expected.to eq [Role::External] }

--- a/spec/decorators/group_decorator_spec.rb
+++ b/spec/decorators/group_decorator_spec.rb
@@ -67,17 +67,15 @@ describe GroupDecorator, :draper_with_helpers do
 
   describe "allowed_roles_for_self_registration" do
     its(:allowed_roles_for_self_registration) do
-      should eq [Role::External,
-        Group::TopGroup::LocalSecretary,
-        Group::TopGroup::Member]
+      should eq [Role::External]
     end
 
     describe "allowed_roles_for_self_registration in a bottom group" do
       let(:model) { groups(:bottom_group_one_one) }
 
-      it "should include roles which are not visible_from_above" do
+      it "should include roles which have no permissions" do
         expect(subject.allowed_roles_for_self_registration).to eq [
-          Role::External, Group::BottomGroup::Member
+          Role::External,
         ]
       end
     end

--- a/spec/decorators/group_decorator_spec.rb
+++ b/spec/decorators/group_decorator_spec.rb
@@ -13,7 +13,7 @@ describe GroupDecorator, :draper_with_helpers do
   let(:context) { double("context") }
   let(:model) { groups(:top_group) }
 
-  subject { GroupDecorator.new(model) }
+  subject(:decorator) { GroupDecorator.new(model) }
 
   describe "possible roles" do
     its(:possible_roles) do
@@ -66,17 +66,21 @@ describe GroupDecorator, :draper_with_helpers do
   end
 
   describe "allowed_roles_for_self_registration" do
-    its(:allowed_roles_for_self_registration) do
-      should eq [Role::External]
-    end
+    let(:group) { model }
+    subject { decorator.allowed_roles_for_self_registration }
 
-    describe "allowed_roles_for_self_registration in a bottom group" do
-      let(:model) { groups(:bottom_group_one_one) }
+    it { is_expected.to eq [Role::External] }
+
+    describe "allowed_roles_for_self_registration with override in wagon" do
+      let(:group) { groups(:bottom_group_one_one) }
+
+      before do
+        stub_const("Role::Types::AllowedPermissionsForSelfRegistration", [:group_read])
+      end
 
       it "should include roles which have no permissions" do
-        expect(subject.allowed_roles_for_self_registration).to eq [
-          Role::External,
-        ]
+        expect(Role::Types::AllowedPermissionsForSelfRegistration).to contain_exactly(:group_read)
+        is_expected.to contain_exactly(Role::External)
       end
     end
   end

--- a/spec/features/email_verification_spec.rb
+++ b/spec/features/email_verification_spec.rb
@@ -253,7 +253,7 @@ describe "Email verification", js: true do
 
     before do
       allow(Settings.groups.self_registration).to receive(:enabled).and_return(true)
-      group.update!(self_registration_role_type: Group::BottomGroup::Member.sti_name)
+      group.update!(self_registration_role_type: Role::External.sti_name)
     end
 
     it "should not auto-confirm email" do

--- a/spec/models/wizards/inscribe_in_group_wizard_spec.rb
+++ b/spec/models/wizards/inscribe_in_group_wizard_spec.rb
@@ -9,7 +9,7 @@ require "spec_helper"
 describe Wizards::InscribeInGroupWizard do
   include ActiveJob::TestHelper
 
-  let(:role_type) { Group::TopGroup::Member }
+  let(:role_type) { Role::External }
   let(:group) { groups(:top_group) }
   let(:person) { people(:bottom_member) }
 

--- a/spec/models/wizards/register_new_user_wizard_spec.rb
+++ b/spec/models/wizards/register_new_user_wizard_spec.rb
@@ -8,7 +8,7 @@ require "spec_helper"
 
 describe Wizards::RegisterNewUserWizard do
   let(:params) { {} }
-  let(:role_type) { Group::TopGroup::Member }
+  let(:role_type) { Role::External }
   let(:group) { groups(:top_group) }
 
   subject(:wizard) do

--- a/spec/resources/group/reads_spec.rb
+++ b/spec/resources/group/reads_spec.rb
@@ -13,7 +13,7 @@ describe GroupResource, type: :resource do
   describe "serialization" do
     let!(:group) { groups(:bottom_group_two_one) }
 
-    before { group.update!(self_registration_role_type: Group::BottomGroup::Member.sti_name) }
+    before { group.update!(self_registration_role_type: Role::External.sti_name) }
 
     def serialized_attrs
       [


### PR DESCRIPTION
closes #2357 

Prüfen. ob es auf einer Instanz Gruppen mit Self-Registation gibt, die dann invalid sind:

```ruby
class SelfRegistrationRoleTypeChecker
  def allowed_role_types_by_group_type(allowed_permissions = [])
    Group.all_types.index_with do |group_type|
      group_type.role_types.reject do |role_type|
        role_type.restricted? || (role_type.permissions - allowed_permissions).any?
      end
    end
  end

  def offending_self_registrations
    allowed_role_types_by_group_type.flat_map do |group_type, allowed_role_types|
      Group.where(type: group_type.sti_name)
           .where.not(self_registration_role_type: allowed_role_types.map(&:sti_name) + [nil])
    end.compact
  end

  def check
    offending_self_registrations.each do |group|
      puts "Group ##{group.id} #{group.name} uses self registration with #{group.self_registration_role_type} (#{group.self_registration_role_type.constantize.permissions.to_sentence})"
    end.none?
  end
end
```