### PR TITLE
PEOPLE: fix missing company name leads to 404.

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -414,7 +414,7 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   end
 
   def to_s(format = :default)
-    if company?
+    if company? && company_name.present?
       company_name
     else
       person_name(format)

--- a/spec/features/roles_controller_spec.rb
+++ b/spec/features/roles_controller_spec.rb
@@ -97,7 +97,7 @@ describe RolesController, js: true do
     end
   end
 
-  it "uses exisiting person when given" do
+  it "uses existing person when given" do
     obsolete_node_safe do
       sign_in
       visit new_group_role_path(group_id: group.id)
@@ -121,7 +121,7 @@ describe RolesController, js: true do
     end
   end
 
-  it "creates new person when fields filled" do
+  def create_new_person(company: false)
     obsolete_node_safe do
       sign_in
       visit new_group_role_path(group_id: group.id)
@@ -137,12 +137,22 @@ describe RolesController, js: true do
       # now define new person
       click_link("Neue Person erfassen")
       fill_in("Vorname", with: "Tester")
+      check("Firma") if company
 
       all("form .btn-group").first.click_button "Speichern"
 
       expect(current_path).not_to eq(group_people_path(group))
-      is_expected.to have_content "Rolle Leader für Tester in TopGroup wurde erfolgreich erstellt."
     end
+  end
+
+  it "creates new person when fields filled" do
+    create_new_person
+    is_expected.to have_content "Rolle Leader für Tester in TopGroup wurde erfolgreich erstellt."
+  end
+
+  it "does not create new person when company name is missing" do
+    create_new_person(company: true)
+    is_expected.to have_content "Firmenname muss ausgefüllt werden"
   end
 
   it "updates info when type changes" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -633,6 +633,36 @@ describe Person do
     end
   end
 
+  describe "#to_s" do
+    let(:company) { false }
+    let(:company_name) { nil }
+    let(:person) { Fabricate.build(:person, first_name: "John", last_name: "Doe", nickname: "Jonny", company: company, company_name: company_name) }
+
+    context "without company" do
+      it "returns full name" do
+        expect(person.to_s).to eq("John Doe / Jonny")
+      end
+    end
+
+    context "with company" do
+      let(:company) { true }
+
+      context "without company name" do
+        it "returns full name" do
+          expect(person.to_s).to eq("John Doe / Jonny")
+        end
+      end
+
+      context "with company name" do
+        let(:company_name) { "FooCorp" }
+
+        it "returns company name" do
+          expect(person.to_s).to eq("FooCorp")
+        end
+      end
+    end
+  end
+
   describe "e-mail validation" do
     let(:person) { people(:top_leader) }
 


### PR DESCRIPTION
refs: hitobito/hitobito_sac_cas#1155

Mysterious error was found, when checkbox company was checked but no company_name was provided.
`tidy_bytes': undefined method `empty?' for nil:NilClass (NoMethodError) return string if string.empty? || string.ascii_only? Problem, was that to_s function returned nil, which should never happen.