### PR TITLE
Fix/remove breaking obsolete migrations

### DIFF
--- a/db/migrate/20240812095000_add_derived_from_to_event_questions.rb
+++ b/db/migrate/20240812095000_add_derived_from_to_event_questions.rb
@@ -1,5 +1,6 @@
 class AddDerivedFromToEventQuestions < ActiveRecord::Migration[6.1]
   def change
+    Event::Question.reset_column_information
     add_reference :event_questions, :derived_from_question, null: true,
                   foreign_key: false, type: :integer
     reversible do |direction|

--- a/db/migrate/20240903131542_change_event_answers_to_json_type.rb
+++ b/db/migrate/20240903131542_change_event_answers_to_json_type.rb
@@ -1,8 +1,0 @@
-class ChangeEventAnswersToJsonType < ActiveRecord::Migration[6.1]
-  # migration is obsolete
-  def up
-  end
-
-  def down
-  end
-end

--- a/db/migrate/20240903131542_change_event_answers_to_json_type.rb
+++ b/db/migrate/20240903131542_change_event_answers_to_json_type.rb
@@ -1,24 +1,8 @@
 class ChangeEventAnswersToJsonType < ActiveRecord::Migration[6.1]
+  # migration is obsolete
   def up
-    execute <<~SQL.squish
-              UPDATE
-                event_answers
-              SET
-                answer = '"' || answer || '"';
-            SQL
-
-    # change_column :event_answers, :answer, 'json USING answer::json'
   end
 
   def down
-    # change_column :event_answers, :answer, :string
-
-    execute <<~SQL.squish
-              UPDATE
-                event_answers
-              SET
-                answer = TRIM(BOTH '"' FROM answer);
-            SQL
   end
-
 end

--- a/db/migrate/20240917173808_revert_change_event_answers_to_json_type.rb
+++ b/db/migrate/20240917173808_revert_change_event_answers_to_json_type.rb
@@ -1,8 +1,0 @@
-class RevertChangeEventAnswersToJsonType < ActiveRecord::Migration[6.1]
-  # migration is obsolete
-  def up
-  end
-
-  def down
-  end
-end

--- a/db/migrate/20240917173808_revert_change_event_answers_to_json_type.rb
+++ b/db/migrate/20240917173808_revert_change_event_answers_to_json_type.rb
@@ -1,19 +1,8 @@
 class RevertChangeEventAnswersToJsonType < ActiveRecord::Migration[6.1]
+  # migration is obsolete
   def up
-    execute <<~SQL.squish
-              UPDATE
-                event_answers
-              SET
-                answer = TRIM(BOTH '"' FROM answer);
-            SQL
   end
 
   def down
-    execute <<~SQL.squish
-              UPDATE
-                event_answers
-              SET
-                answer = '"' || answer || '"';
-            SQL
   end
 end


### PR DESCRIPTION
Im Rahmen des Features [hitobito_youth#58](https://github.com/hitobito/hitobito_youth/issues/58) wurde die eine Mirgration erstellt (_db/migrate/20240903131542_change_event_answers_to_json_type.rb_), welche aber später wieder verworfen und rückgängig gemacht wurde (_db/migrate/20240917173808_revert_change_event_answers_to_json_type.rb_).

Diese Migration wurde aber noch nicht auf production deployt und sollte es auch nicht; Potentiell kann diese Migration die Maximale Grösse von VARCHAR-Feldern sprengen und deshalb failen. Deshalb sollten beide Migrationen wieder entfernt werden, bevor Released wird.