### PR TITLE
Fix error when clicking on sort headers (hitobito/hitobito_sac_cas#1190)

### DIFF
--- a/spec/regressions/label_formats_controller_spec.rb
+++ b/spec/regressions/label_formats_controller_spec.rb
@@ -33,4 +33,9 @@ describe LabelFormatsController, type: :controller do
   before { sign_in(people(:top_leader)) }
 
   include_examples "crud controller", skip: [%w[show]]
+
+  it "can sort by name" do
+    get :index, params: {sort: "name"}
+    expect(response).to be_successful
+  end
 end


### PR DESCRIPTION
500 error when clicking on sorting headers:
affects label formats and others