### PR TITLE
Add default fallback when no event translation exists (#3140)

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -354,7 +354,7 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
   delegate :participant_types, :find_role_type!, to: :singleton_class
 
   def to_s(_format = :default)
-    name
+    name || I18n.t("activerecord.attributes.event.no_name")
   end
 
   def label_detail

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -612,6 +612,7 @@ de:
         automatic_assignment: Automatische Zuteilung
         application_questions: Anmeldeangaben
         admin_questions: Administrationsangaben
+        no_name: "[Kein Name]"
 
       event/contact_attrs:
         required: Obligatorisch
@@ -722,14 +723,14 @@ de:
         multiple_choices: Mehrfachauswahl
         required: Antwort obligatorisch
         disclosure: Antwortangabe
-        
+
       application_questions:
         question: Frage
         choices: Mögliche Antworten
         multiple_choices: Mehrfachauswahl
         required: Antwort obligatorisch
-        disclosure: Antwortangabe 
-        
+        disclosure: Antwortangabe
+
       event/role:
         label: Bezeichnung
         person: Person

--- a/spec/features/quicksearch_spec.rb
+++ b/spec/features/quicksearch_spec.rb
@@ -5,74 +5,74 @@
 
 require "spec_helper"
 
-describe "Quicksearch" do
-  context "with fulltext search" do
-    it "finds people and groups", js: true do
-      obsolete_node_safe do
-        sign_in
-        visit root_path
+describe "Quicksearch", js: true do
+  before do
+    sign_in
+    visit root_path
+  end
 
-        fill_in "quicksearch", with: "top"
-
-        dropdown = find('ul[role="listbox"]')
-        expect(dropdown).to have_content("Top Leader, Greattown")
-        expect(dropdown).to have_content("Top → TopGroup")
-
-        fill_in "quicksearch", with: "Top Leader"
-        expect(dropdown).to have_content("Top Leader, Greattown")
-        expect(dropdown).not_to have_content("Top → TopGroup")
-
-        fill_in "quicksearch", with: "TopGroup"
-        expect(dropdown).not_to have_content("Top Leader, Greattown")
-        expect(dropdown).to have_content("Top → TopGroup")
-
-        fill_in "quicksearch", with: "Greattown"
-        expect(dropdown).to have_content("Top Leader, Greattown")
-        expect(dropdown).not_to have_content("Top → TopGroup")
-      end
-    end
-
-    it "finds people by birthday", js: true do
-      people(:top_leader).update!(birthday: Date.new(2002, 7, 11))
-
-      sign_in
-      visit root_path
-
-      fill_in "quicksearch", with: "11.07.2002"
+  it "finds people and groups" do
+    obsolete_node_safe do
+      fill_in "quicksearch", with: "top"
 
       dropdown = find('ul[role="listbox"]')
       expect(dropdown).to have_content("Top Leader, Greattown")
-    end
+      expect(dropdown).to have_content("Top → TopGroup")
 
-    it "finds people by birthday substring", js: true do
-      people(:top_leader).update!(birthday: Date.new(2002, 7, 11))
-      people(:bottom_member).update!(birthday: Date.new(1993, 7, 11))
-
-      sign_in
-      visit root_path
-
-      fill_in "quicksearch", with: "11.07"
-
-      dropdown = find('ul[role="listbox"]')
+      fill_in "quicksearch", with: "Top Leader"
       expect(dropdown).to have_content("Top Leader, Greattown")
-      expect(dropdown).to have_content("Bottom Member, Greattown")
-    end
+      expect(dropdown).not_to have_content("Top → TopGroup")
 
-    it "finds results when special characters in search term when confiriming with enter" do
-      allow_any_instance_of(FullTextController).to receive(:only_result).and_return(nil)
-      Fabricate(:phone_number, contactable: people(:top_leader), number: "+41 79 123 45 67")
-      sign_in
-      visit root_path
-      fill_in "quicksearch", with: "+41 79"
-      send_keys(:enter)
-      expect(page).to have_current_path("/full?q=%2B41%2079")
-      expect(page).to have_content("Top Leader")
+      fill_in "quicksearch", with: "TopGroup"
+      expect(dropdown).not_to have_content("Top Leader, Greattown")
+      expect(dropdown).to have_content("Top → TopGroup")
+
+      fill_in "quicksearch", with: "Greattown"
+      expect(dropdown).to have_content("Top Leader, Greattown")
+      expect(dropdown).not_to have_content("Top → TopGroup")
     end
   end
 
-  it "renders clickable tables when submitting form via click", js: true do
+  it "finds people by birthday" do
+    people(:top_leader).update!(birthday: Date.new(2002, 7, 11))
+
+    fill_in "quicksearch", with: "11.07.2002"
+
+    dropdown = find('ul[role="listbox"]')
+    expect(dropdown).to have_content("Top Leader, Greattown")
+  end
+
+  it "finds people by birthday substring" do
+    people(:top_leader).update!(birthday: Date.new(2002, 7, 11))
+    people(:bottom_member).update!(birthday: Date.new(1993, 7, 11))
+
+    fill_in "quicksearch", with: "11.07"
+
+    dropdown = find('ul[role="listbox"]')
+    expect(dropdown).to have_content("Top Leader, Greattown")
+    expect(dropdown).to have_content("Bottom Member, Greattown")
+  end
+
+  it "finds results when special characters in search term when confiriming with enter" do
+    allow_any_instance_of(FullTextController).to receive(:only_result).and_return(nil)
+    Fabricate(:phone_number, contactable: people(:top_leader), number: "+41 79 123 45 67")
     sign_in
     visit root_path
+    fill_in "quicksearch", with: "+41 79"
+    send_keys(:enter)
+    expect(page).to have_current_path("/full?q=%2B41%2079")
+    expect(page).to have_content("Top Leader")
+  end
+
+  it "does display event links when event does not have a name" do
+    allow_any_instance_of(FullTextController).to receive(:only_result).and_return(nil)
+    Event::Translation.where(event_id: events(:top_course).id).destroy_all
+    fill_in "quicksearch", with: events(:top_course).number
+    find("button i.fa-search").click
+    expect(page).to have_link("[Kein Name]")
+  end
+
+  it "renders clickable tables when submitting form via click" do
     fill_in "quicksearch", with: "top"
     find("button i.fa-search").click
     expect(page).not_to have_content "TopGroup"

--- a/spec/features/quicksearch_spec.rb
+++ b/spec/features/quicksearch_spec.rb
@@ -53,7 +53,7 @@ describe "Quicksearch", js: true do
     expect(dropdown).to have_content("Bottom Member, Greattown")
   end
 
-  it "finds results when special characters in search term when confiriming with enter" do
+  it "finds results when special characters in search term when confirming with enter" do
     allow_any_instance_of(FullTextController).to receive(:only_result).and_return(nil)
     Fabricate(:phone_number, contactable: people(:top_leader), number: "+41 79 123 45 67")
     sign_in

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -81,6 +81,11 @@ describe Event do
     its(:participant_count) { should == 2 }
   end
 
+  it "to_s returns default string name when no translation exists" do
+    Event::Translation.where(event_id: event.id).destroy_all
+    expect(event.reload.to_s).to eq "[Kein Name]"
+  end
+
   context "#application_possible?" do
     context "without opening and closing dates" do
       it "is open without maximum participant" do


### PR DESCRIPTION
fixes: https://sentry.puzzle.ch/pitc/hitobito-backend/issues/74186 and  https://sentry.puzzle.ch/pitc/hitobito-backend/issues/73987/ and https://sentry.puzzle.ch/pitc/hitobito-backend/issues/74162