### PR TITLE
Rework database config

### DIFF
--- a/.github/actions/core-ci-setup/action.yml
+++ b/.github/actions/core-ci-setup/action.yml
@@ -5,6 +5,9 @@ inputs:
   migrations:
     description: Unless set to false, migrations will be run as part of the setup.
     default: 'true'
+  assets:
+    description: Unless set to false, assets will be precompiled as part of the setup.
+    default: 'true'
 
 runs:
   using: composite
@@ -53,6 +56,7 @@ runs:
       shell: bash
 
     - uses: actions/cache@v4
+      if: inputs.assets == 'true'
       with:
         path: node_modules
         key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
@@ -60,11 +64,13 @@ runs:
           ${{ runner.os }}-node_modules-
 
     - name: 'Yarn install'
+      if: inputs.assets == 'true'
       run: |
         yarn install --frozen-lockfile
       shell: bash
 
     - name: 'Run Webpacker'
+      if: inputs.assets == 'true'
       run: |
         bundle exec rake webpacker:compile
       shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   rubocop:
     runs-on: 'ubuntu-20.04'
+    env:
+      RAILS_DB_ADAPTER: nulldb
 
     steps:
       - name: 'Checkout'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
         uses: ./.github/actions/core-ci-setup
         with:
           migrations: false
+          assets: false
 
       - name: 'Rubocop'
         run: |

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -39,6 +39,8 @@ jobs:
   wagon_rubocop:
     name: rubocop
     runs-on: 'ubuntu-20.04'
+    env:
+      RAILS_DB_ADAPTER: nulldb
 
     steps:
       - name: Check out core with shared setup action

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG NODEJS_VERSION="16"
 ARG YARN_VERSION="1.22.19"
 
 # Packages
-ARG BUILD_PACKAGES="nodejs git sqlite3 libsqlite3-dev imagemagick build-essential libpq-dev"
+ARG BUILD_PACKAGES="nodejs git imagemagick build-essential libpq-dev"
 ARG RUN_PACKAGES="imagemagick shared-mime-info pkg-config libmagickcore-dev libmagickwand-dev libpq-dev libjemalloc-dev libjemalloc2"
 
 # Scripts
@@ -163,7 +163,7 @@ RUN bash -vxc "${POST_BUILD_SCRIPT:-"echo 'no POST_BUILD_SCRIPT provided'"}"
 
 # TODO: Save artifacts
 
-RUN rm -rf vendor/cache/ .git spec/ node_modules/ db/production.sqlite3
+RUN rm -rf vendor/cache/ .git spec/ node_modules/
 
 #################################
 #         Run/App Stage         #

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ARG PRE_BUILD_SCRIPT="\
      cp -v Wagonfile.production Wagonfile; \
      bundle lock; \
 "
-ARG BUILD_SCRIPT="bundle exec rake assets:precompile"
+ARG BUILD_SCRIPT="RAILS_DB_ADAPTER=nulldb bundle exec rake assets:precompile"
 
 ARG POST_BUILD_SCRIPT=" \
      echo \"(built at: $(date '+%Y-%m-%d %H:%M:%S'))\" > /app-src/BUILD_INFO; \

--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,6 @@ gem "simpleidn"
 gem "simple_xlsx_reader" # import data from xlsx files (used in some wagons)
 gem "sorted_set"
 gem "sprockets", "~> 3.7.2" # pinned to older version to avoid having an empty manifest.js
-gem "sqlite3", "~> 1.7.2" # required for asset generation
 gem "strip_attributes" # strip whitespace of attributes
 gem "truemail"
 gem "turbo-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ source "https://rubygems.org"
 gem "rails", "= 6.1.7.8"
 gem "wagons", "~> 0.7.0"
 
+gem "activerecord-nulldb-adapter"
 gem "activerecord-session_store"
 gem "acts-as-taggable-on"
 gem "airbrake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -669,8 +669,6 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.3)
-      mini_portile2 (~> 2.8.0)
     stackprof (0.2.26)
     standard (1.39.1)
       language_server-protocol (~> 3.17.0.2)
@@ -875,7 +873,6 @@ DEPENDENCIES
   sorted_set
   spring-commands-rspec
   sprockets (~> 3.7.2)
-  sqlite3 (~> 1.7.2)
   stackprof
   standard (~> 1.28)
   standard-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     activerecord (6.1.7.8)
       activemodel (= 6.1.7.8)
       activesupport (= 6.1.7.8)
+    activerecord-nulldb-adapter (1.0.1)
+      activerecord (>= 5.2.0, < 7.2)
     activerecord-session_store (2.1.0)
       actionpack (>= 6.1)
       activerecord (>= 6.1)
@@ -752,6 +754,7 @@ DEPENDENCIES
   active_record_distinct_on
   active_storage_validations
   active_storage_variant
+  activerecord-nulldb-adapter
   activerecord-session_store
   acts-as-taggable-on
   airbrake

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@
 #  https://github.com/hitobito/hitobito.
 
 base: &generic
-  adapter: postgresql
+  adapter: <%= ENV['RAILS_DB_ADAPTER'] || 'postgresql' %>
   pool: 20
   checkout_timeout: 5 # seconds
   encoding: "utf8"

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,8 +6,8 @@
 base: &generic
   adapter: postgresql
   pool: 20
-  timeout: 5000
-  encoding: 'utf8'
+  checkout_timeout: 5 # seconds
+  encoding: "utf8"
 <% %w(host port username password socket).each do |option| %>
   <% value = ENV["RAILS_DB_#{option.upcase}"] %>
   <%= "#{option}: #{value}" if value.present? %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,6 +12,12 @@ base: &generic
   <% value = ENV["RAILS_DB_#{option.upcase}"] %>
   <%= "#{option}: #{value}" if value.present? %>
 <% end %>
+<% variables = %w(lock_timeout statement_timeout).map { [_1, ENV["RAILS_DB_#{_1.upcase}"]] }.to_h.compact %>
+<% if variables.any? %>
+  variables:<% variables.each do |option, value| %>
+    <%= "#{option}: #{value}" %>
+<% end %>
+<% end %>
 
 development:
   <<: *generic

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@
 #  https://github.com/hitobito/hitobito.
 
 base: &generic
-  adapter: <%= ENV['RAILS_DB_ADAPTER'] || 'sqlite3' %>
+  adapter: postgresql
   pool: 20
   timeout: 5000
   encoding: 'utf8'
@@ -15,21 +15,17 @@ base: &generic
 
 development:
   <<: *generic
-  database: <%= ENV['RAILS_DB_NAME'] || "#{Rails.root}/db/development.sqlite3" %>
-<% if ENV.fetch('RAILS_DB_ADAPTER', 'sqlite3') =~ /postgresql/ %>
-  schema_search_path: <%= ENV['RAILS_DB_SCHEMA'] || "public" %>
-<% end %>
+  database: <%= ENV["RAILS_DB_NAME"] || "hitobito_development" %>
+  schema_search_path: <%= ENV["RAILS_DB_SCHEMA"] || "public" %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *generic
-  database: <%= ENV['RAILS_TEST_DB_NAME'] || ENV['RAILS_DB_NAME'] || "#{Rails.root}/db/test.sqlite3" %>
+  database: <%= ENV["RAILS_TEST_DB_NAME"] || ENV["RAILS_DB_NAME"] || "hitobito_test" %>
 
 production:
   <<: *generic
-  database: <%= ENV['RAILS_DB_NAME'] || "#{Rails.root}/db/production.sqlite3" %>
-<% if ENV.fetch('RAILS_DB_ADAPTER', 'sqlite3') =~ /postgresql/ %>
-  schema_search_path: <%= ENV['RAILS_DB_SCHEMA'] || "public" %>
-<% end %>
+  database: <%= ENV["RAILS_DB_NAME"] || "hitobito_production" %>
+  schema_search_path: <%= ENV["RAILS_DB_SCHEMA"] || "public" %>


### PR DESCRIPTION
This PR covers 3 aspects:

1. it drops support for sqlite3, which is not usable or needed for local development anymore.
2. it updates a config setting to the current version
3. it supports some more settings for the postgresql-connection. 

The newly supported settings are
- lock_timeout
- statement_timeout

Both help us to stop overly long-running queries and therefore stabilize the application. The actual settings are then done on the server/cluster with environment variables. 