### PR TITLE
Permission von Rolen im info aside richtig ausrichten

### DIFF
--- a/app/views/roles/_info.html.haml
+++ b/app/views/roles/_info.html.haml
@@ -11,7 +11,7 @@
     - if @type.permissions.present?
       = t('.role_has_permissions', role: @type.label, group: @group)
       %br/
-      %ul
+      %ul.ms-3
         - @type.permissions.each do |perm|
           %li= t("activerecord.attributes.role.class.permission.description.#{perm}")
     - else


### PR DESCRIPTION
Damit sind die Bullets der Liste wieder richtig ausgerichtet

**vorher** 
![image](https://github.com/user-attachments/assets/f31a657f-1c54-4c96-b15b-6b606371ceb9)
**nachher**
![image](https://github.com/user-attachments/assets/cbed6b73-8e25-4ee4-b40d-12a547caf39d)


