### PR TITLE
Allow FormFieldCheckDependentController to check all dependent boxes

### DIFF
--- a/app/javascript/controllers/form_field_check_dependent_controller.js
+++ b/app/javascript/controllers/form_field_check_dependent_controller.js
@@ -7,12 +7,19 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   static targets = ["main", "dependent"];
+  static values = {
+    selectDependentCheckboxes: { type: Boolean, default: false },
+  }
 
   // unselects all dependent checkboxes when unchecking master checkbox
   toggleMain() {
     if (!event.target.checked) {
       this.dependentTargets.forEach((checkbox) => {
         checkbox.checked = false;
+      });
+    } else if (this.selectDependentCheckboxesValue) {
+      this.dependentTargets.forEach((checkbox) => {
+        checkbox.checked = true;
       });
     }
   }


### PR DESCRIPTION
Configured with a stimulus value:
https://stimulus.hotwired.dev/reference/values