### PR TITLE
Fix profile pictures on person view

### DIFF
--- a/app/helpers/upload_display_helper.rb
+++ b/app/helpers/upload_display_helper.rb
@@ -75,7 +75,7 @@ module UploadDisplayHelper
 
   def extract_image_dimensions(width_x_height)
     case width_x_height
-    when /^\d+x\d+$/ then width_x_height.split("x")
+    when /^\d+x\d+$/ then width_x_height.split("x").map(&:to_i)
     end
   end
 end


### PR DESCRIPTION
This fixes the `upload_url` helper to extract the image dimensions as integers. With the migration to Rails 7.0 the Active Storage variant processor was changed to `:vips` which raised an "no implicit conversion
of String into Integer" exception when encountering the stringified integers. See also
https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-storage-default-variant-processor-changed-to-vips