### PR TITLE
Structure parser Part II

### DIFF
--- a/app/domain/structure_parser.rb
+++ b/app/domain/structure_parser.rb
@@ -94,10 +94,13 @@ class StructureParser
     end
 
     def class_name
-      @class_name ||= @name.encode(
-        "ASCII", "UTF-8",
-        fallback: {"ä" => "ae", "ü" => "ue", "ö" => "oe"}
-      )
+      @class_name ||= @name
+        .gsub(/\/.*$/, "")
+        .encode("ASCII", "UTF-8", fallback: {
+          "ä" => "ae",
+          "ü" => "ue",
+          "ö" => "oe"
+        })
     end
 
     def child_class_names
@@ -148,8 +151,11 @@ class StructureParser
     end
 
     def class_name
-      @class_name ||= @name.delete_suffix("/-in")
+      @class_name ||= @name
+        .delete_suffix("/-in")
         .delete_suffix("/-r")
+        .delete_suffix(":in")
+        .gsub(/[-\s&]/, "")
         .encode("ASCII", "UTF-8", fallback: {
           "ä" => "ae",
           "ü" => "ue",

--- a/app/domain/structure_parser.rb
+++ b/app/domain/structure_parser.rb
@@ -123,9 +123,13 @@ class StructureParser
   class Role
     attr_accessor :group, :name
 
-    def initialize(name, permissions)
+    def initialize(name, permissions, class_name)
       @name = name
       @permissions = parse_permissions(permissions)
+
+      if class_name.present?
+        @class_name = ActiveSupport::Inflector.demodulize(class_name)
+      end
     end
 
     def parse_permissions(permissions)
@@ -210,9 +214,9 @@ class StructureParser
         @current_layer.children << group
         @current_group = group
         @result[@current_layer][group] ||= []
-      when /^#{@shiftwidth * 2}#{Regexp.escape(@list_marker)} (.*):\s+(\[.*\])$/
+      when /^#{@shiftwidth * 2}#{Regexp.escape(@list_marker)} (.*):\s+(\[.*\])(\s+--\s+\((.*)\))?$/ # role
         match = Regexp.last_match
-        role = Role.new(match[1], match[2])
+        role = Role.new(match[1], match[2], match[4])
 
         @current_group.roles << role
         @result[@current_layer][@current_group] << role

--- a/app/domain/structure_parser.rb
+++ b/app/domain/structure_parser.rb
@@ -33,6 +33,19 @@ class StructureParser
     @errors = []
   end
 
+  def inspect
+    <<~MSG
+      <StructureParser
+       common_indent: #{@common_indent.inspect} (#{@common_indent.size} Spaces)
+       shiftwidth: #{@shiftwidth.inspect} (#{@shiftwidth.size} Spaces)
+       list_marker: #{@list_marker.inspect}
+       allowed_permissions: #{@allowed_permissions}
+       structure:
+      #{@structure}
+      >
+    MSG
+  end
+
   module Structure
     class Group
       attr_reader :name, :layer, :roles
@@ -222,12 +235,14 @@ class StructureParser
         @current_layer.children << group
         @current_group = group
         @result[@current_layer][group] ||= []
-      when /^#{@shiftwidth * 2}#{Regexp.escape(@list_marker)} (.*):\s+(\[.*\])(\s+--\s+\((.*)\))?$/ # role
+      when /^#{@shiftwidth * 2}#{Regexp.escape(@list_marker)} (.*):\s+(\[.*\])(\s+--\s+\(?(.*)\)?)?$/ # role
         match = Regexp.last_match
         role = Role.new(match[1], match[2], match[4])
 
         @current_group.roles << role
         @result[@current_layer][@current_group] << role
+      else
+        @errors << "Unparseable: #{line}"
       end
     end
   end

--- a/app/domain/structure_parser.rb
+++ b/app/domain/structure_parser.rb
@@ -118,6 +118,12 @@ class StructureParser
     def yaml_key
       @yaml_key ||= ActiveSupport::Inflector.underscore(class_name)
     end
+
+    def filename
+      @filename ||= ActiveSupport::Inflector.underscore(
+        ActiveSupport::Inflector.demodulize(class_name)
+      ) + ".rb"
+    end
   end
 
   class Role
@@ -255,7 +261,7 @@ class StructureParser
   end
 
   def output_groups
-    @result.map { |group| group_template(group) }
+    @result.map { |group| [group.filename, group_template(group)] }.to_h
   end
 
   def output_translations

--- a/app/domain/structure_parser.rb
+++ b/app/domain/structure_parser.rb
@@ -9,7 +9,7 @@ require "English"
 require "pathname"
 require "yaml"
 require "active_support/inflector"
-require "set"
+require "set" # rubocop:disable Lint/RedundantRequireStatement
 
 # parses a structure as output by rake app:hitobito:roles
 class StructureParser

--- a/app/domain/structure_parser.rb
+++ b/app/domain/structure_parser.rb
@@ -206,6 +206,8 @@ class StructureParser
       case line.delete_prefix(@common_indent).chomp
       when /^#{Regexp.escape(@list_marker)} (.*?)(\s+<\s+(.*))?$/ # layer
         name = Regexp.last_match(1)
+        # TODO: Currently, this only support ONE super-layer.
+        #       If there are more (comma-separated), this needs to be extended in this clause
         super_layer = find_layer_by_name(Regexp.last_match(3))
         layer = Structure::Layer.new(name)
 

--- a/app/domain/structure_parser.rb
+++ b/app/domain/structure_parser.rb
@@ -291,7 +291,7 @@ class StructureParser
     <<~CODE
       class Group::#{group.class_name} < ::Group
         #{"self.layer = true" if group.layer_group}
-        #{"children " if group.children.any?}#{group.child_class_names.join(",\n")}
+        #{"children " if group.children.any?}#{group.child_class_names.join(",\n    ")}
 
         ### ROLES
 
@@ -305,7 +305,7 @@ class StructureParser
   def role_template(role)
     <<-CODE
   class #{role.class_name} < ::Role
-    self.permissions = [#{role.permissions}]
+    #{"self.permissions = [#{role.permissions}]" if role.permissions?}
   end
     CODE
   end

--- a/lib/tasks/hitobito.rake
+++ b/lib/tasks/hitobito.rake
@@ -147,6 +147,7 @@ namespace :hitobito do
     })
 
     file = Pathname.new(args[:filename]).expand_path
+    dry_run = ENV["DRY_RUN"] == "true"
 
     puts "-------- Parsing #{file}"
     parser = StructureParser.new(
@@ -156,6 +157,7 @@ namespace :hitobito do
       list_marker: "*",
       allowed_permissions: Role::Permissions + [AbilityDsl::Recorder::General::PERMISSION]
     )
+    puts parser.inspect if dry_run
     parser.parse
     if parser.valid?
       puts "Structure and Permissions seem valid."
@@ -169,15 +171,24 @@ namespace :hitobito do
     group_path = file.dirname.join("app", "models", "group")
     puts "writing classes to #{group_path}"
     parser.output_groups.each do |fn, content|
-      group_path.join(fn).write(content)
-      print "."
+      if dry_run
+        puts fn, content
+      else
+        group_path.join(fn).write(content)
+        print "."
+      end
     end
     puts ""
 
     puts "-------- Translations for those -----------"
     locale_path = file.dirname.join("config", "locales").children.first
-    locale_path.write(parser.output_translations)
-    puts "written to #{locale_path}"
+    if dry_run
+      puts locale_path
+      puts parser.output_translations
+    else
+      locale_path.write(parser.output_translations)
+      puts "written to #{locale_path}"
+    end
 
     puts "-------- Done."
   end

--- a/lib/tasks/hitobito.rake
+++ b/lib/tasks/hitobito.rake
@@ -191,5 +191,22 @@ namespace :hitobito do
     end
 
     puts "-------- Done."
+    unless dry_run
+      puts <<~MSG
+
+        Next steps:
+        -----------
+
+        Update the root-groups in your wagon, so that
+
+          rake app:hitobito:roles:update_readme
+
+        works as intended. Take a lookt at
+
+          #{file.dirname.glob("app/models/*/group.rb").first}
+
+        Have fun.
+      MSG
+    end
   end
 end

--- a/lib/tasks/hitobito.rake
+++ b/lib/tasks/hitobito.rake
@@ -7,14 +7,19 @@
 
 namespace :hitobito do
   desc "Print all groups, roles and permissions"
-  task roles: :environment do
+  task :roles, [:with_classes] => [:environment] do |_t, args|
+    args.with_defaults({with_classes: false})
+    with_classes = args[:with_classes].to_s == "true"
+
     Role::TypeList.new(Group.root_types.first).each do |layer, groups|
       puts "    * #{layer}"
       groups.each do |group, roles|
         puts "      * #{group}"
         roles.each do |r|
           twofa_tag = "2FA " if r.two_factor_authentication_enforced
-          puts "        * #{r.label}: #{twofa_tag}#{r.permissions.inspect}  --  (#{r})"
+          role_class_info = "  --  (#{r})" if with_classes
+
+          puts "        * #{r.label}: #{twofa_tag}#{r.permissions.inspect}#{role_class_info}"
         end
       end
     end


### PR DESCRIPTION
The current improvement round offers the following new features:

- nesting of layers (Root < Sublayer)
- validation of used permissions (no more typos)
- allow forcing the wanted class-name for roles (" -- (Group::SubGroup::RoleName)"-notation)
- direct creation of files

Also, there is now a DRY_RUN for the rake-task.
For consistency, the output of `hitobito:roles` has been extended. The role-classes are there optionally available via `hitobito:roles[true]`.

Some next steps are also shown, mostly so that I do not forget. Working with the new structure does not end with this, it only starts with this task.