### PR TITLE
Feature/hitobito#2199

### DIFF
--- a/app/domain/export/pdf/labels.rb
+++ b/app/domain/export/pdf/labels.rb
@@ -25,7 +25,7 @@ module Export::Pdf
     private
 
     def generate_with_households(contactables, pdf)
-      households = Export::Tabular::People::Households.new(contactables)
+      households = Export::Tabular::People::Households.new(contactables, retain_order: true)
       households.list.each_with_index do |household, i|
         name = to_name(household)
         address = household_address(household, name)

--- a/app/domain/export/pdf/labels.rb
+++ b/app/domain/export/pdf/labels.rb
@@ -15,25 +15,25 @@ module Export::Pdf
       pdf = Export::Pdf::Document.new(page_size: format.page_size, page_layout: format.page_layout, margin: 0.cm).pdf
       pdf.font_size = format.font_size
       if household
-        generate_with_households(contactables)
+        generate_with_households(contactables, pdf)
       else
-        generate_without_households(contactables)
+        generate_without_households(contactables, pdf)
       end
       pdf.render
     end
 
     private
 
-    def generate_with_households(contactables)
+    def generate_with_households(contactables, pdf)
       households = Export::Tabular::People::Households.new(contactables)
-      households.each_with_index do |household, i|
-        name = to_name(contactable)
-        address = household_address(contactable, name)
+      households.list.each_with_index do |household, i|
+        name = to_name(household)
+        address = household_address(household, name)
         print_address_in_bounding_box(pdf, address, position(pdf, i))
       end
     end
 
-    def generate_without_households(contactables)
+    def generate_without_households(contactables, pdf)
       contactables.each_with_index do |contactable, i|
         name = to_name(contactable)
         address = address(contactable, name)

--- a/app/domain/export/pdf/labels.rb
+++ b/app/domain/export/pdf/labels.rb
@@ -14,24 +14,31 @@ module Export::Pdf
     def generate(contactables, household = false)
       pdf = Export::Pdf::Document.new(page_size: format.page_size, page_layout: format.page_layout, margin: 0.cm).pdf
       pdf.font_size = format.font_size
-
-      rows = household ? to_households(contactables) : contactables
-
-      rows.each_with_index do |contactable, i|
-        name = to_name(contactable)
-
-        address = household ? household_address(contactable, name) : address(contactable, name)
-
-        print_address_in_bounding_box(pdf, address, position(pdf, i))
+      if household
+        generate_with_households(contactables)
+      else
+        generate_without_households(contactables)
       end
-
       pdf.render
     end
 
     private
 
-    def to_households(contactables)
-      Export::Tabular::People::Households.new(contactables).list
+    def generate_with_households(contactables)
+      households = Export::Tabular::People::Households.new(contactables)
+      households.each_with_index do |household, i|
+        name = to_name(contactable)
+        address = household_address(contactable, name)
+        print_address_in_bounding_box(pdf, address, position(pdf, i))
+      end
+    end
+
+    def generate_without_households(contactables)
+      contactables.each_with_index do |contactable, i|
+        name = to_name(contactable)
+        address = address(contactable, name)
+        print_address_in_bounding_box(pdf, address, position(pdf, i))
+      end
     end
 
     def to_name(contactable)

--- a/app/domain/export/tabular/people/households.rb
+++ b/app/domain/export/tabular/people/households.rb
@@ -26,7 +26,7 @@ module Export::Tabular::People
       @household_list ||= begin # rubocop:disable Naming/MemoizedInstanceVariableName @list is already used in the base-class, which shadows this extension
         people = super
         people = Person.where(id: people) unless people.respond_to?(:only_public_data)
-        ::People::HouseholdList.new(people.order(:first_name).only_public_data.includes(:primary_group), order: :retain)
+        ::People::HouseholdList.new(people.only_public_data.includes(:primary_group))
       end
     end
   end

--- a/app/domain/export/tabular/people/households.rb
+++ b/app/domain/export/tabular/people/households.rb
@@ -10,6 +10,11 @@ module Export::Tabular::People
     self.model_class = ::Person
     self.row_class = HouseholdRow
 
+    def initialize(*, retain_order: false)
+      super(*)
+      @retain_order = retain_order
+    end
+
     def person_attributes
       [:salutation, :name, :address, :zip_code, :town, :country, :layer_group]
     end
@@ -26,7 +31,7 @@ module Export::Tabular::People
       @household_list ||= begin # rubocop:disable Naming/MemoizedInstanceVariableName @list is already used in the base-class, which shadows this extension
         people = super
         people = Person.where(id: people) unless people.respond_to?(:only_public_data)
-        ::People::HouseholdList.new(people.only_public_data.includes(:primary_group), order: :retain)
+        ::People::HouseholdList.new(people.only_public_data.includes(:primary_group), retain_order: @retain_order)
       end
     end
   end

--- a/app/domain/export/tabular/people/households.rb
+++ b/app/domain/export/tabular/people/households.rb
@@ -26,7 +26,7 @@ module Export::Tabular::People
       @household_list ||= begin # rubocop:disable Naming/MemoizedInstanceVariableName @list is already used in the base-class, which shadows this extension
         people = super
         people = Person.where(id: people) unless people.respond_to?(:only_public_data)
-        ::People::HouseholdList.new(people.order(:first_name).only_public_data.includes(:primary_group))
+        ::People::HouseholdList.new(people.order(:first_name).only_public_data.includes(:primary_group), order: :retain)
       end
     end
   end

--- a/app/domain/export/tabular/people/households.rb
+++ b/app/domain/export/tabular/people/households.rb
@@ -26,7 +26,7 @@ module Export::Tabular::People
       @household_list ||= begin # rubocop:disable Naming/MemoizedInstanceVariableName @list is already used in the base-class, which shadows this extension
         people = super
         people = Person.where(id: people) unless people.respond_to?(:only_public_data)
-        ::People::HouseholdList.new(people.only_public_data.includes(:primary_group))
+        ::People::HouseholdList.new(people.only_public_data.includes(:primary_group), order: :retain)
       end
     end
   end

--- a/app/domain/people/household_list.rb
+++ b/app/domain/people/household_list.rb
@@ -75,8 +75,6 @@ class People::HouseholdList
     Arel::Nodes::NamedFunction.new("COALESCE", [
       Person.arel_table[:household_key],
       Arel::Nodes::NamedFunction.new("FORMAT", [Arel::Nodes.build_quoted("_%s"), Person.arel_table[:id]])
-      # compare performance
-      # [Person.arel_table[:id].cast(:text)])
     ])
   end
 

--- a/app/domain/people/household_list.rb
+++ b/app/domain/people/household_list.rb
@@ -10,8 +10,9 @@ class People::HouseholdList
 
   include Enumerable
 
-  def initialize(people_scope, order: :default)
+  def initialize(people_scope, order: :member_count)
     @people_scope = people_scope
+    @order = order
   end
 
   def only_households_in_batches(&)
@@ -26,7 +27,11 @@ class People::HouseholdList
     in_batches(@people_scope, &)
   end
 
-  delegate :each, :map, :to_a, to: :households_in_batches
+  def count
+    person_ids_grouped_by_household_query(@people_scope).count
+  end
+
+  delegate :each, :each_with_index, :map, :to_a, to: :households_in_batches
 
   private
 
@@ -36,6 +41,7 @@ class People::HouseholdList
     # load complete list of ids to retain order
     person_ids = person_ids_grouped_by_household_query(people_scope).map(&:person_ids)
     person_ids.each_slice(batch_size) do |batch|
+      # index involved_people for quicker access
       involved_people = Person.where(id: batch.flatten).index_by(&:id)
       batch.map do |household|
         yield household.map { |person_id| involved_people[person_id] }
@@ -43,11 +49,15 @@ class People::HouseholdList
     end
   end
 
-  def computed_ordinal_column(people_scope)
-    ids_in_order = ArelArrayLiteral.new(people_scope.unscope(:limit, :select).pluck(:id))
-    Arel::Nodes::NamedFunction.new("ARRAY_POSITION", [ids_in_order.to_sql, Person.arel_table[:id]])
+  # create a virtual column with the array position in the underlying @people_scope
+  # to be able to sort by this column
+  def computed_ordinal_column(scope)
+    ids = scope.unscope(:limit).pluck(:id)
+    ArelArrayLiteral.new(ids).array_position(Person.arel_table[:id]) if ids.present?
   end
 
+  # create a virtual column with household_key OR _person_id to be able
+  # to group by this column
   def computed_household_key_column
     Arel::Nodes::NamedFunction.new("COALESCE", [
       Person.arel_table[:household_key],
@@ -57,30 +67,37 @@ class People::HouseholdList
     ])
   end
 
-  def ordered_computed_household_key_query(people_scope)
-    ordinal_column = computed_ordinal_column(people_scope)
+  # create a virtual table with computed household_key and ordinal colums to be able
+  # to sort and group the result
+  def ordered_computed_household_key_query(scope)
+    ordinal_column = computed_ordinal_column(scope)
     household_key_column = computed_household_key_column
+    ids, household_keys = scope.unscope(:select, :includes, :limit, :order).pluck(:id, :household_key).transpose
 
     Person.arel_table
-      .where(Person.arel_table[:id].in(people_scope.unscope(:select, :includes, :limit, :order).pluck(:id)))
+      .where(Person.arel_table[:id].in(ids).or(Person.arel_table[:household_key].in(household_keys.uniq.compact)))
       .project(Person.arel_table[:id].as("person_id"))
       .project(household_key_column.as("household_key"))
       .project(ordinal_column.as("ordinal"))
       .order(ordinal_column.alias)
-    # apply limit to people, not to households
-    # .take(people_scope.limit_value.presence)
   end
 
-  def person_ids_grouped_by_household_query(people_scope)
-    ordered_keys = Arel::Nodes::TableAlias.new(ordered_computed_household_key_query(people_scope), "ordered_keys")
+  def person_ids_grouped_by_household_query(scope)
+    return Person.none if scope.none?
 
-    Person
-      .from(ordered_keys)
+    ordered_households_table = Arel::Nodes::TableAlias.new(ordered_computed_household_key_query(scope), "ordered_keys")
+    order_statement = (@order == :retain) ? ordered_households_table[:ordinal].minimum : "member_count DESC"
+    aggregated_person_ids_column = Arel::Nodes::NamedFunction.new("ARRAY_AGG", [ordered_households_table[:person_id]])
+
+    x = Person
+      .from(ordered_households_table)
       .select(Arel.star.count.as("member_count"))
-      .select(Arel::Nodes::NamedFunction.new("ARRAY_AGG", [ordered_keys[:person_id]]).as("person_ids"))
-      .group(ordered_keys[:household_key])
-      .order(ordered_keys[:ordinal].minimum)
-      # apply limit to households?
-      .limit(people_scope.limit_value.presence)
+      .select(aggregated_person_ids_column.as("person_ids"))
+      .group(ordered_households_table[:household_key])
+      .order(order_statement)
+      # existing behaviour: apply limit to households, not to people
+      .limit(scope.limit_value.presence)
+    Rails.logger.info x.to_sql
+    x
   end
 end

--- a/app/domain/people/household_list.rb
+++ b/app/domain/people/household_list.rb
@@ -44,9 +44,8 @@ class People::HouseholdList
   def order_statement
     case @order
     when :retain
-      quoted_ids = @people_scope.pluck(:id).map { |id| Arel::Nodes.build_quoted(id).to_sql }
-      array_literal = Arel.sql("ARRAY[#{quoted_ids.join(",")}]")
-      Arel::Nodes::NamedFunction.new("array_position", [array_literal, Person.arel_table[:id]])
+      ids_in_order = ArelArrayLiteral.new(@people_scope.pluck(:id))
+      Arel::Nodes::NamedFunction.new("array_position", [ids_in_order, Person.arel_table[:id]])
     when :default
       '"member_count" DESC, id ASC'
     else

--- a/app/domain/people/household_list.rb
+++ b/app/domain/people/household_list.rb
@@ -14,16 +14,16 @@ class People::HouseholdList
     @people_scope = people_scope
   end
 
-  def only_households_in_batches(&block)
-    in_batches(@people_scope.where.not(household_key: nil), &block)
+  def only_households_in_batches(&)
+    in_batches(@people_scope.where.not(household_key: nil), &)
   end
 
-  def people_without_household_in_batches(&block)
-    in_batches(@people_scope.where(household_key: nil), &block)
+  def people_without_household_in_batches(&)
+    in_batches(@people_scope.where(household_key: nil), &)
   end
 
-  def households_in_batches(&block)
-    in_batches(@people_scope, &block)
+  def households_in_batches(&)
+    in_batches(@people_scope, &)
   end
 
   delegate :each, :map, :to_a, to: :households_in_batches
@@ -45,7 +45,7 @@ class People::HouseholdList
 
   def computed_ordinal_column(people_scope)
     ids_in_order = ArelArrayLiteral.new(people_scope.unscope(:limit, :select).pluck(:id))
-    computed_ordinal_column = Arel::Nodes::NamedFunction.new("ARRAY_POSITION", [ids_in_order.to_sql, Person.arel_table[:id]])
+    Arel::Nodes::NamedFunction.new("ARRAY_POSITION", [ids_in_order.to_sql, Person.arel_table[:id]])
   end
 
   def computed_household_key_column
@@ -63,87 +63,24 @@ class People::HouseholdList
 
     Person.arel_table
       .where(Person.arel_table[:id].in(people_scope.unscope(:select, :includes, :limit, :order).pluck(:id)))
-      .project(Person.arel_table[:id].as('person_id'))
-      .project(household_key_column.as('household_key'))
-      .project(ordinal_column.as('ordinal'))
+      .project(Person.arel_table[:id].as("person_id"))
+      .project(household_key_column.as("household_key"))
+      .project(ordinal_column.as("ordinal"))
       .order(ordinal_column.alias)
-      # apply limit to people, not to households
-      # .take(people_scope.limit_value.presence)
+    # apply limit to people, not to households
+    # .take(people_scope.limit_value.presence)
   end
 
   def person_ids_grouped_by_household_query(people_scope)
-    ordered_keys = Arel::Nodes::TableAlias.new(ordered_computed_household_key_query(people_scope), 'ordered_keys')
+    ordered_keys = Arel::Nodes::TableAlias.new(ordered_computed_household_key_query(people_scope), "ordered_keys")
 
     Person
       .from(ordered_keys)
-      .select(Arel.star.count.as('member_count'))
-      .select(Arel::Nodes::NamedFunction.new("ARRAY_AGG", [ordered_keys[:person_id]]).as('person_ids'))
+      .select(Arel.star.count.as("member_count"))
+      .select(Arel::Nodes::NamedFunction.new("ARRAY_AGG", [ordered_keys[:person_id]]).as("person_ids"))
       .group(ordered_keys[:household_key])
       .order(ordered_keys[:ordinal].minimum)
-       # apply limit to households?
+      # apply limit to households?
       .limit(people_scope.limit_value.presence)
   end
 end
-
-  # def key_scope
-  #   key = Arel::Nodes::NamedFunction.new("COALESCE", [
-  #           Person.arel_table[:household_key],
-  #           Arel::Nodes::NamedFunction.new("CAST", [Person.arel_table[:id].as(Arel::Nodes::SqlLiteral.new('TEXT'))])
-  #         ]).as('key')
-
-  #   Person
-  #     .select(key)
-  #     .select("(array_agg(#{people_table}.\"id\"))[1] AS \"id\"")
-  #     .select("(array_agg(#{people_table}.\"household_key\"))[1] AS \"household_key\"")
-  #     .select(Arel::Nodes::NamedFunction.new("COUNT", [:key]))
-  #     .where(id: @people_scope.unscope(:select, :includes, :limit, :order).pluck(:id))
-  #     .group(:key)
-  # end
-
-  # def base_scope_with_working_arrays
-  #   query = Person
-  #     .from(table_alias)
-  #     .select(table_alias[:household_key])
-  #     .select(Arel.star.count.as('member_count'))
-  #     .select(Arel::Nodes::NamedFunction.new("ARRAY_AGG", [table_alias[:person_id]]).as('person_ids'))
-  #     .group(table_alias[:household_key])
-  # end
-
-  # def base_scope_with_select_manager
-  #   table_alias = Arel::Nodes::TableAlias.new(ordered_key_list(@people_scope), 'ordered_key_list')
-  #   query = Arel::SelectManager.new
-  #     .from(table_alias)
-  #     .project(table_alias[:household_key])
-  #     .project(Arel.star.count.as('member_count'))
-  #     .project(Arel::Nodes::NamedFunction.new("ARRAY_AGG", [table_alias[:person_id]]).as('person_ids'))
-  #     .group(table_alias[:household_key])
-
-  #   binding.pry
-  #   @base_scope
-  # end
-
-  # def only_households
-  #   base_scope
-  #     # .select(:household_key)
-  #     # # .select("MIN(#{people_table}.\"id\") AS \"id\"")
-  #     # .select("(array_agg(#{people_table}.\"id\"))[1] AS \"id\"")
-  #     # .select("COUNT(#{people_table}.\"household_key\") AS \"member_count\"")
-  #     # .select("#{people_table}.\"household_key\" AS \"key\"")
-  #     .where.not(household_key: nil)
-  #     # .group(:household_key)
-  # end
-
-  # def people_without_household
-  #   base_scope
-  #   # .select(:household_key)
-  #   # .select(:id)
-  #   #   .select("1 AS \"member_count\"")
-  #   #   .select("CAST(#{people_table}.\"id\" AS TEXT) AS \"key\"")
-  #     .where(household_key: nil)
-  # end
-
-
-  # def order_statement(people_scope)
-  #   ids_in_order = ArelArrayLiteral.new(people_scope.unscope(:limit, :select).pluck(:id))
-  #   Arel::Nodes::NamedFunction.new("ARRAY_POSITION", [ids_in_order.to_sql, Person.arel_table[:id]])
-  # end

--- a/app/domain/people/household_list.rb
+++ b/app/domain/people/household_list.rb
@@ -87,7 +87,7 @@ class People::HouseholdList
     household_key_column = computed_household_key_column
     unscoped = scope.unscope(:select, :includes, :limit, :order)
     ids = unscoped.pluck(:id)
-    household_keys =  @include_housemates ? unscoped.pluck(:household_key) : []
+    household_keys = @include_housemates ? unscoped.pluck(:household_key) : []
 
     Person.arel_table
       .where(Person.arel_table[:id].in(ids).or(Person.arel_table[:household_key].in(household_keys.uniq.compact)))

--- a/app/jobs/export/labels_job.rb
+++ b/app/jobs/export/labels_job.rb
@@ -23,13 +23,10 @@ class Export::LabelsJob < Export::ExportBaseJob
     @group ||= Group.find(@group_id)
   end
 
-  # retain order of @people_ids but allow override in wagons
   def order_statement
-    quoted_ids = @people_ids.map { |id| Arel::Nodes.build_quoted(id).to_sql }
-
-    # unfortunately arel does not support the postgres ARRAY-literal, so DIY it is
-    array_literal = Arel.sql("ARRAY[#{quoted_ids.join(",")}]")
-    Arel::Nodes::NamedFunction.new("array_position", [array_literal, Person.arel_table[:id]])
+    # retain order of @people_ids but allow override in wagons
+    ids_in_order = ArelArrayLiteral.new(@people_ids)
+    Arel::Nodes::NamedFunction.new("array_position", [ids_in_order, Person.arel_table[:id]])
   end
 
   def data

--- a/app/jobs/export/labels_job.rb
+++ b/app/jobs/export/labels_job.rb
@@ -16,12 +16,18 @@ class Export::LabelsJob < Export::ExportBaseJob
   end
 
   def people
-    @people ||= Person.where(id: @people_ids)
+    @people ||= Person.where(id: @people_ids).order(order_clause)
   end
 
   def group
     @group ||= Group.find(@group_id)
   end
+
+  # retain order of @people_ids but allow override in wagons
+  def order_clause
+    Person.arel_table[:last_name].asc
+  end
+
 
   def data
     case @format

--- a/app/jobs/export/labels_job.rb
+++ b/app/jobs/export/labels_job.rb
@@ -25,8 +25,7 @@ class Export::LabelsJob < Export::ExportBaseJob
 
   def order_statement
     # retain order of @people_ids but allow override in wagons
-    ids_in_order = ArelArrayLiteral.new(@people_ids)
-    Arel::Nodes::NamedFunction.new("array_position", [ids_in_order, Person.arel_table[:id]])
+    ArelArrayLiteral.new(@people_ids).array_position(Person.arel_table[:id])
   end
 
   def data

--- a/app/jobs/export/labels_job.rb
+++ b/app/jobs/export/labels_job.rb
@@ -23,8 +23,8 @@ class Export::LabelsJob < Export::ExportBaseJob
     @group ||= Group.find(@group_id)
   end
 
+  # retain order of @people_ids but allow override in wagons
   def order_statement
-    # retain order of @people_ids but allow override in wagons
     ArelArrayLiteral.new(@people_ids).array_position(Person.arel_table[:id])
   end
 

--- a/app/models/mailing_list.rb
+++ b/app/models/mailing_list.rb
@@ -150,7 +150,7 @@ class MailingList < ActiveRecord::Base
     households = People::HouseholdList.new(subscribers_scope)
 
     # count total rows after grouping, instead of adding a count to each grouped row
-    Person.from(households.grouped_households).count
+    households.count
   end
 
   def sync

--- a/app/utils/arel_array_literal.rb
+++ b/app/utils/arel_array_literal.rb
@@ -22,4 +22,8 @@ class ArelArrayLiteral
   def eql?(other)
     self.class == other.class && items == other.items
   end
+
+  def array_position(column)
+    Arel::Nodes::NamedFunction.new("ARRAY_POSITION", [to_sql, column])
+  end
 end

--- a/app/utils/arel_array_literal.rb
+++ b/app/utils/arel_array_literal.rb
@@ -20,6 +20,6 @@ class ArelArrayLiteral
   end
 
   def eql?(other)
-    self.class == other.class && self.items == other.items
+    self.class == other.class && items == other.items
   end
 end

--- a/app/utils/arel_array_literal.rb
+++ b/app/utils/arel_array_literal.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Wanderwege. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+# Builder for postgres array literals
+class ArelArrayLiteral < Arel::Nodes::Node
+  attr_reader :items
+
+  def initialize(items)
+    @items = items
+  end
+
+  def to_sql
+    quoted_items = items.map { |item| Arel::Nodes.build_quoted(item).to_sql }
+    # unfortunately arel does not support the postgres ARRAY-literal
+    Arel.sql("ARRAY[#{quoted_items.join(",")}]")
+  end
+
+  def eql?(other)
+    self.class == other.class && self.items == other.items
+  end
+end

--- a/app/utils/arel_array_literal.rb
+++ b/app/utils/arel_array_literal.rb
@@ -6,7 +6,7 @@
 #  https://github.com/hitobito/hitobito.
 
 # Builder for postgres array literals
-class ArelArrayLiteral < Arel::Nodes::Node
+class ArelArrayLiteral
   attr_reader :items
 
   def initialize(items)
@@ -14,9 +14,9 @@ class ArelArrayLiteral < Arel::Nodes::Node
   end
 
   def to_sql
-    quoted_items = items.map { |item| Arel::Nodes.build_quoted(item).to_sql }
     # unfortunately arel does not support the postgres ARRAY-literal
-    Arel.sql("ARRAY[#{quoted_items.join(",")}]")
+    quoted_items = items.map { |item| Arel::Nodes.build_quoted(item).to_sql }
+    Arel::Nodes::SqlLiteral.new("ARRAY[#{quoted_items.join(",")}]")
   end
 
   def eql?(other)

--- a/spec/domain/people/household_list_spec.rb
+++ b/spec/domain/people/household_list_spec.rb
@@ -18,7 +18,7 @@ describe People::HouseholdList do
   let(:scope) { Person.where(id: [person1, person2, person3, person4, person5]) }
 
   describe "#people_without_household_in_batches" do
-    subject(:list) { household_list.people_without_household_in_batches.map(&:itself) }
+    subject(:list) { household_list.people_without_household_in_batches.to_a.flatten }
 
     it "returns only people with nil household_key" do
       expect(list).to contain_exactly([person1], [person2])
@@ -34,7 +34,7 @@ describe People::HouseholdList do
   end
 
   describe "#only_households_in_batches" do
-    subject(:list) { household_list.only_households_in_batches.map(&:itself) }
+    subject(:list) { household_list.only_households_in_batches.to_a.flatten }
 
     it "returns only people with nil household_key" do
       expect(list).to contain_exactly(contain_exactly(person3, person4), [person5])
@@ -44,7 +44,7 @@ describe People::HouseholdList do
   describe "#households_in_batches" do
     let(:scope) { Person.where(id: [person1, person2, person3, person4, person5]) }
 
-    subject(:list) { household_list.households_in_batches.map(&:itself) }
+    subject(:list) { household_list.households_in_batches.to_a.flatten }
 
     it "returns grouped households" do
       expect(list).to contain_exactly(

--- a/spec/domain/people/household_list_spec.rb
+++ b/spec/domain/people/household_list_spec.rb
@@ -8,91 +8,93 @@
 require "spec_helper"
 
 describe People::HouseholdList do
-  let(:subject) { described_class.new(scope) }
+  subject(:household_list) { described_class.new(scope) }
   let(:person1) { Fabricate(:person) }
   let(:person2) { Fabricate(:person) }
   let(:person3) { Fabricate(:person, household_key: "1234") }
   let(:person4) { Fabricate(:person, household_key: "1234") }
   let(:person5) { Fabricate(:person, household_key: 1111) }
+  let(:scope) { Person.where(id: [person1, person2, person3, person4, person5]) }
 
-  context "#people_without_households" do
-    let(:scope) { Person.where(id: [person1, person2, person3, person4, person5]) }
+  describe "#people_without_household_in_batches" do
+    subject(:list) { household_list.people_without_household_in_batches.map(&:itself) }
 
     it "returns only people with nil household_key" do
-      list = []
-      subject.people_without_household_in_batches { |batch| list.concat(batch) }
-      expect(list).to eq([[person1], [person2]])
+      expect(list).to contain_exactly([person1], [person2])
     end
 
-    context "limited people scope" do
+    context "with limited people scope" do
       let(:scope) { Person.where(id: [person1, person2, person3, person4, person5]).limit(1) }
 
       it "respects limit" do
-        list = []
-        subject.people_without_household_in_batches { |batch| list.concat(batch) }
-        expect(list).to eq([[person1]])
+        expect(list).to contain_exactly([scope.first])
       end
     end
   end
 
-  context "#grouped_households" do
+  describe "#only_households_in_batches" do
+    subject(:list) { household_list.only_households_in_batches.map(&:itself) }
+
+    it "returns only people with nil household_key" do
+      expect(list).to contain_exactly(contain_exactly(person3, person4), [person5])
+    end
+  end
+
+
+  describe "#households_in_batches" do
     let(:scope) { Person.where(id: [person1, person2, person3, person4, person5]) }
+    subject(:list) { household_list.households_in_batches.map(&:itself) }
 
     it "returns grouped households" do
-      expect(subject.grouped_households.map(&:key)).to match_array([
-        person1.id.to_s,
-        person2.id.to_s,
-        person3.household_key,
-        person5.household_key
-      ])
+      expect(list).to contain_exactly(
+        [person1],
+        [person2],
+        [person3, person4],
+        [person5]
+      )
     end
 
-    context "limited people scope" do
+    context "with limited people scope" do
       let(:scope) { Person.where(id: [person1, person2, person3, person4, person5]).limit(2) }
 
       it "respects limit" do
-        expect(subject.grouped_households.to_a.size).to eq(2)
+        expect(list.size).to eq(2)
       end
     end
-  end
 
-  context "#households_in_batches" do
-    let(:scope) { Person.where(id: [person1, person2, person3, person4, person5]) }
+    context "with given order" do
+      let(:scope) { Person.where(id: [person1, person2, person3, person4, person5]).order(order) }
 
-    it "yields a list of household arrays, orders by descending household size" do
-      yielded_batch = []
-      subject.households_in_batches { |batch| yielded_batch = batch }
-      expect(yielded_batch.map { |household| household.map(&:id) }).to contain_exactly(
-        contain_exactly(person3.id, person4.id),
-        [person1.id],
-        [person2.id],
-        [person5.id]
-      )
-    end
+      context "with last_name DESC" do
+        let(:order) { {last_name: :DESC} }
+        it "keeps order" do
+          last_names = list.map { |household| household.first.last_name }
+          expect(last_names).to eq(last_names.sort.reverse)
+        end
+      end
 
-    it "yields only rows with household_key when queried for only_households" do
-      yielded_batch = []
-      subject.only_households_in_batches { |batch| yielded_batch = batch }
-      expect(yielded_batch.map { |household| household.map(&:id) }).to contain_exactly(
-        contain_exactly(person3.id, person4.id),
-        [person5.id]
-      )
+      context "with first_name ASC" do
+        let(:order) { {first_name: :ASC} }
+        it "keeps order" do
+          first_names = list.map { |household| household.first.first_name }
+          expect(first_names).to eq(first_names.sort)
+        end
+      end
     end
 
     context "limited people scope" do
       let(:scope) do
-        Person.where(id: [person1, person2, person3, person4, person5, person6, person7]).limit(2)
+        Person.where(id: [person1, person2, person3, person4, person5, person6, person7]).limit(3)
       end
       let(:person6) { Fabricate(:person, household_key: "1234") }
       let(:person7) { Fabricate(:person, household_key: "1234") }
       let!(:person_not_in_scope) { Fabricate(:person, household_key: "1234") }
 
       it "respects limit, but still groups all housemates from scope" do
-        yielded_batch = []
-        subject.households_in_batches { |batch| yielded_batch = batch }
-        expect(yielded_batch.map { |household| household.map(&:id) }).to contain_exactly(
-          contain_exactly(person3.id, person4.id, person6.id, person7.id),
-          [person1.id]
+        expect(list).to contain_exactly(
+          [person1],
+          [person2],
+          contain_exactly(person3, person4, person6, person7)
         )
       end
     end
@@ -107,24 +109,22 @@ describe People::HouseholdList do
       let!(:person_not_in_scope) { Fabricate(:person, household_key: 1111) }
 
       it "works" do
-        yielded_batch = []
-        subject.households_in_batches { |batch| yielded_batch = batch }
-        expect(yielded_batch.map { |household| household.map(&:id) }).to contain_exactly(
-          contain_exactly(person3.id, person4.id, person6.id, person7.id),
-          [person1.id],
-          [person2.id],
-          [person5.id]
+        expect(list).to contain_exactly(
+          contain_exactly(person3, person4, person6, person7),
+          [person1],
+          [person2],
+          [person5]
         )
       end
     end
   end
 
-  context "enumerable" do
+  describe "enumerable" do
     let(:scope) { Person.all }
 
     it "is enumerable" do
       expect(subject).to be_an Enumerable
-      expect(subject.each).to be_an Enumerator
+      expect(household_list.each).to be_an Enumerator
     end
   end
 end

--- a/spec/domain/people/household_list_spec.rb
+++ b/spec/domain/people/household_list_spec.rb
@@ -9,6 +9,7 @@ require "spec_helper"
 
 describe People::HouseholdList do
   subject(:household_list) { described_class.new(scope) }
+
   let(:person1) { Fabricate(:person) }
   let(:person2) { Fabricate(:person) }
   let(:person3) { Fabricate(:person, household_key: "1234") }
@@ -40,9 +41,9 @@ describe People::HouseholdList do
     end
   end
 
-
   describe "#households_in_batches" do
     let(:scope) { Person.where(id: [person1, person2, person3, person4, person5]) }
+
     subject(:list) { household_list.households_in_batches.map(&:itself) }
 
     it "returns grouped households" do
@@ -67,6 +68,7 @@ describe People::HouseholdList do
 
       context "with last_name DESC" do
         let(:order) { {last_name: :DESC} }
+
         it "keeps order" do
           last_names = list.map { |household| household.first.last_name }
           expect(last_names).to eq(last_names.sort.reverse)
@@ -75,6 +77,7 @@ describe People::HouseholdList do
 
       context "with first_name ASC" do
         let(:order) { {first_name: :ASC} }
+
         it "keeps order" do
           first_names = list.map { |household| household.first.first_name }
           expect(first_names).to eq(first_names.sort)

--- a/spec/jobs/export/event_participations_export_job_spec.rb
+++ b/spec/jobs/export/event_participations_export_job_spec.rb
@@ -87,7 +87,7 @@ describe Export::EventParticipationsExportJob do
       lines = file.read.lines
       expect(lines.size).to eq(2)
       expect(lines[0]).to match(/Name;Adresse;PLZ;.*/)
-      expect(lines[1]).to match(/Bottom und Other Member.*/)
+      expect(lines[1]).to match(/Bottom und Other Member.*/).or match(/Other und Bottom Member.*/)
     end
   end
 

--- a/spec/utils/arel_array_literal.rb
+++ b/spec/utils/arel_array_literal.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024. This file is part of
+#  hitobito_cevi and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_cevi.
+
+require "spec_helper"
+
+describe ArelArrayLiteral do
+  let(:items) { [] }
+  subject(:array_literal) { described_class.new(items) }
+
+  describe "#to_sql" do
+    subject(:to_sql) { array_literal.to_sql }
+    context "with ids" do
+      let(:items) { [1, 2, "test", true, nil] }
+      it "evaluates to postgres ARRAY[] literal" do
+        is_expected.to eq("ARRAY[1,2,'test',TRUE,NULL]")
+      end
+    end
+  end
+
+  describe "#eql" do
+    it "is equal when items are equal" do
+      expect(described_class.new([1,2])).to eql(described_class.new([1,2]))
+    end
+
+    it "is not equal when items are equal" do
+      expect(described_class.new([1,2])).not_to eql(described_class.new([3,4]))
+    end
+  end
+end

--- a/spec/utils/arel_array_literal_spec.rb
+++ b/spec/utils/arel_array_literal_spec.rb
@@ -9,12 +9,15 @@ require "spec_helper"
 
 describe ArelArrayLiteral do
   let(:items) { [] }
+
   subject(:array_literal) { described_class.new(items) }
 
   describe "#to_sql" do
     subject(:to_sql) { array_literal.to_sql }
+
     context "with ids" do
       let(:items) { [1, 2, "test", true, nil] }
+
       it "evaluates to postgres ARRAY[] literal" do
         is_expected.to eq("ARRAY[1,2,'test',TRUE,NULL]")
       end
@@ -23,11 +26,11 @@ describe ArelArrayLiteral do
 
   describe "#eql" do
     it "is equal when items are equal" do
-      expect(described_class.new([1,2])).to eql(described_class.new([1,2]))
+      expect(described_class.new([1, 2])).to eql(described_class.new([1, 2]))
     end
 
     it "is not equal when items are equal" do
-      expect(described_class.new([1,2])).not_to eql(described_class.new([3,4]))
+      expect(described_class.new([1, 2])).not_to eql(described_class.new([3, 4]))
     end
   end
 end


### PR DESCRIPTION
refs #2199 

## Lösungsansatz

1. Sortierreihenfolge des ursprünglichen Scopes für den LabelsJob «retten», mithilfe der `ARRAY_POSITION` Funktion von postgres
2. Für die Haushalte dito, aber danach noch nach `household_key` gruppieren können
3. `household_key` für Einzelhaushalte berechnen, um danach gruppieren zu können
4. batch-Processing manuell implementieren, um die Reihenfolge beibehalten zu können

## TODO

- [x] Wagons auf die Verwendung von `grouped_households`, `people_without_household`, `only_households` checken
  - https://github.com/hitobito/hitobito_pbs/blob/9836e9c5c5603746276a7da1592a572947f0616b/db/migrate/20211108083000_harmonize_digital_correspondence_on_households.rb#L39 => nicht relevant, oder?
- [x] Performance Tests machen
  - Im SWW Wagon mit 10000 Personen:
    Alt: 50.26048829901265s
    Neu: 16.778351766988635s