### PR TITLE
MULTISELECT: allow all multiselect sizes

### DIFF
--- a/app/controllers/concerns/filtered_people.rb
+++ b/app/controllers/concerns/filtered_people.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025-2025, Schweizer Wanderwege. This file is part of
+#  hitobito_sww and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sww.
+
+# collect everything needed to filter people in a group with People::Filter::List
+# depends on methods to determine the current user and group
+module FilteredPeople
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :list_filter_args
+  end
+
+  private
+
+  def person_filter(accessibles_class = nil)
+    @person_filter ||= Person::Filter::List.new(group, current_user, list_filter_args, accessibles_class)
+  end
+
+  def list_filter_args
+    if params[:filter_id]
+      # DB-Stored filter with prepared params
+      PeopleFilter.for_group(group).find(params[:filter_id]).to_params
+    else
+      # ad-hoc/unsaved filter or nothing
+      params
+    end
+  end
+end

--- a/app/controllers/concerns/filtered_people.rb
+++ b/app/controllers/concerns/filtered_people.rb
@@ -27,7 +27,7 @@ module FilteredPeople
       @people_ids = %w[all]
       person_filter.entries
     else
-      Person.where(id: list_params(:ids)).distinct
+      Person.where(id: list_param(:ids)).distinct
     end
   end
 

--- a/app/controllers/concerns/filtered_people.rb
+++ b/app/controllers/concerns/filtered_people.rb
@@ -6,6 +6,10 @@
 #  https://github.com/hitobito/hitobito_sww.
 
 # collect everything needed to filter people in a group with People::Filter::List
+#
+# the most common approach is wrapped in all_filtered_or_listed_people. if that
+# does not fit, implement the same ideas directly in your controller
+#
 # depends on methods to determine the current user and group
 module FilteredPeople
   extend ActiveSupport::Concern
@@ -15,6 +19,17 @@ module FilteredPeople
   end
 
   private
+
+  def all_filtered_or_listed_people
+    if params[:ids] == "all"
+      params.delete(:ids)
+
+      @people_ids = %w[all]
+      person_filter.entries
+    else
+      Person.where(id: list_params(:ids)).distinct
+    end
+  end
 
   def person_filter(accessibles_class = nil)
     @person_filter ||= Person::Filter::List.new(group, current_user, list_filter_args, accessibles_class)

--- a/app/controllers/event/invitation_lists_controller.rb
+++ b/app/controllers/event/invitation_lists_controller.rb
@@ -4,6 +4,8 @@
 #  https://github.com/hitobito/hitobito.
 
 class Event::InvitationListsController < SimpleCrudController
+  include FilteredPeople # provides all_filtered_or_listed_people, person_filter and list_filter_args
+
   skip_authorization_check
   skip_authorize_resource
 
@@ -22,7 +24,7 @@ class Event::InvitationListsController < SimpleCrudController
   end
 
   def new
-    @people_ids = params[:ids]
+    @people_ids ||= params[:ids]
     @event_type = params[:type]
     @event_label = params[:label]
     render "new"
@@ -63,10 +65,6 @@ class Event::InvitationListsController < SimpleCrudController
   end
 
   def people
-    @people ||= Person.where(id: people_ids).distinct
-  end
-
-  def people_ids
-    list_param(:ids)
+    @people ||= all_filtered_or_listed_people
   end
 end

--- a/app/controllers/event/participation_lists_controller.rb
+++ b/app/controllers/event/participation_lists_controller.rb
@@ -4,6 +4,8 @@
 #  https://github.com/hitobito/hitobito.
 
 class Event::ParticipationListsController < SimpleCrudController
+  include FilteredPeople # provides all_filtered_or_listed_people, person_filter and list_filter_args
+
   skip_authorization_check
   skip_authorize_resource
 
@@ -28,7 +30,7 @@ class Event::ParticipationListsController < SimpleCrudController
   end
 
   def new
-    @people_ids = params[:ids]
+    @people_ids ||= params[:ids]
     @event_type = params[:type]
     @event_label = params[:label]
     render "new"
@@ -70,10 +72,6 @@ class Event::ParticipationListsController < SimpleCrudController
   end
 
   def people
-    @people ||= Person.where(id: people_ids).distinct
-  end
-
-  def people_ids
-    list_param(:ids)
+    @people ||= all_filtered_or_listed_people
   end
 end

--- a/app/controllers/invoice_lists_controller.rb
+++ b/app/controllers/invoice_lists_controller.rb
@@ -110,7 +110,7 @@ class InvoiceListsController < CrudController
   end
 
   def invoices
-    parent.invoices.where(id: list_param(:ids))
+    Invoice::Filter.new(params).apply(parent.invoices)
   end
 
   def flash_message(action: action_name, count: nil, title: nil)

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -10,7 +10,7 @@ class PeopleController < CrudController
   include AsyncDownload
   include Tags
   prepend RenderTableDisplays
-  include FilteredPeople # provide person_filter and list_filter_args
+  include FilteredPeople # provides all_filtered_or_listed_people, person_filter and list_filter_args
 
   self.nesting = Group
 

--- a/app/controllers/role_lists_controller.rb
+++ b/app/controllers/role_lists_controller.rb
@@ -1,4 +1,6 @@
 class RoleListsController < CrudController
+  include FilteredPeople # provides all_filtered_or_listed_people, person_filter and list_filter_args
+
   self.nesting = Group
 
   self.permitted_attrs = [:type, :group_id] + Role.used_attributes
@@ -36,7 +38,7 @@ class RoleListsController < CrudController
 
   def new
     @group_selection = group.groups_in_same_layer.to_a
-    @people_ids = params[:ids]
+    @people_ids ||= params[:ids]
     @people_count = people.count
   end
 
@@ -44,18 +46,18 @@ class RoleListsController < CrudController
     entry # initialize entry so form extensions work without modifications
 
     @group_selection = group.groups_in_same_layer.to_a
-    @people_ids = params[:ids]
+    @people_ids ||= params[:ids]
   end
 
   def movable
     assign_attributes
     @role_types = role_list.collect_available_role_types
-    @people_ids = params[:ids]
+    @people_ids ||= params[:ids]
   end
 
   def deletable
     @role_types = role_list.collect_available_role_types
-    @people_ids = params[:ids]
+    @people_ids ||= params[:ids]
   end
 
   def self.model_class
@@ -91,15 +93,7 @@ class RoleListsController < CrudController
   end
 
   def people
-    @people ||= Person.where(id: people_ids).uniq
-  end
-
-  def people_ids
-    list_param(:ids)
-  end
-
-  def person_filter
-    @person_filter ||= Person::Filter::List.new(@group, current_user, list_filter_args)
+    @people ||= all_filtered_or_listed_people
   end
 
   def role_list

--- a/app/controllers/subscriber/subscriber_lists_controller.rb
+++ b/app/controllers/subscriber/subscriber_lists_controller.rb
@@ -7,6 +7,8 @@
 
 module Subscriber
   class SubscriberListsController < SimpleCrudController
+    include FilteredPeople # provides all_filtered_or_listed_people, person_filter and list_filter_args
+
     helper_method :group
 
     respond_to :js, only: [:new]
@@ -17,7 +19,7 @@ module Subscriber
     skip_authorize_resource
 
     def new
-      @people_ids = params[:ids]
+      @people_ids ||= params[:ids]
     end
 
     def create
@@ -47,7 +49,7 @@ module Subscriber
     private
 
     def people
-      @people ||= Person.where(id: people_ids).distinct
+      @people ||= all_filtered_or_listed_people
     end
 
     def non_subscribed_people
@@ -63,10 +65,6 @@ module Subscriber
 
     def group
       @group ||= Group.find(params[:group_id])
-    end
-
-    def people_ids
-      list_param(:ids)
     end
 
     def self.model_class

--- a/app/controllers/tag_lists_controller.rb
+++ b/app/controllers/tag_lists_controller.rb
@@ -11,13 +11,19 @@ class TagListsController < ListController
   respond_to :js, only: [:new, :deletable]
 
   def create
-    Bulk::TagAddJob.new(manageable_people.map(&:ids), tag_names).enqueue
+    manageable_people_ids = manageable_people.map(&:id)
+
+    Bulk::TagAddJob.new(manageable_people_ids, tag_names).enqueue!
+    count = manageable_people_ids.size
 
     redirect_to(group_people_path(group), notice: flash_message(:success, count: count))
   end
 
   def destroy
-    Bulk::TagRemoveJob.new(manageable_people.map(&:ids), tag_names.enqueue)
+    manageable_people_ids = manageable_people.map(&:id)
+
+    Bulk::TagRemoveJob.new(manageable_people_ids, tag_names).enqueue!
+    count = manageable_people_ids.size
 
     redirect_to(group_people_path(group), notice: flash_message(:success, count: count))
   end

--- a/app/controllers/tag_lists_controller.rb
+++ b/app/controllers/tag_lists_controller.rb
@@ -55,7 +55,7 @@ class TagListsController < ListController
       person_filter(PersonFullReadables).entries.includes(:tags).distinct
     else
       Person.where(id: list_param(:ids)).includes(:tags).distinct
-        .select { |person| current_ability.can?(needed_permission, person) }
+        .select { |person| current_ability.can?(:manage_tags, person) }
     end
   end
 

--- a/app/domain/invoice/filter.rb
+++ b/app/domain/invoice/filter.rb
@@ -48,6 +48,8 @@ class Invoice::Filter
   end
 
   def invoice_ids
+    return [] if params[:ids] == "all"
+
     @invoice_ids = params[:ids].to_s.split(",")
   end
 end

--- a/app/domain/person/filter/list.rb
+++ b/app/domain/person/filter/list.rb
@@ -8,13 +8,14 @@
 class Person::Filter::List
   attr_reader :group, :user, :chain, :range, :name
 
-  def initialize(group, user, params = {})
+  def initialize(group, user, params = {}, accessibles_class = nil)
     @group = group
     @user = user
     @chain = Person::Filter::Chain.new(params[:filters])
     @range = params[:range]
     @name = params[:name]
     @ids = params[:ids].to_s.split(",")
+    @accessibles_class = accessibles_class
   end
 
   def entries
@@ -70,12 +71,11 @@ class Person::Filter::List
   end
 
   def accessibles_class
-    abilities = chain.required_abilities
-    if abilities.include?(:full)
-      PersonFullReadables
-    else
-      PersonReadables
-    end
+    @accessibles_class ||= full_ability_needed? ? PersonFullReadables : PersonReadables
+  end
+
+  def full_ability_needed?
+    chain.required_abilities.include?(:full)
   end
 
   def group_range?

--- a/app/helpers/multiselect_helper.rb
+++ b/app/helpers/multiselect_helper.rb
@@ -4,12 +4,12 @@
 #  https://github.com/hitobito/hitobito
 
 module MultiselectHelper
-  def extended_all_checkbox(scope, max_pages = 10)
-    return unless scope.total_pages <= max_pages && scope.first.respond_to?(:id)
-    ids = scope.unscope(:limit).pluck(:id)
+  def extended_all_checkbox(scope)
+    count = scope.unscope(:limit).count
+
     content_tag(:label, class: "extended_all btn btn-link d-inline d-none") do
-      check_box_tag(:extended_all, ids.count, false, data: {ids: JSON.generate(ids)}, class: "d-none") +
-        content_tag(:span, t("global.extended_select_all", count: ids.count))
+      check_box_tag(:extended_all, count, false, data: {ids: 'all'}, class: "d-none") +
+        content_tag(:span, t("global.extended_select_all", count: count))
     end
   end
 end

--- a/app/javascript/javascripts/modules/multiselect.js
+++ b/app/javascript/javascripts/modules/multiselect.js
@@ -95,7 +95,7 @@ function getSelectedIds(table) {
     "thead input[name=extended_all]",
   );
   if (extendedAllElement?.checked)
-    return JSON.parse(extendedAllElement.dataset.ids);
+    return extendedAllElement.dataset.ids;
 
   const checkboxElements = table.querySelectorAll(
     "tbody input[type=checkbox]:checked",
@@ -103,6 +103,16 @@ function getSelectedIds(table) {
   return Array.from(checkboxElements).map(
     (checkboxElement) => checkboxElement.value,
   );
+}
+
+function getFilterParams() {
+  const extendedAllElement = document.querySelector(
+    "thead input[name=extended_all]",
+  );
+  if (extendedAllElement?.checked)
+    return window.location.search.substring(1);
+
+  return null;
 }
 
 function buildLinkWithIds(templateHref, table) {
@@ -114,7 +124,9 @@ function buildLinkWithIds(templateHref, table) {
     queryParams = `ids=${[match[1]]}&singular=true`;
   } else {
     const ids = getSelectedIds(table);
-    queryParams = `ids=${ids}`;
+    const filterParams = getFilterParams();
+
+    queryParams = [`ids=${ids}`, filterParams].filter(function(it) {return it}).join("&")
   }
   return templateHref + separator + queryParams;
 }
@@ -129,17 +141,11 @@ function toggleActions(table) {
     allElement.checked = counts.checked > 0 && counts.unchecked === 0;
 
   // toggle extended select all checkbox
-  const extendedAllElement = table.querySelector(
-    "thead input[name=extended_all]",
-  );
+  const extendedAllElement = table.querySelector("thead input[name=extended_all]");
   if (extendedAllElement && extendedAllElement.checked && !allElement?.checked)
     extendedAllElement.checked = false;
-  const showExtendedAllElement =
-    !extendedAllElement?.checked && +extendedAllElement?.value > counts.checked;
-  extendedAllElement?.parentElement?.classList?.toggle(
-    "d-none",
-    !showExtendedAllElement,
-  );
+  const showExtendedAllElement = !extendedAllElement?.checked && +extendedAllElement?.value > counts.checked;
+  extendedAllElement?.parentElement?.classList?.toggle("d-none", !showExtendedAllElement);
 
   // display count of selected elements
   const showCount = extendedAllElement?.checked

--- a/app/jobs/bulk/tag_add_job.rb
+++ b/app/jobs/bulk/tag_add_job.rb
@@ -11,7 +11,7 @@ class Bulk::TagAddJob < BaseJob
   def initialize(ids, tag_names)
     @ids = ids
     @tag_names = tag_names
-    super
+    super()
   end
 
   def perform

--- a/app/jobs/bulk/tag_add_job.rb
+++ b/app/jobs/bulk/tag_add_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025-2025, Schweizer Wanderwege. This file is part of
+#  hitobito_sww and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sww.
+
+class Bulk::TagAddJob < BaseJob
+  self.parameters = [:ids, :tag_names]
+
+  def initialize(ids, tag_names)
+    @ids = ids
+    @tag_names = tag_names
+    super
+  end
+
+  def perform
+    TagList.new(people, tags).add
+  end
+
+  private
+
+  def people
+    Person.where(id: @ids).includes(:tags).distinct
+  end
+
+  def tags
+    ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name(@tag_names)
+  end
+end

--- a/app/jobs/bulk/tag_remove_job.rb
+++ b/app/jobs/bulk/tag_remove_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025-2025, Schweizer Wanderwege. This file is part of
+#  hitobito_sww and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sww.
+
+class Bulk::TagRemoveJob < BaseJob
+  self.parameters = [:ids, :tag_names]
+
+  def initialize(ids, tag_names)
+    @ids = ids
+    @tag_names = tag_names
+    super
+  end
+
+  def perform
+    TagList.new(people, tags).remove
+  end
+
+  private
+
+  def people
+    Person.where(id: @ids).includes(:tags).distinct
+  end
+
+  def tags
+    ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name(@tag_names)
+  end
+end

--- a/app/jobs/bulk/tag_remove_job.rb
+++ b/app/jobs/bulk/tag_remove_job.rb
@@ -11,7 +11,7 @@ class Bulk::TagRemoveJob < BaseJob
   def initialize(ids, tag_names)
     @ids = ids
     @tag_names = tag_names
-    super
+    super()
   end
 
   def perform

--- a/app/views/mailing_lists/imap_mails/_multiselect_actions.html.haml
+++ b/app/views/mailing_lists/imap_mails/_multiselect_actions.html.haml
@@ -8,7 +8,7 @@
     %span
       .count
       = ti('selected')
-    = extended_all_checkbox(@mails)
+    -# extended_all_checkbox is disabled here because handling mails that way is not intended
     .actions
       = imap_mail_move_button :inbox
       = imap_mail_move_button :spam

--- a/app/views/tag_lists/_new.html.haml
+++ b/app/views/tag_lists/_new.html.haml
@@ -11,7 +11,7 @@
           .row-fluid
 
             - unless @people_count.zero?
-              = hidden_field_tag('ids', @manageable_people.map(&:id).join(','))
+              = hidden_field_tag('ids', @manageable_people_ids.join(','))
               = f.text_field(:tags,
                              name: :tags,
                              class: 'tag-list-add form-control form-control-sm',

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -1980,12 +1980,12 @@ de:
       success:
         zero: Es wurden keine Tags entfernt
         one: Ein Tag wurde entfernt
-        other: "%{count} Tags wurden entfernt"
+        other: "Tags auf %{count} Personen werden im Hintergrund entfernt"
     create:
       success:
         zero: Es wurden keine Tags erstellt
         one: Ein Tag wurde erstellt
-        other: "%{count} Tags wurden erstellt"
+        other: "Tags auf %{count} Personen werden im Hintergrund erstellt"
     deletable:
       title: Welche Tags sollen gelöscht werden?
       no_entries: Von keiner der ausgewählten Personen können Tags entfernt werden


### PR DESCRIPTION
Currently, only the first 10 pages are considered. If there are more pages, then the "check all"-link is not shown. This limit helps to avoid too-big requests and slow responses.

The previous model listed all IDs and passed them along. While undeniably correct, it was a slow and bulky process. The new approach in this (WIP) PR is - instead of listing ids explicitely - to pass "all" and the needed filter-params to the mutating controller. The translation into IDs can then happen there or - if needed - be passed further to a background-job.

The current problem and blocker of this PR is that the translation from filter-params to people-list is not tested properly. Since this translation is a central building block used by multiple controllers, it needs to tested well.

Once there is a working unit-test (suite), we can process with a controller-test to have a verified integration. From there, we can refactor things to handle the data-mutation in a background-job.

Currently, we use the domain-class `Person::Filter::List` in a controller-concern `FilteredPeople`, which is included (among others) in the `TagListController`. Once that chain works, the other controllers including this concern can be checked and verified.

fixes hitobito/hitobito_sww#233