### PR TITLE
Show Invoice-Text unless configured otherwise

### DIFF
--- a/app/domain/export/pdf/invoice/articles.rb
+++ b/app/domain/export/pdf/invoice/articles.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2025, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -32,7 +32,7 @@ module Export::Pdf::Invoice
     end
 
     def render_description(reminder)
-      text invoice.description if reminder&.show_invoice_description?
+      text invoice.description if reminder.nil? || reminder.show_invoice_description?
 
       if reminder
         pdf.move_down 8 if reminder.show_invoice_description?

--- a/spec/domain/export/pdf/invoice_spec.rb
+++ b/spec/domain/export/pdf/invoice_spec.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2025, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -453,7 +453,7 @@ describe Export::Pdf::Invoice do
       end
     end
 
-    context "with default show_invoice_description: true" do
+    context "with show_invoice_description: false" do
       let(:show) { false }
 
       it "only shows payment reminder title and text" do
@@ -461,6 +461,20 @@ describe Export::Pdf::Invoice do
         is_expected.not_to include(sent.description)
         is_expected.to(include reminder.text)
       end
+    end
+  end
+
+  describe "normal invoice" do
+    before { invoice.update(description: "We want your moneyz") }
+
+    subject { PDF::Inspector::Text.analyze(pdf).show_text }
+
+    it "includes title" do
+      is_expected.to include(invoice.title)
+    end
+
+    it "includes text" do
+      is_expected.to include(invoice.description)
     end
   end
 


### PR DESCRIPTION
This means:

- show text in a normal invoice
- show text on a reminder and the original text should be shown
- do not show it, if it is a reminder and the text should not be shown

The PR fixes #3124 