### PR TITLE
Make more DB-connection aspects configurable

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,8 +5,9 @@
 
 base: &generic
   adapter: <%= ENV['RAILS_DB_ADAPTER'] || 'postgresql' %>
-  pool: 20
-  checkout_timeout: 5 # seconds
+  pool: <%= ENV['RAILS_DB_POOL'] || 20 %> # connections
+  idle_timeout: <%= ENV['RAILS_DB_IDLE_TIMEOUT'] || 300 %> # seconds
+  checkout_timeout: <%= ENV['RAILS_DB_CHECKOUT_TIMEOUT'] || 5 %> # seconds
   encoding: "utf8"
 <% %w(host port username password socket).each do |option| %>
   <% value = ENV["RAILS_DB_#{option.upcase}"] %>


### PR DESCRIPTION
As we have a lot of idle-connections, I want to set the timeout lower in integration-setups. For this, configuration through env-vars is needed.