### PR TITLE
Replace deprecated imap constructor call

### DIFF
--- a/app/utils/imap/connector.rb
+++ b/app/utils/imap/connector.rb
@@ -95,7 +95,9 @@ class Imap::Connector
     return if @connected
 
     @imap = Net::IMAP.new(
-      config(:address), config(:imap_port) || 993, config(:enable_ssl) || true
+      config(:address),
+      port: config(:imap_port) || 993,
+      ssl: config(:enable_ssl) || true
     )
     @imap.login(config(:user_name), config(:password))
     @connected = true


### PR DESCRIPTION
Reduziert das noise im delayed job log

```
│ 2025-01-20T17:24:27+0100: [Worker(host:delayed-job-785b9b4556-jn7dd pid:1)] Job MailingLists::MailRetrieverJob (id=254583) RUNNING                                                                                                                                                                                           │
│ /app-src/app/utils/imap/connector.rb:97: warning: DEPRECATED: Call Net::IMAP.new with keyword options                                                                                                                                                                                                                        │
│ 2025-01-20T17:24:28+0100: [Worker(host:delayed-job-785b9b4556-jn7dd pid:1)] Job MailingLists::MailRetrieverJob (id=254583) COMPLETED after 0.1079 
```