### PR TITLE
Add model aggregator

### DIFF
--- a/app/domain/model_aggregator.rb
+++ b/app/domain/model_aggregator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2017-2024, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class ModelAggregator
+  def initialize(model_class)
+    @model_class = model_class
+  end
+
+  def aggregated_columns(aggregate_function = "MAX")
+    @model_class.columns.map do |column|
+      if column.type == :boolean
+        "BOOL_OR(#{@model_class.table_name}.#{column.name}) AS #{column.name}"
+      else
+        "#{aggregate_function}(#{@model_class.table_name}.#{column.name}) AS #{column.name}"
+      end
+    end.join(", ")
+  end  
+end

--- a/app/domain/model_aggregator.rb
+++ b/app/domain/model_aggregator.rb
@@ -18,5 +18,5 @@ class ModelAggregator
         "#{aggregate_function}(#{@model_class.table_name}.#{column.name}) AS #{column.name}"
       end
     end.join(", ")
-  end  
+  end
 end


### PR DESCRIPTION
When dealing with grouped queries and wanting to select every attribute of a model, like "roles.*" it is not that easy since every value has to be used in an aggregate function.

Because of that we would have to write something like `"MAX(roles.id) as id, MAX(roles.name) as name, ...."`, the simple way of writing it is something like: `Role.column_names.map { |column| "MAX(roles.#{column}) AS #{column}" }.join(", ")`

That leads to another problem tho, because `MAX` is not a aggregate function for bool values, for bool we have to use `BOOL_OR`, so we would have to also check the type of each column to use the correct aggregate function for each of the values, this new domain class basically just adds an easy way to generate a select string, for all column names of a certain model.