### PR TITLE
Fix event API leaders relation

### DIFF
--- a/app/models/event/course.rb
+++ b/app/models/event/course.rb
@@ -59,6 +59,8 @@
 # A course is a specialised Event that has by default applications,
 # preconditions and may give a qualification after attending it.
 class Event::Course < Event
+  LEADER_ROLES = [Event::Role::Leader].map(&:sti_name)
+
   # This statement is required because this class would not be loaded otherwise.
   require_dependency "event/course/role/participant"
 

--- a/app/resources/event/course_resource.rb
+++ b/app/resources/event/course_resource.rb
@@ -23,10 +23,4 @@ class Event::CourseResource < EventResource
   def base_scope
     Event::Course.all.accessible_by(index_ability).includes(:groups, :translations).list
   end
-
-  def resolve(scope)
-    scope.to_a.tap do |events|
-      events.each { |event| event.singleton_class.attr_accessor :leaders }
-    end
-  end
 end

--- a/app/resources/event_resource.rb
+++ b/app/resources/event_resource.rb
@@ -68,4 +68,10 @@ class EventResource < ApplicationResource
   def index_ability
     JsonApi::EventAbility.new(current_ability)
   end
+
+  def resolve(scope)
+    scope.to_a.tap do |events|
+      events.select { |event| event.type == Event::Course.sti_name }.each { |event| event.singleton_class.attr_accessor :leaders }
+    end
+  end
 end

--- a/app/resources/person/name_resource.rb
+++ b/app/resources/person/name_resource.rb
@@ -21,7 +21,7 @@ class Person::NameResource < ApplicationResource
         .joins(event_participations: :roles)
         .select("people.id, first_name, last_name, event_id AS leads_course_id")
         .where(event_participations: {event_id: course_ids},
-          event_roles: {type: Event::Role::Leader.sti_name})
+          event_roles: {type: Event::Course::LEADER_ROLES})
     end
   end
 


### PR DESCRIPTION
Fixes #2848

- makes sure that `:leaders` atribute accessor exists for courses
- adds a constant defining the leader roles to be overridden in wagons