### PR TITLE
Allow more time for bigger jobs WITH concurrency

### DIFF
--- a/app/jobs/export/subscriptions_job.rb
+++ b/app/jobs/export/subscriptions_job.rb
@@ -6,6 +6,14 @@
 class Export::SubscriptionsJob < Export::ExportBaseJob
   self.parameters = PARAMETERS + [:mailing_list_id]
 
+  # avoid long-running exports if only one is allowed at the same time.
+  #
+  # this could block exports for a long time. If a higher concurrency is allowed,
+  # then the problem is known and can be mitigated with a higher concurrency.
+  if Settings.delayed_jobs.concurrency.limit > 1
+    self.max_run_time = 24.hours
+  end
+
   def initialize(format, user_id, mailing_list_id, options)
     super(format, user_id, options)
     @mailing_list_id = mailing_list_id


### PR DESCRIPTION
The limit of 4 hours is not enough for the big exports to finish. Therefore, as we have deemed the `Export::SubscriptionsJob` a big one in config/settings.yml, I want to give it more time. 
Should it be quicker? yes.
Is it always? no.

The limit in the BaseJob is 4 hours and we only raise it here if  we also allow for concurrent execution. This ensures that the problem is known and scaling measures are in place.

Does this solve every case ever? no
In some cases? time will tell. 24 hours, in this case. 