### PR TITLE
Validate recievers and items on invoice_list (hitobito/hitbito_sww#235)

### DIFF
--- a/app/domain/invoice/batch_create.rb
+++ b/app/domain/invoice/batch_create.rb
@@ -45,7 +45,7 @@ class Invoice::BatchCreate
 
   def create_invoice(recipient)
     attrs = attributes(recipient)
-    invoice_list.group.invoices.build(attrs).save if attrs[:invoice_items_attributes].any?
+    invoice_list.group.invoices.build(attrs).save
   end
 
   private

--- a/app/models/invoice_list.rb
+++ b/app/models/invoice_list.rb
@@ -46,6 +46,9 @@ class InvoiceList < ActiveRecord::Base
 
   scope :list, -> { order(:created_at) }
 
+  validate :assert_recipients
+  validate :assert_invoice_items
+
   validates_by_schema except: :invalid_recipient_ids
 
   def to_s
@@ -73,11 +76,11 @@ class InvoiceList < ActiveRecord::Base
   end
 
   def recipient_ids_count
-    receiver ? receiver.people.unscope(:select).count : recipient_ids.count
+    recipients.count
   end
 
   def first_recipient
-    receiver ? receiver.people.first : Person.find(recipient_ids.first)
+    recipients.first
   end
 
   def recipients
@@ -91,6 +94,17 @@ class InvoiceList < ActiveRecord::Base
   def recipient_ids = @recipient_ids.to_a
 
   def recipient_ids=(ids)
-    @recipient_ids = ids.is_a?(Array) ? ids : ids.to_s.split(",").map(&:to_i).select(&:positive?)
+    @recipient_ids = ids.is_a?(Array) ? ids : ids.to_s.scan(/\d+/).map(&:to_i).select(&:positive?)
+  end
+
+  def assert_recipients
+    errors.add(:receiver, :empty) if recipients.none?
+  end
+
+  def assert_invoice_items
+    if invoice && invoice.invoice_items.blank?
+      message = [InvoiceItem.model_name.human, I18n.t("activerecord.errors.messages.must_exist")].join(" ")
+      errors.add(:base, message)
+    end
   end
 end

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -1148,7 +1148,7 @@ de:
 
       message_template:
         title: Titel
-        body: Text   
+        body: Text
 
       payment:
         invoice: Rechnung

--- a/spec/controllers/invoice_lists_controller_spec.rb
+++ b/spec/controllers/invoice_lists_controller_spec.rb
@@ -48,7 +48,7 @@ describe InvoiceListsController do
     before { sign_in(people(:top_leader)) }
 
     it "renders final Empfänger count" do
-      InvoiceList.create!(group: group, title: "title", recipients_processed: 20, recipients_total: 20)
+      Fabricate(:invoice_list, group: group, title: "title", recipients_processed: 20, recipients_total: 20)
       get :index, params: {group_id: group.id}
       expect(column).to have_text("20")
     end
@@ -257,7 +257,7 @@ describe InvoiceListsController do
     end
 
     it "PUT#update redirects to invoice_list_invoices path if invoice_list is set" do
-      list = InvoiceList.create!(title: :title, group: group)
+      list = Fabricate(:invoice_list, title: :title, group: group, receiver: groups(:top_group))
       invoice = Invoice.create!(group: group, title: "test", recipient: person,
         invoice_list: list,
         invoice_items_attributes:

--- a/spec/domain/invoice/payment_processor_spec.rb
+++ b/spec/domain/invoice/payment_processor_spec.rb
@@ -58,7 +58,7 @@ describe Invoice::PaymentProcessor do
   end
 
   it "creates payment and marks invoice as payed and updates invoice_list" do
-    list = InvoiceList.create!(title: :title, group: invoice.group)
+    list = Fabricate(:invoice_list, title: :title, group: invoice.group)
     invoice.update_columns(reference: "000000000000100000000000905",
       invoice_list_id: list.id,
       total: 710.82)
@@ -76,7 +76,7 @@ describe Invoice::PaymentProcessor do
   end
 
   it "creates payment, saves transaction xml and payee" do
-    list = InvoiceList.create!(title: :title, group: invoice.group)
+    list = Fabricate(:invoice_list, title: :title, group: invoice.group)
     invoice.update_columns(reference: "000000000000100000000000905",
       invoice_list_id: list.id,
       total: 710.82)

--- a/spec/fabricators/invoice_fabricator.rb
+++ b/spec/fabricators/invoice_fabricator.rb
@@ -53,6 +53,17 @@ Fabricator(:invoice) do
   title { Faker::Name.name }
 end
 
+Fabricator(:invoice_item) do
+  count { rand(3) }
+  description { Faker::Commerce.product_name }
+  unit_cost { (Faker::Commerce.price / 0.05).to_i * BigDecimal("0.05") }
+end
+
+Fabricator(:invoice_list) do
+  title { Faker::Name.name }
+  recipient_ids { [ActiveRecord::FixtureSet.identify(:top_leader)] }
+end
+
 Fabricator(:invoice_article) do
   number { Faker::Number.hexadecimal(digits: 5).to_s.upcase }
   name { Faker::Commerce.product_name }

--- a/spec/features/invoice_lists/destroys_controller_spec.rb
+++ b/spec/features/invoice_lists/destroys_controller_spec.rb
@@ -23,7 +23,7 @@ describe InvoiceLists::DestroysController, js: true do
   end
 
   let!(:invoice_list) do
-    InvoiceList.create(title: "membership fee", invoices: draft_invoices, group: layer)
+    Fabricate(:invoice_list, title: "membership fee", invoices: draft_invoices, group: layer, receiver: groups(:top_group))
   end
 
   let(:user) { people(:top_leader) }

--- a/spec/features/invoices_spec.rb
+++ b/spec/features/invoices_spec.rb
@@ -82,7 +82,7 @@ describe :invoices, js: true do
 
     let(:letter) { messages(:with_invoice) }
     let!(:sent) { invoices(:sent) }
-    let!(:invoice_list) { letter.create_invoice_list(title: "test", group_id: group.id) }
+    let(:invoice_list) { letter.create_invoice_list(title: "test", group_id: group.id, recipient_ids: user.id) }
 
     describe "GET #index" do
       before do


### PR DESCRIPTION
Leere Sammelrechnung mit 0 Empfängern erstellen wir aktuell, falls 

a) Das Auslesen der Empfänger (via ids, receiver, filter) nicht funktioniert
b) [Keine Rechnungsposten vorhanden sind](https://github.com/hitobito/hitobito/blob/6b5f91a81f6362a7e395e151e1fd5243ce01cda0/app/domain/invoice/batch_create.rb#L48) und folglich keine Rechnungen erstellt werden.

Das Problem lässt sich über 2 Validierungen auf der Sammelrechnung am einfachsten beheben (Empfänger, Rechnungsposten).

Bei den Empfängern bin ich mir relativ sicher (Sammelrechnung ohne Empfänger erscheint unsinnig) bei den Rechnungsposten bin ich weniger sicher, das sollte noch geprüft werden .. letztendlich ist zu klären, ob die Validierungen so kommen sollen. Zudem müssten man, wenn das so umgsetzt werden soll, noch einiges an specs geradeziehen.

Zudem ist mir noch folgendes augefallen:

- Rechnung auf Gruppe erstellen (erzeugt Sammelrechnung und Einzelrechnungen (die aber nur unter Sammelrechnung aufscheinen), ich denke das ist das normale Feature)
- Rechnung auf Gruppe via gespeichertem Filter (verhält sich wie oben, ignoriert aber den Filter, für mich ein Bug)
- Rechnung auf Gruppe mit nicht gespeichertem Filter  (-> erstellt Einzelrechungen für die Personen falls unter 100 Rechnungen. Bei >100 sind die Rechnungsempfänger nicht richtig gesetzt -> Sammelrechnung mit 0 Empfänger. Ist das gewünscht?)

Fraglich ob wir das auch noch grade ziehen wollen
