### PR TITLE
Remove Request-Identifier from logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -95,9 +95,6 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-
-  # allow to identify requests in the log
-  config.log_tags = [:uuid]
 
   config.lograge.enabled = true
   # Use a different logger for distributed setups.

--- a/spec/domain/tags/merger_spec.rb
+++ b/spec/domain/tags/merger_spec.rb
@@ -116,7 +116,7 @@ describe Tags::Merger do
     end
 
     it "ignores non existent tag ids" do
-      @src_tag_ids = [tag2.id, 42]
+      @src_tag_ids = [tag2.id, -1]
 
       merger.merge!
 


### PR DESCRIPTION
It does not help across different services and prevents easy JSON-parsing of the log-lines. Therefore, a removal seems sensible.