### PR TITLE
Run seeds in CI

### DIFF
--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -106,6 +106,7 @@ jobs:
       - name: 'Prepare'
         uses: ./.hitobito_core_repo/.github/actions/wagon-ci-setup
         with:
+          assets: false
           wagon_repository: ${{ inputs.wagon_repository }}
           wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
           core_ref: ${{ inputs.core_ref }}

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -78,7 +78,8 @@ jobs:
       RAILS_DB_PASSWORD: hitobito
       RAILS_DB_NAME: hitobito_development
       RAILS_ENV: development
-
+    # only run seeds on master
+    if: ${{ github.ref_name == 'master' }}
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -66,6 +66,56 @@ jobs:
         run: |
           bundle exec rake app:rubocop
 
+  wagon_seeds:
+    name: seeds
+    runs-on: 'ubuntu-20.04'
+    env:
+      HEADLESS: true
+      RAILS_DB_ADAPTER: postgresql
+      RAILS_DB_HOST: 127.0.0.1
+      RAILS_DB_PORT: 5432
+      RAILS_DB_USERNAME: hitobito
+      RAILS_DB_PASSWORD: hitobito
+      RAILS_DB_NAME: hitobito_test
+      RAILS_TEST_DB_NAME: hitobito_test
+      RAILS_ENV: test
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: hitobito
+          POSTGRES_PASSWORD: hitobito
+          POSTGRES_DB: hitobito_test
+        ports:
+          - '5432:5432'
+        options: >-
+          --health-cmd "pg_isready -U hitobito"
+          --health-interval 10s
+          --health-timeout 10s
+          --health-retries 10
+    steps:
+      - name: Check out the core, which contains the shared setup action
+        uses: actions/checkout@v4
+        with:
+          repository: hitobito/hitobito
+          ref: ${{ inputs.core_ref }}
+          path: .hitobito_core_repo
+          fetch-depth: 1
+
+      - name: 'Prepare'
+        uses: ./.hitobito_core_repo/.github/actions/wagon-ci-setup
+        with:
+          wagon_repository: ${{ inputs.wagon_repository }}
+          wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
+          core_ref: ${{ inputs.core_ref }}
+          wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
+
+      - name: Run ${{ inputs.wagon_repository }} seeds
+        working-directory: ${{ inputs.wagon_repository }}
+        run: |
+          bundle exec rake db:seed wagon:seed
+
   wagon_specs:
     name: specs
     runs-on: 'ubuntu-20.04'

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -112,7 +112,6 @@ jobs:
           wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
 
       - name: Run ${{ inputs.wagon_repository }} seeds
-        working-directory: ${{ inputs.wagon_repository }}
         run: |
           bundle exec rake db:seed wagon:seed
 

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -76,9 +76,8 @@ jobs:
       RAILS_DB_PORT: 5432
       RAILS_DB_USERNAME: hitobito
       RAILS_DB_PASSWORD: hitobito
-      RAILS_DB_NAME: hitobito_test
-      RAILS_TEST_DB_NAME: hitobito_test
-      RAILS_ENV: test
+      RAILS_DB_NAME: hitobito_development
+      RAILS_ENV: development
 
     services:
       postgres:
@@ -86,7 +85,7 @@ jobs:
         env:
           POSTGRES_USER: hitobito
           POSTGRES_PASSWORD: hitobito
-          POSTGRES_DB: hitobito_test
+          POSTGRES_DB: hitobito_development
         ports:
           - '5432:5432'
         options: >-


### PR DESCRIPTION
In the SAC project we had the issue from time to time, that changes in the code would break the seeds and thus interrupt the workflow of other developers which needed to reseed locally.

To avoid that we want to run the seeds during CI so we'd notice of a PR would beeak the seeds.

Actual CI run is here: https://github.com/hitobito/hitobito_sac_cas/pull/1047