### PR TITLE
Convert custom content placeholders to string

### DIFF
--- a/app/models/custom_content.rb
+++ b/app/models/custom_content.rb
@@ -70,7 +70,7 @@ class CustomContent < ActiveRecord::Base
     placeholders_list.each_with_object(string) do |placeholder, output|
       token = placeholder_token(placeholder)
       if output.include?(token)
-        output.gsub!(token, placeholders.fetch(placeholder))
+        output.gsub!(token, placeholders.fetch(placeholder).to_s)
       end
     end
   end


### PR DESCRIPTION
To prevent errors when not converting to string in mailer (e.g. [here](https://github.com/hitobito/hitobito_sac_cas/blob/6d5c8a107255861685043ed792c5fe2f70434f83/app/mailers/signup/sektion_mailer.rb#L34))