### PR TITLE
Do not depend on method that is not guaranteed for all questions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,6 +35,7 @@ Lint/ConstantDefinitionInBlock:
     - 'spec/controllers/mailing_lists/imap_mails_controller_spec.rb'
     - 'spec/controllers/mailing_lists/imap_mails_move_controller_spec.rb'
     - 'spec/domain/address/parser_spec.rb'
+    - 'spec/domain/event/participant_assigner_spec.rb'
     - 'spec/features/event/events_controller_spec.rb'
     - 'spec/helpers/mailing_lists/imap_mails_helper_spec.rb'
     - 'spec/jobs/event/participation_confirmation_job_spec.rb'

--- a/app/domain/event/participant_assigner.rb
+++ b/app/domain/event/participant_assigner.rb
@@ -100,7 +100,7 @@ class Event::ParticipantAssigner
     event.questions.each do |q|
       existing = current_answers.find do |a|
         a.question.question == q.question &&
-          a.question.choice_items == q.choice_items &&
+          a.question.choices == q.choices &&
           a.question.multiple_choices? == q.multiple_choices?
       end
       if existing

--- a/spec/domain/event/participant_assigner_spec.rb
+++ b/spec/domain/event/participant_assigner_spec.rb
@@ -75,6 +75,26 @@ describe Event::ParticipantAssigner do
         end
       end
 
+      context "with non default question" do
+        class Event::Question::NonDefaultQuestion < ::Event::Question; end
+
+        let(:event) do
+          quest = course.questions.first
+          other = Fabricate(:course, groups: [groups(:top_layer)])
+          other.questions << Event::Question::NonDefaultQuestion.create!(event: other,
+            disclosure: :optional,
+            question: participation.answers.first.question.question)
+          other.questions << Fabricate(:event_question, event: other, question: quest.question, choices: quest.choices, multiple_choices: quest.multiple_choices)
+          other
+        end
+
+        it "updates participation" do
+          subject.add_participant
+
+          expect(participation.event_id).to eq(event.id)
+        end
+      end
+
       context "on existing participation" do
         it "raises error" do
           Fabricate(:event_participation, event: event, person: participation.person, application: Fabricate(:event_application))


### PR DESCRIPTION
Due to the recent refactoring in https://github.com/hitobito/hitobito/pull/2769 the choice_items method is only implemented by Event::Question::Default

Fixes:
- https://sentry.puzzle.ch/pitc/hitobito-backend/issues/73536/?environment=integration
- https://help.puzzle.ch/#ticket/zoom/8560