### PR TITLE
Dev setup improvements

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# see https://gist.github.com/kateinoigakukun/b0bc920e587851bfffa98b9e279175f2
+89f4f71d2153124421c8069db36837707ee57c2d

--- a/Procfile
+++ b/Procfile
@@ -2,3 +2,4 @@ web: bundle exec rails s -b 0.0.0.0 -p 3000
 worker: bundle exec rake jobs:work
 mail: mailcatcher -f --smtp-port 2025
 webpack: bin/webpack-dev-server
+migrate: echo "Migrating core" && rails db:migrate && echo "Migrating wagons" && rails wagon:migrate

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,5 +1,0 @@
-web: bundle exec rails s -b 0.0.0.0 -p 3000
-worker: bundle exec rake jobs:work
-mail: mailcatcher -f --smtp-port 2025
-webpack: bin/webpack-dev-server
-migrate: echo "Migrating core" && rails db:migrate && echo "Migrating wagons" && rails wagon:migrate

--- a/bin/active_wagon.rb
+++ b/bin/active_wagon.rb
@@ -26,10 +26,12 @@ class Setup
 
     write('Wagonfile', gemfile)
     write('.envrc', environment)
+    symlink_gemfile
 
     wagons.each do |wagon|
       write("../hitobito_#{wagon}/.envrc", environment(core: false))
       FileUtils.touch("../hitobito_#{wagon}/config/environment.rb") # needed for rails-vim
+      symlink_gemfile(directory: "../hitobito_#{wagon}")
     end
 
     FileUtils.rm_rf(root.join('tmp'))
@@ -37,6 +39,13 @@ class Setup
 
   def write(name, content)
     File.write(root.join(name), strip_heredoc(content))
+  end
+
+  def symlink_gemfile(directory: Dir.pwd, gemfile_dev: ENV["BUNDLE_GEMFILE"])
+    return unless gemfile_dev
+
+    FileUtils.ln_s("#{directory}/Gemfile", "#{directory}/#{gemfile_dev}", force: true)
+    FileUtils.ln_s("#{directory}/Gemfile.lock", "#{directory}/#{gemfile_dev}.lock", force: true)
   end
 
   def write_and_copy(name, content)

--- a/bin/dev
+++ b/bin/dev
@@ -10,4 +10,4 @@ if ! gem list mailcatcher -i --silent; then
   gem install mailcatcher
 fi
 
-DISABLE_SPRING=1 OVERMIND_SHOW_TIMESTAMPS=1 OVERMIND_CAN_DIE=migrate exec overmind start -f Procfile.dev "$@"
+DISABLE_SPRING=1 OVERMIND_SHOW_TIMESTAMPS=1 OVERMIND_CAN_DIE=migrate exec overmind start "$@"

--- a/doc/developer/local_setup.md
+++ b/doc/developer/local_setup.md
@@ -1,27 +1,19 @@
-# Setup your system
+# Setup your system for generic wagon
 
-Install `asdf` and `direnv` to manage versions for Ruby, Node and Yarn. See `.tool-versions` and install the currently used versions.
+Install `asdf` and `direnv` to manage versions for Ruby, Node and Yarn. See `.tool-versions` and install the currently
+used versions.
 
-Install Postgres locally or use the one from the [docker setup](https://github.com/hitobito/development/) (`docker-compose up -d db`).
+Install Postgres locally or use the one from the [docker setup](https://github.com/hitobito/development/)
+(`docker-compose up -d db`).
 
-Clone all desired hitobito repositories (core and wagons) into a common base folder. Adjust your `Wagonfile` in the core. See the [Wagons documentation](04_wagons.md).
+Clone all desired hitobito repositories (core and wagons) into a common base folder. To activate a specific wagon use
+`./bin/wagon activate`, See the [Wagons documentation](04_wagons.md).
 
 Add a `.envrc` to the base folder:
 
 ```bash
-export RAILS_DB_ADAPTER=postgresql
-export RAILS_DB_USERNAME=hitobito
-export RAILS_DB_PASSWORD=hitobito
-export RAILS_DB_HOST=127.0.0.1
-export RAILS_DB_PORT=5432
-export RAILS_DB_NAME=hitobito_development
-export RAILS_TEST_DB_NAME=hitobito_test
-
+export BUNDLE_GEMFILE=Gemfile.local
 export RAILS_MAIL_DELIVERY_CONFIG='address: localhost, port: 2025'
-export RAILS_MAIL_DELIVERY_METHOD=smtp
-export RAILS_MAIL_DOMAIN=localhost
-
-export HITOBITO_DEV_PASSWORD=hito42bito
 ```
 
 ## Install Dependencies
@@ -31,20 +23,26 @@ Install all ruby and node dependencies (in the core folder):
     bundle install
     yarn install
 
-## Setup Database
+## Setup Application
 
 In the core directory:
 
-    rails db:migrate
-    rails wagon:migrate
-    rails db:seed
-    rails wagon:seed
+    ./bin/wagon activate generic
+    rails db:create db:migrate wagon:migrate db:seed wagon:seed dev:local:admin
 
-## Server
+## Start the application
 
-In the core directory, in two separate shells:
+In the core you can start with overmind
 
-    rails s
-    bin/webpack-dev-server
+    ./bin/dev
 
-Login on http://localhost:3000 with the root email (see `wagon/config/settings.yml`) and the password set in `HITOBITO_DEV_PASSWORD`.
+## Adjusting git blame ignores
+
+Add the following to `.git/config`
+
+```
+  [blame]
+    ignoreRevsFile = .git-blame-ignore-revs
+```
+
+to ignore a very large rubocop reformatting commit


### PR DESCRIPTION
Mit setzen von `BUNDLE_GEMFILE` kann man die Gemfile.lock Problematik fürs lokale entwickeln beheben. Da die Problematik allen zur genüge bekannt ist und wir deutlich mehr entwickeln als gems updaten wäre ich für die Lösung. 


Den rubocop reformatting commit 89f4f71d2153124421c8069db36837707ee57c2d aus der blame history rauszunehmen finde ich ebefalls sinnvoll. Was meint ihr? 

Falls wir das pushen wollen, wie verteilen wir die Infos am besten an den Rest vom Team?