### PR TITLE
feat: add button to get to participation (hitobito_jubla#85)

### DIFF
--- a/app/decorators/event/participation_decorator.rb
+++ b/app/decorators/event/participation_decorator.rb
@@ -21,9 +21,9 @@ class Event::ParticipationDecorator < ApplicationDecorator
   end
 
   def labeled_link
-    group ||= event.groups.first
-    event.labeled_link(h.group_event_participation_path(group, event, self),
-      can?(:show, self))
+    url = h.group_event_participation_path(event.groups.first, event, model)
+    label = model.model_name.human
+    h.link_to_if(can?(:show, model), label, url)
   end
 
   def person_location_information

--- a/app/decorators/event/participation_decorator.rb
+++ b/app/decorators/event/participation_decorator.rb
@@ -14,8 +14,16 @@ class Event::ParticipationDecorator < ApplicationDecorator
     :all_phone_numbers, :all_social_accounts, :complete_address, :town, :layer_group_label,
     :layer_group, to: :person
 
+  delegate :dates_full, to: :event
+
   def person_additional_information
     h.tag(:br) + h.muted(person.additional_name) + incomplete_label
+  end
+
+  def labeled_link
+    group ||= event.groups.first
+    event.labeled_link(h.group_event_participation_path(group, event, self),
+      can?(:show, self))
   end
 
   def person_location_information

--- a/app/decorators/person_decorator.rb
+++ b/app/decorators/person_decorator.rb
@@ -134,6 +134,11 @@ class PersonDecorator < ApplicationDecorator
     @upcoming_events ||= EventDecorator.decorate_collection(event_queries.upcoming_events)
   end
 
+  def upcoming_participations
+    @upcoming_participations ||=
+      Event::ParticipationDecorator.decorate_collection(event_queries.upcoming_participations)
+  end
+
   def relations
     @relations ||= relations_to_tails.includes(tail: [:groups, :roles])
   end

--- a/app/domain/person/event_queries.rb
+++ b/app/domain/person/event_queries.rb
@@ -41,6 +41,21 @@ class Person::EventQueries
     ).order_by_date
   end
 
+  def upcoming_participations
+    Event::Participation.select("*").from(
+      person
+        .event_participations
+        .merge(Event::Participation.upcoming)
+        .active
+        .joins(event: :dates)
+        .select("event_participations.*", "event_dates.start_at")
+        .distinct_on(:id)
+        .includes(:roles, event: [:translations, :dates, :groups])
+    ).order(:start_at).tap do |applications|
+      Event::PreloadAllDates.for(applications.collect(&:event))
+    end
+  end
+
   def alltime_participations
     Event::Participation.select("*").from(
       person

--- a/app/domain/person/event_queries.rb
+++ b/app/domain/person/event_queries.rb
@@ -51,8 +51,8 @@ class Person::EventQueries
         .select("event_participations.*", "event_dates.start_at")
         .distinct_on(:id)
         .includes(:roles, event: [:translations, :dates, :groups])
-    ).order(:start_at).tap do |applications|
-      Event::PreloadAllDates.for(applications.collect(&:event))
+    ).order(:start_at).tap do |participations|
+      Event::PreloadAllDates.for(participations.collect(&:event))
     end
   end
 

--- a/app/views/people/_attrs.html.haml
+++ b/app/views/people/_attrs.html.haml
@@ -41,7 +41,7 @@
       = render 'roles'
       = render 'add_requests'
       = render 'event_aside', title: Event::Application.model_name.human(count: 2), collection: entry.pending_applications
-      = render 'event_aside', title: upcoming_events_title, collection: entry.upcoming_participations
+      = render 'participation_aside', title: upcoming_events_title, collection: entry.upcoming_participations
 
       = render_extensions :show_event
 

--- a/app/views/people/_attrs.html.haml
+++ b/app/views/people/_attrs.html.haml
@@ -41,7 +41,7 @@
       = render 'roles'
       = render 'add_requests'
       = render 'event_aside', title: Event::Application.model_name.human(count: 2), collection: entry.pending_applications
-      = render 'event_aside', title: upcoming_events_title, collection: entry.upcoming_events
+      = render 'event_aside', title: upcoming_events_title, collection: entry.upcoming_participations
 
       = render_extensions :show_event
 

--- a/app/views/people/_event_aside.html.haml
+++ b/app/views/people/_event_aside.html.haml
@@ -6,8 +6,4 @@
 = section_table(title, collection) do |item|
   %td
     %strong= item.labeled_link
-    %div.mt-1
-      - participation = entry.event_participations.find { |p| p.event_id == item.id  }
-      - if can?(:show, participation)
-        = action_button(Event::Participation.model_name.human,group_event_participation_path(item.groups.first, item, participation))
   %td= item.dates_full

--- a/app/views/people/_event_aside.html.haml
+++ b/app/views/people/_event_aside.html.haml
@@ -5,7 +5,6 @@
 
 = section_table(title, collection) do |item|
   %td
-    = item.inspect
     %strong= item.labeled_link
   %td= item.dates_full
 

--- a/app/views/people/_event_aside.html.haml
+++ b/app/views/people/_event_aside.html.haml
@@ -4,6 +4,14 @@
 -#  https://github.com/hitobito/hitobito.
 
 = section_table(title, collection) do |item|
-  %td
-    %strong= item.labeled_link
-  %td= item.dates_full
+  - case item 
+  - when EventDecorator
+    %td
+      %strong= item.labeled_link
+    %td= item.dates_full
+  - when Event::ParticipationDecorator, ApplicationDecorator
+    %td
+      %strong= item.event.labeled_link
+      %br
+      = item.labeled_link
+    %td= item.event.dates_full

--- a/app/views/people/_event_aside.html.haml
+++ b/app/views/people/_event_aside.html.haml
@@ -5,13 +5,15 @@
 
 = section_table(title, collection) do |item|
   - case item 
-  - when EventDecorator
-    %td
-      %strong= item.labeled_link
-    %td= item.dates_full
-  - when Event::ParticipationDecorator, ApplicationDecorator
+  - when Event::ParticipationDecorator
     %td
       %strong= item.event.labeled_link
       %br
       = item.labeled_link
     %td= item.event.dates_full
+  - else # preserve previous behaviour for EventDecorator, ApplicationDecorator
+    %td
+      = item.inspect
+      %strong= item.labeled_link
+    %td= item.dates_full
+

--- a/app/views/people/_event_aside.html.haml
+++ b/app/views/people/_event_aside.html.haml
@@ -6,4 +6,8 @@
 = section_table(title, collection) do |item|
   %td
     %strong= item.labeled_link
+    %div.mt-1
+      - participation = entry.event_participations.find { |p| p.event_id == item.id  }
+      - if can?(:show, participation)
+        = action_button(Event::Participation.model_name.human,group_event_participation_path(item.groups.first, item, participation))
   %td= item.dates_full

--- a/app/views/people/_participation_aside.html.haml
+++ b/app/views/people/_participation_aside.html.haml
@@ -5,7 +5,7 @@
 
 = section_table(title, collection) do |item|
   %td
-    = item.inspect
-    %strong= item.labeled_link
-  %td= item.dates_full
-
+    %strong= item.event.labeled_link
+    %br
+    = item.labeled_link
+  %td= item.event.dates_full

--- a/spec/decorators/event/participation_decorator.rb
+++ b/spec/decorators/event/participation_decorator.rb
@@ -1,0 +1,25 @@
+#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+describe Event::ParticipationDecorator, :draper_with_helpers do
+  include Rails.application.routes.url_helpers
+
+  let(:person) { people(:top_leader) }
+  let(:event) { events(:top_event) }
+  let(:participation) { Fabricate(:event_participation, event: event, person: person) }
+
+  subject(:decorator) { described_class.new(participation) }
+
+  describe '#labeled_link' do
+    subject(:labeled_link) { decorator.labeled_link }
+
+    it "returns event name as link to particpation" do
+      is_expected.to have_text(event.name)
+      is_expected.to include(group_event_participation_path(event.groups.first, event, participation))
+    end
+  end
+end

--- a/spec/decorators/event/participation_decorator.rb
+++ b/spec/decorators/event/participation_decorator.rb
@@ -14,7 +14,7 @@ describe Event::ParticipationDecorator, :draper_with_helpers do
 
   subject(:decorator) { described_class.new(participation) }
 
-  describe '#labeled_link' do
+  describe "#labeled_link" do
     subject(:labeled_link) { decorator.labeled_link }
 
     it "returns event name as link to particpation" do

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -133,7 +133,7 @@ describe PersonDecorator, :draper_with_helpers do
       expect(subject.upcoming_events).to be_empty
     end
 
-    describe '#upcoming_participations' do
+    describe "#upcoming_participations" do
       subject(:upcoming_participations) { decorator.upcoming_participations }
 
       it "returns participations that are active" do

--- a/spec/decorators/person_decorator_spec.rb
+++ b/spec/decorators/person_decorator_spec.rb
@@ -10,7 +10,7 @@ describe PersonDecorator, :draper_with_helpers do
 
   let(:person) { people(:top_leader) }
 
-  subject { PersonDecorator.new(person) }
+  subject(:decorator) { PersonDecorator.new(person) }
 
   its(:full_label) { should == "Top Leader, Greattown" }
   its(:address_name) { should == "<strong>Top Leader</strong>" }
@@ -47,7 +47,7 @@ describe PersonDecorator, :draper_with_helpers do
   end
 
   context "roles grouped" do
-    let(:roles_grouped) { PersonDecorator.new(person).roles_grouped }
+    let(:roles_grouped) { decorator.roles_grouped }
 
     before do
       Fabricate(Group::TopGroup::Member.name.to_sym, group: groups(:top_group), person: person)
@@ -68,7 +68,7 @@ describe PersonDecorator, :draper_with_helpers do
     end
 
     it "displays only roles of the group without group name" do
-      roles_short = PersonDecorator.new(person).roles_short(groups(:top_layer))
+      roles_short = decorator.roles_short(groups(:top_layer))
       expect(roles_short).to include("Admin")
       expect(roles_short).not_to include('<span class="muted">Top</span>')
       expect(roles_short).not_to include("Leader")
@@ -78,7 +78,7 @@ describe PersonDecorator, :draper_with_helpers do
     end
 
     it "displays roles of the group and its subgroups including the group name" do
-      roles_short = PersonDecorator.new(person).roles_short(groups(:top_layer).decorate, true)
+      roles_short = decorator.roles_short(groups(:top_layer).decorate, true)
       expect(roles_short).to include("Admin")
       expect(roles_short).to include('<span class="muted">Top</span>')
       expect(roles_short).to include("Leader")
@@ -88,7 +88,7 @@ describe PersonDecorator, :draper_with_helpers do
     end
 
     it "does not display roles in groups which are not subgroups" do
-      roles_short = PersonDecorator.new(person).roles_short(groups(:bottom_layer_one).decorate, true)
+      roles_short = decorator.roles_short(groups(:bottom_layer_one).decorate, true)
       expect(roles_short).not_to include("Admin")
       expect(roles_short).not_to include('<span class="muted">Top</span>')
       expect(roles_short).not_to include("Leader")
@@ -132,10 +132,30 @@ describe PersonDecorator, :draper_with_helpers do
 
       expect(subject.upcoming_events).to be_empty
     end
+
+    describe '#upcoming_participations' do
+      subject(:upcoming_participations) { decorator.upcoming_participations }
+
+      it "returns participations that are active" do
+        dates = [Fabricate(:event_date, start_at: 2.days.from_now, finish_at: 5.days.from_now)]
+        event = Fabricate(:event, groups: [groups(:top_layer)], dates: dates)
+        participation = Fabricate(:event_participation, event: event, person: person, active: true)
+
+        is_expected.to eq [participation]
+      end
+
+      it "does not return past events" do
+        dates = [Fabricate(:event_date, start_at: 10.days.ago, finish_at: 8.days.ago)]
+        event = Fabricate(:event, groups: [groups(:top_layer)], dates: dates)
+        Fabricate(:event_participation, event: event, person: person, active: true)
+
+        is_expected.to be_empty
+      end
+    end
   end
 
   context "layer group" do
-    let(:label) { PersonDecorator.new(person).layer_group_label }
+    let(:label) { decorator.layer_group_label }
 
     it "creates link for group layer" do
       expect(label).to match(/Top/)

--- a/spec/regressions/people_controller_spec.rb
+++ b/spec/regressions/people_controller_spec.rb
@@ -185,7 +185,7 @@ describe PeopleController, type: :controller do
     let(:header) { section.find("h2").text.strip }
     let(:dates) { section.find("tr:eq(1) td:eq(2)").text.strip }
     let(:label) { section.find("tr:eq(1) td:eq(1)") }
-    let(:label_link) { label.find("a") }
+    let(:label_link) { label.all("a")[0] }
     let(:course) { Fabricate(:course, groups: [groups(:top_layer)], kind: event_kinds(:slk)) }
 
     context "pending applications" do
@@ -215,6 +215,7 @@ describe PeopleController, type: :controller do
     context "upcoming events" do
       let(:section) { dom.all("aside section")[2] }
       let(:date) { 2.days.from_now }
+      let(:participation_link) { label.all("a")[1] }
       let(:pretty_date) do
         "#{I18n.l(date,
           format: "%a %d.%m.%Y %H:%M")} - #{I18n.l(date + 5.days,
@@ -240,6 +241,14 @@ describe PeopleController, type: :controller do
         expect(label_link.text).to eq "Eventus"
         expect(label.text).to match(/Top/)
         expect(dates).to eq pretty_date
+      end
+
+      it "lists participation link" do
+        participation = create_participation(date, active_participation: true)
+        get :show, params: params
+        expect(participation_link[:href]).to eq group_event_participation_path(course.groups.first,
+          course, participation)
+        expect(participation_link.text).to eq "Teilnahme"
       end
     end
 


### PR DESCRIPTION
refs [hitobito_youth#85](https://github.com/hitobito/hitobito_youth/issues/85)

## Summary

Auf der Person unter «Meine nächsten Anlässe» soll ein Link zur Anmeldung dieser Person haben. Zuerst war die Idee den bestehenden Link anzupassen, was aber zu Problemen bei Personen ohne Rollen hätte führen können. Deshalb wurde entschieden, einfach einen zusätzlichen Link einzufügen.