### PR TITLE
When deleting addresses, do not validate

### DIFF
--- a/db/migrate/20240513100000_split_addresses.rb
+++ b/db/migrate/20240513100000_split_addresses.rb
@@ -273,7 +273,7 @@ class Splitter
     warn "Deleting left-over Addresses of #{count} #{name}"
     scope.each do |contactable|
       contactable.address = nil
-      contactable.save!
+      contactable.save(validate: false)
       $stderr.print(".")
     end
     $stderr.print("\n")


### PR DESCRIPTION
We know that this is desctructive, which is why there is a report to STDOUT, via mail and an a PaperTrail associated with the affected person-entry in the database.

See #3144