### PR TITLE
Read inactive roles via person_readables if configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Altes Adress-Feld wurde von Personen und Gruppen entfernt, neu gelten die strukturierten Adressfelder (#2226)
 - QR-Referenz kann in Rechnungeinstellungen erfasst werden, dieser gilt als Prefix für die Referenznummer auf dem Einzahlungsschein (#3032)
 - Filtern nach vergangenen Rollen zeigt nur Personen, welche für den User aktuell sichtbar sind (hitobito_sac_cas#1655)
+- Neues Setting mit welchem die Sichtbarkeit von vergangenen Rollen konfiguriert werden kann (Default 0 Tage) (hitobito_sac_cas#1655)
 - Mahnungen können nun in den Rechnungseinstellungen übersetzt werden. Sie werden automatisch in der Sprache der jeweiligen Person für jede Rechnung generiert. (hitobito_sww#198)
 
 ## Version 2.4

--- a/app/abilities/ability_dsl/constraints/person.rb
+++ b/app/abilities/ability_dsl/constraints/person.rb
@@ -17,16 +17,32 @@ module AbilityDsl::Constraints
       permission_in_groups?(person.group_ids)
     end
 
+    def readable_in_same_group
+      permission_in_groups?(person.roles_with_ended_readable.collect(&:group_id))
+    end
+
     def in_same_group_or_below
-      permission_in_groups?(person.groups.collect(&:local_hierarchy).flatten.collect(&:id).uniq)
+      permission_in_groups?(local_hiearchy_ids(person.groups))
+    end
+
+    def readable_in_same_group_or_below
+      permission_in_groups?(local_hiearchy_ids(person.groups_with_roles_ended_readable))
     end
 
     def in_same_layer
       permission_in_layers?(person.layer_group_ids)
     end
 
+    def readable_in_same_layer
+      permission_in_layers?(person.groups_with_roles_ended_readable.map(&:layer_group_id).uniq)
+    end
+
     def in_same_layer_or_visible_below
       in_same_layer || visible_below
+    end
+
+    def readable_in_same_layer_or_visible_below
+      readable_in_same_layer || readable_visible_below
     end
 
     def in_same_layer_or_below
@@ -37,14 +53,17 @@ module AbilityDsl::Constraints
       permission_in_layers?(person.above_groups_where_visible_from.collect(&:id))
     end
 
+    def readable_visible_below
+      groups = person.groups_where_visible_from_above(person.roles_with_ended_readable)
+      permission_in_layers?(person.above_groups_where_visible_from(groups).collect(&:id))
+    end
+
     def non_restricted_in_same_group
       permission_in_groups?(person.non_restricted_groups.collect(&:id))
     end
 
     def non_restricted_in_same_group_or_below
-      permission_in_groups?(
-        person.non_restricted_groups.collect(&:local_hierarchy).flatten.collect(&:id).uniq
-      )
+      permission_in_groups?(local_hiearchy_ids(person.non_restricted_groups))
     end
 
     def non_restricted_in_same_layer
@@ -53,6 +72,10 @@ module AbilityDsl::Constraints
 
     def non_restricted_in_same_layer_or_visible_below
       non_restricted_in_same_layer || visible_below
+    end
+
+    def local_hiearchy_ids(groups)
+      groups.collect(&:local_hierarchy).flatten.collect(&:id).uniq
     end
   end
 end

--- a/app/abilities/person_ability.rb
+++ b/app/abilities/person_ability.rb
@@ -23,7 +23,8 @@ class PersonAbility < AbilityDsl::Base
 
     permission(:contact_data).may(:show).other_with_contact_data
 
-    permission(:group_read).may(:show, :show_details).in_same_group
+    permission(:group_read).may(:show_details).in_same_group
+    permission(:group_read).may(:show).readable_in_same_group
 
     permission(:group_full).may(:show_full, :history).in_same_group
     permission(:group_full)
@@ -33,7 +34,8 @@ class PersonAbility < AbilityDsl::Base
     permission(:group_full).may(:update_email).if_permissions_in_all_capable_groups
     permission(:group_full).may(:create).all # restrictions are on Roles
 
-    permission(:group_and_below_read).may(:show, :show_details).in_same_group_or_below
+    permission(:group_and_below_read).may(:show_details).in_same_group_or_below
+    permission(:group_and_below_read).may(:show).readable_in_same_group_or_below
 
     permission(:group_and_below_full)
       .may(:show_full, :history)
@@ -48,8 +50,11 @@ class PersonAbility < AbilityDsl::Base
     permission(:group_and_below_full).may(:create).all # restrictions are on Roles
 
     permission(:layer_read)
-      .may(:show, :show_full, :show_details, :history)
+      .may(:show_full, :show_details, :history)
       .in_same_layer
+    permission(:layer_read)
+      .may(:show)
+      .readable_in_same_layer
 
     permission(:layer_full)
       .may(:update, :primary_group, :send_password_instructions, :log, :approve_add_request,
@@ -61,8 +66,11 @@ class PersonAbility < AbilityDsl::Base
     permission(:layer_full).may(:totp_reset).in_same_layer
 
     permission(:layer_and_below_read)
-      .may(:show, :show_full, :show_details, :history)
+      .may(:show_full, :show_details, :history)
       .in_same_layer_or_visible_below
+    permission(:layer_and_below_read)
+      .may(:show)
+      .readable_in_same_layer_or_visible_below
 
     permission(:layer_and_below_full)
       .may(:update, :primary_group, :send_password_instructions, :log, :approve_add_request,

--- a/app/abilities/person_readables.rb
+++ b/app/abilities/person_readables.rb
@@ -5,12 +5,13 @@
 
 # This class is only used for fetching lists based on a group association.
 class PersonReadables < GroupBasedReadables
-  attr_reader :group
+  attr_reader :group, :roles_readable_for
 
-  def initialize(user, group = nil)
+  def initialize(user, group = nil, include_ended_roles: false)
     super(user)
 
     @group = group
+    @roles_join = include_ended_roles ? [roles_with_ended_readable: :group] : [roles: :group]
 
     if @group.nil?
       can :index, Person, accessible_people { |_| true }
@@ -21,34 +22,39 @@ class PersonReadables < GroupBasedReadables
 
   private
 
-  def group_accessible_people
-    if read_permission_for_this_group?
-      can :index, Person,
-        group.people.only_public_data { |_| true }
+  attr_reader :roles_join
 
-    elsif layer_and_below_read_in_above_layer?
-      can :index, Person,
-        group.people.only_public_data.visible_from_above(group) { |_| true }
+  def accessible_people
+    return people_roles_scope if user.root?
 
-    elsif contact_data_visible?
-      can :index, Person,
-        group.people.only_public_data.contact_data_visible { |_| true }
+    people_roles_scope.then do |scope|
+      scope = scope.where(accessible_conditions.to_a).distinct
+      has_group_based_conditions? ? scope.where(groups: {deleted_at: nil}) : scope
     end
   end
 
-  def accessible_people
-    if user.root?
-      Person.only_public_data.then do |scope|
-        group ? scope.joins(roles: :group).distinct : scope
-      end
-    else
-      scope = Person.only_public_data.where(accessible_conditions.to_a).distinct
-      if has_group_based_conditions?
-        # Only add these joins when really necessary, because they are extremely expensive to
-        # compute when there are a lot of people and roles
-        scope = scope.joins(roles: :group).where(groups: {deleted_at: nil})
-      end
-      scope
+  def group_accessible_people
+    group_people = people_roles_scope.where(groups: {id: group.id})
+
+    if read_permission_for_this_group?
+      can :index, Person,
+        group_people.only_public_data { |_| true }
+
+    elsif layer_and_below_read_in_above_layer?
+      can :index, Person,
+        group_people.only_public_data.visible_from_above(group) { |_| true }
+
+    elsif contact_data_visible?
+      can :index, Person,
+        group_people.only_public_data.contact_data_visible { |_| true }
+    end
+  end
+
+  def people_roles_scope
+    Person.only_public_data.then do |scope|
+      next scope if user.root? && group.nil?
+
+      (group || has_group_based_conditions?) ? scope.joins(roles_join) : scope
     end
   end
 

--- a/app/domain/person/filter/base.rb
+++ b/app/domain/person/filter/base.rb
@@ -30,6 +30,10 @@ class Person::Filter::Base
     args.blank?
   end
 
+  def include_ended_roles?
+    false
+  end
+
   # Returns a serializable, persistable representation of this filter.
   def to_hash
     args

--- a/app/domain/person/filter/chain.rb
+++ b/app/domain/person/filter/chain.rb
@@ -51,6 +51,10 @@ class Person::Filter::Chain
     filters.blank?
   end
 
+  def include_ended_roles?
+    filters.any?(&:include_ended_roles?)
+  end
+
   def roles_join
     first_custom_roles_join || {roles: :group}
   end

--- a/app/domain/person/filter/list.rb
+++ b/app/domain/person/filter/list.rb
@@ -65,7 +65,7 @@ class Person::Filter::List
   end
 
   def accessibles
-    ability = accessibles_class.new(user, group_range? ? @group : nil)
+    ability = accessibles_class.new(user, group_range? ? @group : nil, include_ended_roles: chain.include_ended_roles?)
     Person.accessible_by(ability).select(:contact_data_visible)
   end
 

--- a/app/domain/person/filter/role.rb
+++ b/app/domain/person/filter/role.rb
@@ -61,6 +61,10 @@ class Person::Filter::Role < Person::Filter::Base
     end
   end
 
+  def include_ended_roles?
+    args[:kind].present?
+  end
+
   private
 
   def parse_day(date, default)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -195,8 +195,12 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   has_many :roles, inverse_of: :person
   has_many :roles_unscoped, -> { with_inactive },
     class_name: "Role", foreign_key: "person_id", inverse_of: :person
+  has_many :roles_with_ended_readable, -> { with_ended_readable },
+    class_name: "Role", foreign_key: "person_id", inverse_of: :person
 
   has_many :groups, through: :roles
+  has_many :groups_with_roles_ended_readable, through: :roles_with_ended_readable,
+    source: :group
 
   has_many :event_participations, class_name: "Event::Participation",
     dependent: :destroy,

--- a/app/models/person/groups.rb
+++ b/app/models/person/groups.rb
@@ -8,6 +8,10 @@
 module Person::Groups
   extend ActiveSupport::Concern
 
+  def readable_group_ids
+    @readable_group_ids ||= Role.where(person_id: id)
+  end
+
   # Uniq set of all group ids in hierarchy.
   def groups_hierarchy_ids
     @groups_hierarchy_ids ||= groups.collect(&:hierarchy).flatten.collect(&:id).uniq
@@ -45,13 +49,13 @@ module Person::Groups
   end
 
   # All groups where this person has a role that is visible from above.
-  def groups_where_visible_from_above
-    roles_with_groups.select { |r| r.class.visible_from_above }.collect(&:group).uniq
+  def groups_where_visible_from_above(roles = roles_with_groups)
+    roles.select { |r| r.class.visible_from_above }.collect(&:group).uniq
   end
 
   # All above and actual groups where this person is visible from.
-  def above_groups_where_visible_from
-    groups_where_visible_from_above.collect(&:hierarchy).flatten.uniq
+  def above_groups_where_visible_from(groups = groups_where_visible_from_above)
+    groups.collect(&:hierarchy).flatten.uniq
   end
 
   def last_non_restricted_role

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -158,6 +158,12 @@ class Role < ActiveRecord::Base
   ### CLASS METHODS
 
   class << self
+    def with_ended_readable
+      return with_inactive if Settings.people.ended_roles_readable_for.nil?
+
+      with_inactive.where(end_on: [nil, [Settings.people.ended_roles_readable_for.seconds.ago.to_date..]])
+    end
+
     # Is the given attribute used in the current STI class
     def attr_used?(attr)
       used_attributes.include?(attr)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -144,6 +144,7 @@ people:
   default_sort: name
   abos: true
   totp_drift: 15
+  ended_roles_readable_for: <%= 0.days %>
   manual_deletion:
     enabled: false
   cleanup_job:

--- a/spec/abilities/person_ability_spec.rb
+++ b/spec/abilities/person_ability_spec.rb
@@ -105,7 +105,7 @@ describe PersonAbility do
       is_expected.to be_able_to(:show, other.person.reload)
     end
 
-    it "may show person with ended role in layer even if outside configured period" do
+    it "may show person with ended role in layer even if outside configured period because it may show deleted people" do
       allow(Settings.people).to receive(:ended_roles_readable_for).and_return(1.month)
       other = Fabricate(Group::TopGroup::Leader.name.to_sym, group: groups(:top_group), start_on: 3.months.ago, end_on: 2.months.ago)
       is_expected.to be_able_to(:show, other.person.reload)

--- a/spec/abilities/person_ability_spec.rb
+++ b/spec/abilities/person_ability_spec.rb
@@ -105,6 +105,12 @@ describe PersonAbility do
       is_expected.to be_able_to(:show, other.person.reload)
     end
 
+    it "may show person with ended role in layer even if outside configured period" do
+      allow(Settings.people).to receive(:ended_roles_readable_for).and_return(1.month)
+      other = Fabricate(Group::TopGroup::Leader.name.to_sym, group: groups(:top_group), start_on: 3.months.ago, end_on: 2.months.ago)
+      is_expected.to be_able_to(:show, other.person.reload)
+    end
+
     it "may show person with ended role in lower layer" do
       other = Fabricate(Group::BottomLayer::Member.name.to_sym, group: groups(:bottom_layer_one), start_on: 2.weeks.ago, end_on: 1.week.ago)
       is_expected.to be_able_to(:show, other.person.reload)
@@ -369,6 +375,24 @@ describe PersonAbility do
     it "may not show person with ended role in layer" do
       other = Fabricate(Group::TopGroup::LocalGuide.name.to_sym, group: groups(:top_group), start_on: 2.weeks.ago, end_on: 1.week.ago)
       is_expected.to_not be_able_to(:show, other.person.reload)
+    end
+
+    it "may show person with ended role in layer if configured" do
+      allow(Settings.people).to receive(:ended_roles_readable_for).and_return(1.month)
+      other = Fabricate(Group::TopGroup::LocalGuide.name.to_sym, group: groups(:top_group), start_on: 2.weeks.ago, end_on: 1.week.ago)
+      is_expected.to be_able_to(:show, other.person.reload)
+    end
+
+    it "may show person with ended role in lower layer if configured" do
+      allow(Settings.people).to receive(:ended_roles_readable_for).and_return(1.month)
+      other = Fabricate(Group::BottomLayer::Member.name.to_sym, group: groups(:bottom_layer_one), start_on: 2.weeks.ago, end_on: 1.week.ago)
+      is_expected.to be_able_to(:show, other.person.reload)
+    end
+
+    it "may not show person with ended role in layer if outside configured period" do
+      allow(Settings.people).to receive(:ended_roles_readable_for).and_return(1.month)
+      other = Fabricate(Group::TopGroup::LocalGuide.name.to_sym, group: groups(:top_group), start_on: 2.years.ago, end_on: 2.months.ago)
+      is_expected.not_to be_able_to(:show, other.person.reload)
     end
 
     context "without any writing permission" do
@@ -747,6 +771,24 @@ describe PersonAbility do
     it "may not show person with ended role in layer" do
       other = Fabricate(Group::BottomLayer::Member.name.to_sym, group: groups(:bottom_layer_one), start_on: 2.weeks.ago, end_on: 1.week.ago)
       is_expected.to_not be_able_to(:show, other.person.reload)
+    end
+
+    it "may show person with ended role in layer if configured" do
+      allow(Settings.people).to receive(:ended_roles_readable_for).and_return(1.month)
+      other = Fabricate(Group::TopGroup::Leader.name.to_sym, group: groups(:top_group), start_on: 2.weeks.ago, end_on: 1.week.ago)
+      is_expected.to be_able_to(:show, other.person.reload)
+    end
+
+    it "may not show person with ended role in layer if outside configured period" do
+      allow(Settings.people).to receive(:ended_roles_readable_for).and_return(1.month)
+      other = Fabricate(Group::TopGroup::Leader.name.to_sym, group: groups(:top_group), start_on: 3.months.ago, end_on: 2.months.ago)
+      is_expected.not_to be_able_to(:show, other.person.reload)
+    end
+
+    it "may not show person with ended role in lower layer if configured" do
+      allow(Settings.people).to receive(:ended_roles_readable_for).and_return(1.month)
+      other = Fabricate(Group::BottomLayer::Member.name.to_sym, group: groups(:bottom_layer_one), start_on: 2.weeks.ago, end_on: 1.week.ago)
+      is_expected.not_to be_able_to(:show, other.person.reload)
     end
 
     it "may not create households" do
@@ -1239,6 +1281,23 @@ describe PersonAbility do
     it "may view others in same group" do
       other = Fabricate(Group::BottomGroup::Leader.name.to_sym, group: groups(:bottom_group_one_one))
       is_expected.to be_able_to(:show, other.person.reload)
+    end
+
+    it "may show person with ended role in group" do
+      other = Fabricate(Group::BottomGroup::Leader.name.to_sym, group: groups(:bottom_group_one_one), end_on: Time.zone.yesterday)
+      is_expected.not_to be_able_to(:show, other.person.reload)
+    end
+
+    it "may show person with ended role in group if configured" do
+      allow(Settings.people).to receive(:ended_roles_readable_for).and_return(1.month)
+      other = Fabricate(Group::BottomGroup::Leader.name.to_sym, group: groups(:bottom_group_one_one), end_on: Time.zone.yesterday)
+      is_expected.to be_able_to(:show, other.person.reload)
+    end
+
+    it "may show person with ended role in group if outside configured period" do
+      allow(Settings.people).to receive(:ended_roles_readable_for).and_return(1.month)
+      other = Fabricate(Group::BottomGroup::Leader.name.to_sym, group: groups(:bottom_group_one_one), end_on: 2.months.ago)
+      is_expected.not_to be_able_to(:show, other.person.reload)
     end
 
     it "may view externals in same group" do

--- a/spec/features/self_registration_spec.rb
+++ b/spec/features/self_registration_spec.rb
@@ -59,6 +59,8 @@ describe :self_registration, js: true do
 
       click_button "Anmelden"
 
+      expect(page).to have_text("TopGroup")
+      expect(page).to have_text("Max Muster")
       expect(person.roles.map(&:type)).to eq([self_registration_role.to_s])
       expect(current_path).to eq("#{group_person_path(group_id: group, id: person)}.html")
     end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -125,6 +125,25 @@ describe Role do
       end
     end
 
+    describe ":with_ended_readable" do
+      it "excludes ended roles" do
+        role.update!(end_on: Date.current.yesterday)
+        expect(Role.with_ended_readable).not_to include(role)
+      end
+
+      it "includes ended roles if inside configured period" do
+        allow(Settings.people).to receive(:ended_roles_readable_for).and_return(1.month)
+        role.update!(end_on: 1.days.ago)
+        expect(Role.with_ended_readable).to include(role)
+      end
+
+      it "includes ended roles if from anytime if setting is set to nil" do
+        allow(Settings.people).to receive(:ended_roles_readable_for).and_return(nil)
+        role.update!(end_on: 100.years.ago)
+        expect(Role.with_ended_readable).to include(role)
+      end
+    end
+
     describe ":inactive" do
       it "excludes roles without end_on and archived_at" do
         expect(role.end_on).to be_nil


### PR DESCRIPTION
Soll das noch ins Changelog, oder die zeile vom fix angepasst werden, zb. 

statt
> Filtern nach vergangenen Rollen zeigt nur Personen, welche für den User aktuell sichtbar sind (hitobito_sac_cas#1655)

statt
> Personen ohne aktive Rolle sind via Filter auf der Gruppe auf Basis ihrer vergangen Rollen, nach einem konfigurierbarem Zeitraum (aktuell sofort), nicht mehr auffindbar
(hitobito_sac_cas#1655)

Fraglich auch ob wir wirklich einen association wollen, ob uns das wo was kostet  oder weh tut. Sonst finde ich liest es sich so besser. Es scheint auch, dass für layer_permission kein ability change notwendig ist, das hab ich noch nicht ganz durchschaut warum das auch ohne geht
