### PR TITLE
Prevent errors when using browser-autocomplete

### DIFF
--- a/app/views/groups/_general_fields.html.haml
+++ b/app/views/groups/_general_fields.html.haml
@@ -1,5 +1,5 @@
 = field_set_tag do
-  = f.labeled_input_fields(:name, :short_name, disabled: entry.static_name)
+  = f.labeled_input_fields(:name, :short_name, disabled: entry.static_name, autocomplete: :off)
   - entry.modifiable_attributes(:description).each do |attr|
     = f.labeled_input_field attr
 

--- a/spec/views/groups/_form.html.haml_spec.rb
+++ b/spec/views/groups/_form.html.haml_spec.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -35,6 +35,13 @@ describe "groups/_form.html.haml" do
     partials.each do |partial|
       expect(view).to render_template(partial: partial)
     end
+  end
+
+  it "disables autocomplete for name and short_name fields" do
+    @rendered = render partial: "groups/form"
+
+    expect(dom.find("input#group_name")["autocomplete"]).to eq "off"
+    expect(dom.find("input#group_short_name")["autocomplete"]).to eq "off"
   end
 
   it "disables name and short_name fields" do


### PR DESCRIPTION
I did not want to separate the fields and duplicate the static-name logic. Also, not autocompleting the group-name is probably a good idea anyway.

fixes hitobito/hitobito_jubla#170

