### PR TITLE
Add some invoice_list validations

### DIFF
--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -1148,7 +1148,7 @@ de:
 
       message_template:
         title: Titel
-        body: Text   
+        body: Text
 
       payment:
         invoice: Rechnung

--- a/spec/fabricators/invoice_fabricator.rb
+++ b/spec/fabricators/invoice_fabricator.rb
@@ -53,6 +53,16 @@ Fabricator(:invoice) do
   title { Faker::Name.name }
 end
 
+Fabricator(:invoice_item) do
+  count { rand(3) }
+  description { Faker::Commerce.product_name }
+  unit_cost { (Faker::Commerce.price / 0.05).to_i * BigDecimal("0.05") }
+end
+
+Fabricator(:invoice_list) do
+  title { Faker::Name.name }
+end
+
 Fabricator(:invoice_article) do
   number { Faker::Number.hexadecimal(digits: 5).to_s.upcase }
   name { Faker::Commerce.product_name }


### PR DESCRIPTION
Das Problem lässt sich über eine Validierung am einfachsten beheben. Fraglich ob das so in den use case von den Kunden passt. 

Was mir bisher aufgefallen ist 

- a) Rechnung auf Gruppe erstellen (-> Sammelrechnung + Einzelrechnungen (die aber nur unter Sammelrechnung aufscheinen))
- Rechnung auf Gruppe via gespeichertem Filter (ignoriert Filter, verhält sich wie a)
- Rechnung auf Gruppe nicht gespeichertem Filter erstellen (-> nur Einzel, keine Sammelrechnung)

Fraglich ob wir das auch noch grade ziehen wollen

