### PR TITLE
Render wagon extensions in subscriber filter partials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,7 @@ gem "active_storage_variant" # variants for Rails < 7
 
 group :development, :test do
   gem "graphiti_spec_helpers"
+  gem "rails_sql_prettifier"
   gem "parallel_tests"
   gem "pry-byebug"
   gem "pry-doc" # provides show-source/$ in the pry-console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,6 +414,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     netrc (0.11.0)
+    niceql (0.6.1)
     nio4r (2.7.3)
     nokogiri (1.16.6)
       mini_portile2 (~> 2.8.2)
@@ -525,6 +526,9 @@ GEM
       actionview (> 3.1)
       activesupport (> 3.1)
       railties (> 3.1)
+    rails_sql_prettifier (6.1.5)
+      activerecord (>= 6.1, < 7)
+      niceql (~> 0.6)
     railties (6.1.7.8)
       actionpack (= 6.1.7.8)
       activesupport (= 6.1.7.8)
@@ -846,6 +850,7 @@ DEPENDENCIES
   rails-erd
   rails-i18n
   rails_autolink
+  rails_sql_prettifier
   redcarpet
   remotipart
   request_profiler

--- a/app/views/people_filters/_filter.html.haml
+++ b/app/views/people_filters/_filter.html.haml
@@ -1,5 +1,5 @@
 - id = type.to_s.pluralize
-- caption = t("people_filters.#{type}.title")
+- caption ||= t("people_filters.#{type}.title")
 - open_class = "show" if entry.filter_chain[type.to_sym].present?
 
 .accordion-item

--- a/app/views/subscriber/filter/_form.html.haml
+++ b/app/views/subscriber/filter/_form.html.haml
@@ -18,3 +18,5 @@
     - FeatureGate.if('person_language') do
       = render(layout: 'people_filters/filter', locals: { type: :language }) do
         = render 'people_filters/language', f: f, entry: @mailing_list
+
+    = render_extensions('filter_form', locals: { entry: entry })

--- a/app/views/subscriber/filter/_show.html.haml
+++ b/app/views/subscriber/filter/_show.html.haml
@@ -20,3 +20,4 @@
       - languages = @mailing_list.filter_chain[:language].allowed_values.map { Person::LANGUAGES.fetch(_1.to_sym, _1) }
       - language_sentence = languages.to_sentence(last_word_connector: t('people_filters.language.word_connector'), two_words_connector: t('people_filters.language.word_connector'))
       = t('people_filters.language.one_of', languages: language_sentence)
+  = render_extensions(:filter_show, mailing_list: @mailing_list)

--- a/config/initializers/niceql.rb
+++ b/config/initializers/niceql.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Niceql.configure do |c|
+  # You can adjust pg_adapter in prooduction at your own risk!
+  # If you need it in production use exec_niceql
+  # default: false
+  # c.pg_adapter_with_nicesql = Rails.env.development?
+
+  # this are default settings, change it to your project needs
+  # c.indentation_base = 2
+  # c.open_bracket_is_newliner = false
+  # c.prettify_active_record_log_output = false
+end


### PR DESCRIPTION
Im SAC Wagon wollen wir zusätzliche subscriber filter implementieren.
Im Core sollen in den subscriber filter partials entsprechend die wagon extensions gerendert werden.