### PR TITLE
Fix table displays for root by using roles join

### DIFF
--- a/app/abilities/person_readables.rb
+++ b/app/abilities/person_readables.rb
@@ -39,7 +39,9 @@ class PersonReadables < GroupBasedReadables
 
   def accessible_people
     if user.root?
-      Person.only_public_data
+      Person.only_public_data.then do |scope|
+        group ? scope.joins(@roles_join).distinct : scope
+      end
     else
       scope = Person.only_public_data.where(accessible_conditions.to_a).distinct
       if has_group_based_conditions?

--- a/spec/abilities/person_readables_spec.rb
+++ b/spec/abilities/person_readables_spec.rb
@@ -597,6 +597,10 @@ describe PersonReadables do
             other = Fabricate(Role::External.name.to_sym, group: group)
             is_expected.to include(other.person)
           end
+
+          it "does join roles so table displays based of roles work" do
+            expect { subject.where(roles: {type: ""}) }.not_to raise_error
+          end
         end
 
         if action == :global

--- a/spec/controllers/tags/merge_controller_spec.rb
+++ b/spec/controllers/tags/merge_controller_spec.rb
@@ -74,7 +74,7 @@ describe Tags::MergeController do
 
       expect(tag1_owner.reload.tags.to_a).to eq([tag1])
       expect(tag2_owner.reload.tags.to_a).to eq([tag2])
-      expect(all_tag_owner.reload.tags.to_a).to eq([tag1, tag2])
+      expect(all_tag_owner.reload.tags.to_a).to match_array([tag1, tag2])
     end
   end
 


### PR DESCRIPTION
Da der root user keine permissions hat und folglich `has_group_based_conditions?` immer `false` ist joinen wir dennoch Gruppen und Rollen, damit die TableDisplays, die Spalten von den Rollen anzeigen auch für den root user funktionieren.