### PR TITLE
Follow Deprecation-Warning

### DIFF
--- a/lib/templates/wagon/spec/spec_helper.rb.tt
+++ b/lib/templates/wagon/spec/spec_helper.rb.tt
@@ -10,5 +10,5 @@ require File.join(ENV['APP_ROOT'], 'spec', 'spec_helper.rb')
 Dir[<%= class_name %>::Wagon.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 RSpec.configure do |config|
-  config.fixture_path = File.expand_path('../fixtures', __FILE__)
+  config.fixture_paths = [File.expand_path('../fixtures', __FILE__)]
 end


### PR DESCRIPTION
The warning said:

>  Rails 7.1 has deprecated the singular fixture_path in favour of an array.You should migrate to plural: