### PR TITLE
Order event kinds by short name

### DIFF
--- a/app/models/event/kind.rb
+++ b/app/models/event/kind.rb
@@ -25,6 +25,13 @@ class Event::Kind < ActiveRecord::Base
   include Paranoia::Globalized
   translates :label, :short_name, :general_information, :application_conditions
 
+  def self.list
+    with_translations.unscope(:select).select(Event::Kind.column_names, "LOWER(event_kind_translations.short_name)")
+      .order("event_kinds.deleted_at ASC NULLS FIRST",
+        "LOWER(event_kind_translations.short_name)")
+      .distinct
+  end
+
   ### ASSOCIATIONS
 
   has_many :events

--- a/app/views/events/_general_fields.html.haml
+++ b/app/views/events/_general_fields.html.haml
@@ -8,7 +8,7 @@
 
   - entry.used?(:kind_id) do
     = f.labeled(:kind_id) do
-      = f.input_field(:kind_id, data: { action: 'form-field-inheritance#inherit' })
+      = f.input_field(:kind_id, list: @kinds, data: { action: 'form-field-inheritance#inherit' })
       .form-text
         = link_to(t('global.link.override'), '#', title: t('.kind_overrides_link_title'),
             data: { action: "form-field-inheritance#override"})

--- a/spec/models/event/kind_spec.rb
+++ b/spec/models/event/kind_spec.rb
@@ -31,4 +31,15 @@ describe Event::Kind do
   it "does destroy translations on hard destroy" do
     expect { slk.really_destroy! }.to change { Event::Kind::Translation.count }.by(-1)
   end
+
+  context "#list" do
+    it "orders by short_name, deleted last" do
+      expect(Event::Kind.list).to match_array([
+        event_kinds(:fk),
+        event_kinds(:glk),
+        event_kinds(:slk),
+        event_kinds(:old)
+      ])
+    end
+  end
 end


### PR DESCRIPTION
Refs: https://github.com/hitobito/hitobito_sac_cas/issues/1201
Mit diesem PR wird neu nach dem `short_name` sortiert (also der Wert **vor** der Klammer). Das macht aus meiner Sicht zumindest generisch mehr Sinn ~aber ich spreche das dann noch mit Tobi ab~ Tobi findets auch gut