### PR TITLE
Add exlude_attr method to table displays column (hitobito/hitobito_sac_cas#1512)

### DIFF
--- a/app/controllers/concerns/render_table_displays.rb
+++ b/app/controllers/concerns/render_table_displays.rb
@@ -33,7 +33,7 @@ module RenderTableDisplays
   def add_table_display_selects(scope, person, selected_group)
     # preserve previously selected columns
     previous = scope.select_values.presence || [scope.model.arel_table[Arel.star]]
-    scope.select((previous + table_display_selects(person, selected_group)).uniq)
+    scope.select((previous + table_display_selects(person, selected_group)).uniq).includes(table_display_includes(person, selected_group))
   end
 
   def table_display_selects(person, selected_group)
@@ -41,6 +41,14 @@ module RenderTableDisplays
       column_class = person.table_display_for(model_class).column_for(column)
 
       column_class.required_model_attrs(column).map(&:to_s) unless column_class.exclude_attr?(selected_group)
+    end
+  end
+
+  def table_display_includes(person, selected_group)
+    TableDisplay.active_columns_for(person, model_class).map do |column|
+      column_class = person.table_display_for(model_class).column_for(column)
+
+      column_class.required_model_includes(column) unless column_class.exclude_attr?(selected_group)
     end
   end
 end

--- a/app/controllers/concerns/render_table_displays.rb
+++ b/app/controllers/concerns/render_table_displays.rb
@@ -8,42 +8,39 @@
 module RenderTableDisplays
   def list_entries
     return super if sorting?
-    add_table_display_to_query(super, current_person)
+    add_table_display_to_query(super, current_person, group)
   end
 
   private
 
-  def add_table_display_to_query(scope, person)
-    add_table_display_joins(scope, person)
-    add_table_display_selects(scope, person)
+  def add_table_display_to_query(scope, person, selected_group)
+    add_table_display_joins(scope, person, selected_group)
+    add_table_display_selects(scope, person, selected_group)
   end
 
-  def add_table_display_joins(scope, person)
-    scope.joins(table_display_joins(person))
+  def add_table_display_joins(scope, person, selected_group)
+    scope.joins(table_display_joins(person, selected_group))
   end
 
-  def table_display_joins(person)
+  def table_display_joins(person, selected_group)
     TableDisplay.active_columns_for(person, model_class).map do |column|
-      person
-        .table_display_for(model_class)
-        .column_for(column)
-        .required_model_joins(column)
+      column_class = person.table_display_for(model_class).column_for(column)
+
+      column_class.required_model_joins(column) unless column_class.exclude_attr?(selected_group)
     end
   end
 
-  def add_table_display_selects(scope, person)
+  def add_table_display_selects(scope, person, selected_group)
     # preserve previously selected columns
     previous = scope.select_values.presence || [scope.model.arel_table[Arel.star]]
-    scope.select((previous + table_display_selects(person)).uniq)
+    scope.select((previous + table_display_selects(person, selected_group)).uniq)
   end
 
-  def table_display_selects(person)
+  def table_display_selects(person, selected_group)
     TableDisplay.active_columns_for(person, model_class).flat_map do |column|
-      person
-        .table_display_for(model_class)
-        .column_for(column)
-        .required_model_attrs(column)
-        .map(&:to_s)
+      column_class = person.table_display_for(model_class).column_for(column)
+
+      column_class.required_model_attrs(column).map(&:to_s) unless column_class.exclude_attr?(selected_group)
     end
   end
 end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -165,7 +165,7 @@ class PeopleController < CrudController
   end
 
   def filter_entries
-    entries = add_table_display_to_query(person_filter.entries, current_person)
+    entries = add_table_display_to_query(person_filter.entries, current_person, group)
     sort_by_sort_expression(entries)
   end
 

--- a/app/domain/export/tabular/people/table_displays.rb
+++ b/app/domain/export/tabular/people/table_displays.rb
@@ -10,11 +10,12 @@ module Export::Tabular::People
     self.model_class = ::Person
     self.row_class = TableDisplayRow
 
-    attr_reader :table_display
+    attr_reader :table_display, :selected_group
 
-    def initialize(list, table_display)
-      super(add_table_display_to_query(list, table_display.person))
+    def initialize(list, table_display, selected_group)
+      super(add_table_display_to_query(list, table_display.person, selected_group))
       @table_display = table_display
+      @selected_group = selected_group
     end
 
     def build_attribute_labels
@@ -23,7 +24,7 @@ module Export::Tabular::People
 
     def selected_labels
       table_display.active_columns(list).each_with_object({}) do |attr, hash|
-        hash[attr] = attribute_label(attr)
+        hash[attr] = attribute_label(attr) unless table_display.column_for(attr).exclude_attr?(selected_group)
       end
     end
 

--- a/app/domain/table_displays/column.rb
+++ b/app/domain/table_displays/column.rb
@@ -22,6 +22,11 @@ module TableDisplays
       resolve_database_joins(attr)
     end
 
+    # Allows custom columns to override and load additional tables into query to prevent n+1 queries
+    def required_model_includes(attr)
+      []
+    end
+
     # Allows a column class to specify which database columns need to be fetched for calculating the
     # value
     def required_model_attrs(_attr)

--- a/app/domain/table_displays/column.rb
+++ b/app/domain/table_displays/column.rb
@@ -53,13 +53,13 @@ module TableDisplays
 
     # Can be overwritten, if for some conditions, this column should not be displayed,
     # for example only for certain group types
-    def exclude_attr?(template)
+    def exclude_attr?(group)
       false
     end
 
     def render(attr)
       raise "implement in subclass, using `super do ... end`" unless block_given?
-      return if exclude_attr?(template)
+      return if exclude_attr?(template&.parent)
 
       table.col(header(attr), data: {attribute_name: attr}) do |object|
         value_for(object, attr) do |target, target_attr|

--- a/app/domain/table_displays/column.rb
+++ b/app/domain/table_displays/column.rb
@@ -40,6 +40,8 @@ module TableDisplays
     end
 
     def label(attr)
+      return I18n.t("table_displays.#{model_class.to_s.downcase}.#{attr}") if I18n.exists?("table_displays.#{model_class.to_s.downcase}.#{attr}")
+
       model_class.human_attribute_name(attr)
     end
 
@@ -49,8 +51,15 @@ module TableDisplays
       nil
     end
 
+    # Can be overwritten, if for some conditions, this column should not be displayed,
+    # for example only for certain group types
+    def exclude_attr?(template)
+      false
+    end
+
     def render(attr)
       raise "implement in subclass, using `super do ... end`" unless block_given?
+      return if exclude_attr?(template)
 
       table.col(header(attr), data: {attribute_name: attr}) do |object|
         value_for(object, attr) do |target, target_attr|

--- a/app/domain/table_displays/people/primary_group_column.rb
+++ b/app/domain/table_displays/people/primary_group_column.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+module TableDisplays::People
+  class PrimaryGroupColumn < TableDisplays::Column
+    def required_model_attrs(attr)
+      []
+    end
+
+    def required_model_includes(attr)
+      [:primary_group]
+    end
+
+    def render(attr)
+      super do |person|
+        person.primary_group.name
+      end
+    end
+
+    def required_permission(attr)
+      :show
+    end
+  end
+end

--- a/app/helpers/dropdown/table_displays.rb
+++ b/app/helpers/dropdown/table_displays.rb
@@ -45,6 +45,8 @@ module Dropdown
     end
 
     def render_item(name, column, value, label = render_label(column, value))
+      return if column.exclude_attr?(template)
+
       content_tag(:li) do
         check_box_tag(name, value, selected?(value), id: value, data: {submit: true}) +
           label_tag(value, label)

--- a/app/helpers/dropdown/table_displays.rb
+++ b/app/helpers/dropdown/table_displays.rb
@@ -45,7 +45,7 @@ module Dropdown
     end
 
     def render_item(name, column, value, label = render_label(column, value))
-      return if column.exclude_attr?(template)
+      return if column.exclude_attr?(template&.parent)
 
       content_tag(:li) do
         check_box_tag(name, value, selected?(value), id: value, data: {submit: true}) +

--- a/app/jobs/export/people_export_job.rb
+++ b/app/jobs/export/people_export_job.rb
@@ -38,7 +38,7 @@ class Export::PeopleExportJob < Export::ExportBaseJob
     return super unless @options[:selection]
 
     table_display = TableDisplay.for(@user_id, Person)
-    Export::Tabular::People::TableDisplays.export(@format, entries, table_display)
+    Export::Tabular::People::TableDisplays.export(@format, entries, table_display, group)
   end
 
   def exporter

--- a/app/jobs/export/subscriptions_job.rb
+++ b/app/jobs/export/subscriptions_job.rb
@@ -17,7 +17,7 @@ class Export::SubscriptionsJob < Export::ExportBaseJob
     return super unless @options[:selection]
 
     table_display = TableDisplay.for(@user_id, Person)
-    Export::Tabular::People::TableDisplays.export(@format, entries, table_display)
+    Export::Tabular::People::TableDisplays.export(@format, entries, table_display, mailing_list.group)
   end
 
   def mailing_list

--- a/config/initializers/table_displays.rb
+++ b/config/initializers/table_displays.rb
@@ -10,7 +10,7 @@ Rails.application.config.to_prepare do
   public_person_attrs = (
     Person::PUBLIC_ATTRS -
     [:first_name, :last_name, :nickname, :picture] -
-    [:zip_code, :town, :address, :street, :housenumber, :address_care_of, :postbox] -
+    [:zip_code, :town, :address, :street, :housenumber, :address_care_of, :postbox, :primary_group_id] -
     show_details_person_attrs -
     Person::INTERNAL_ATTRS
   ) & Person.used_attributes
@@ -21,6 +21,9 @@ Rails.application.config.to_prepare do
   TableDisplay.register_column(Person,
                                TableDisplays::ShowDetailsColumn,
                                show_details_person_attrs)
+  TableDisplay.register_column(Person,
+                               TableDisplays::People::PrimaryGroupColumn,
+                               :primary_group_id)
   TableDisplay.register_column(Person,
                                TableDisplays::People::LayerGroupLabelColumn,
                                :layer_group_label)

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -1282,6 +1282,16 @@ describe PeopleController do
         expect(dom.find("table tbody tr")).not_to have_content "03.03.2003"
       end
     end
+
+    it "GET#index does not render column when exclude attr is true even tho it is selected" do
+      allow_any_instance_of(TableDisplays::PublicColumn).to receive(:exclude_attr?).and_return(true)
+      TableDisplay.register_column(Person, TableDisplays::PublicColumn, :gender)
+      top_leader.table_display_for(Person).update!(selected: %w[gender])
+
+      get :index, params: {group_id: group.id}
+      expect(dom).not_to have_checked_field "Geschlecht"
+      expect(dom.find("table tbody tr")).not_to have_content "unbekannt"
+    end
   end
 
   context "table_displays as configured in the core" do

--- a/spec/domain/table_displays/people/login_status_column_spec.rb
+++ b/spec/domain/table_displays/people/login_status_column_spec.rb
@@ -16,6 +16,7 @@ describe TableDisplays::People::LoginStatusColumn, type: :helper do
   let(:table) { StandardTableBuilder.new([person], self) }
 
   before do
+    allow_any_instance_of(ActionView::Base).to receive(:parent).and_return(groups(:top_group))
     allow(person).to receive(:login_status_icon).and_return("login_status_icon")
   end
 

--- a/spec/domain/table_displays/people/primary_group_column_spec.rb
+++ b/spec/domain/table_displays/people/primary_group_column_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+require "spec_helper"
+
+describe TableDisplays::People::PrimaryGroupColumn, type: :helper do
+  include UtilityHelper
+  include FormatHelper
+
+  let(:person) { people(:top_leader).decorate }
+  let(:ability) { Ability.new(person) }
+  let(:table) { StandardTableBuilder.new([person], self) }
+
+  before do
+    allow_any_instance_of(ActionView::Base).to receive(:parent).and_return(groups(:top_group))
+  end
+
+  it_behaves_like "table display", {
+    column: :primary_group_id,
+    header: "Hauptgruppe",
+    value: "TopGroup",
+    permission: :show
+  }
+end


### PR DESCRIPTION
This Pull Request introduces #exclude_attr? which was an SAC implementation, to not display certain table display attributes in some groups.

This came with the issue that when a person selects an attribute, that does not exist in another group, the query is still trying to execute with the "excluded attr". That throws an error which is also fixed in this Pull Request (all columns that are `exclued_attr? = true`, will not be displayed/exported in any way, also when selected via a previous group/condition where it was possible)