### PR TITLE
Add different input_types to person filter

### DIFF
--- a/app/domain/person/filter/attributes.rb
+++ b/app/domain/person/filter/attributes.rb
@@ -111,10 +111,8 @@ class Person::Filter::Attributes < Person::Filter::Base
     case constraint.to_s
     when "match" then "LIKE"
     when "not_match" then "NOT LIKE"
-    when "greater" then ">"
-    when "smaller" then "<"
-    when "before" then "<"
-    when "after" then ">"
+    when "greater", "after" then ">"
+    when "smaller", "before" then "<"
     when "equal", "blank" then "="
     else raise("unexpected constraint: #{constraint.inspect}")
     end

--- a/app/domain/person/filter/attributes.rb
+++ b/app/domain/person/filter/attributes.rb
@@ -113,6 +113,8 @@ class Person::Filter::Attributes < Person::Filter::Base
     when "not_match" then "NOT LIKE"
     when "greater" then ">"
     when "smaller" then "<"
+    when "before" then "<"
+    when "after" then ">"
     when "equal", "blank" then "="
     else raise("unexpected constraint: #{constraint.inspect}")
     end
@@ -123,7 +125,7 @@ class Person::Filter::Attributes < Person::Filter::Base
     when "match", "not_match"
       "%#{ActiveRecord::Base.send(:sanitize_sql_like, value.to_s.strip)}%"
     when "blank" then ""
-    when "equal", "greater", "smaller" then value
+    when "equal", "greater", "smaller", "before", "after" then value
     else raise("unexpected constraint: #{constraint.inspect}")
     end
   end

--- a/app/helpers/people_filter_helper.rb
+++ b/app/helpers/people_filter_helper.rb
@@ -12,123 +12,21 @@ module PeopleFilterHelper
     Person.filter_attrs.transform_values { |v| v[:type] }.to_h.to_json
   end
 
-  def people_filter_attribute_forms(filter)
+  def people_filter_attribute_controls(filter)
     return unless filter
 
     filter.args.each_with_index.map do |(_k, attr), i|
-      people_filter_attribute_form(attr, i)
+      people_filter_attribute_control(attr, i)
     end.join.html_safe
   end
 
-  def people_filter_attribute_form_template
-    people_filter_attribute_form(nil, 0, disabled: :disabled)
+  def people_filter_attribute_control_template
+    people_filter_attribute_control(nil, 0, disabled: :disabled)
   end
 
-  def people_filter_attribute_form(attr, count, html_options = {}) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
-    key, constraint, value = attr.to_h.symbolize_keys.slice(:key, :constraint, :value).values
-    type = Person.filter_attrs[key.to_sym][:type] if key
-    time = (Time.zone.now.to_f * 1000).to_i + count
+  private
 
-    content_tag(:div,
-      class: 'people_filter_attribute_form d-flex align-items-center
-                        justify-content-between mb-2 controls controls-row') do
-      content = attribute_key_hidden_field(key, time, disabled: attr.blank?)
-      content << attribute_key_field(key, time, html_options)
-      content << attribute_constraint_field(key, constraint, type, time, html_options)
-
-      attribute_value_class = "#{(constraint == "blank") ? " invisible" : ""} attribute_value_input"
-      content << content_tag(:div, class: "col") do
-        if type
-          send(:"#{type}_field", time, attribute_value_class, value, html_options)
-        else
-          all_field_types(time, attribute_value_class, value, html_options)
-        end
-      end
-
-      content << link_to(icon(:"trash-alt", filled: false), "#",
-        class: "remove_filter_attribute col lh-lg ms-5")
-    end
-  end
-
-  def attribute_key_hidden_field(key, time, disabled: false)
-    hidden_field_tag("filters[attributes][#{time}][key]",
-      key,
-      disabled: disabled,
-      class: "attribute_key_hidden_field")
-  end
-
-  def attribute_key_field(key, time, html_options)
-    content_tag(:div, class: "col") do
-      select_tag("filters[attributes][#{time}][key]",
-        options_from_collection_for_select(people_filter_attributes_for_select, :last, :first, key),
-        html_options.merge(disabled: true,
-          class: 'attribute_key_dropdown form-select
-                                                form-select-sm'))
-    end
-  end
-
-  def attribute_constraint_field(key, constraint, type, time, html_options)
-    content_tag(:div, class: "col") do
-      select_tag("filters[attributes][#{time}][constraint]",
-        options_from_collection_for_select(constraint_options_for(type, key), :last, :first, constraint),
-        html_options.merge(class:
-                           'attribute_constraint_dropdown
-                                       ms-3 form-select form-select-sm'))
-    end
-  end
-
-  def all_field_types(time, attribute_value_class, value, html_options)
-    safe_join([
-      string_field(time, attribute_value_class, value, html_options),
-      country_select_field(time, attribute_value_class, value, html_options),
-      integer_field(time, attribute_value_class, value, html_options),
-      date_field(time, attribute_value_class, value, html_options),
-      gender_select_field(time, attribute_value_class, value, html_options)
-    ])
-  end
-
-  def constraint_options_for(type, key)
-    filters = [[t(".equal"), :equal], [t(".blank"), :blank]]
-    filters += [[t(".match"), :match], [t(".not_match"), :not_match]] if type == :string || key.blank?
-    filters += [[t(".smaller"), :smaller], [t(".greater"), :greater]] if type == :integer || key.blank?
-    filters += [[t(".before"), :before], [t(".after"), :after]] if type == :date || key.blank?
-    filters
-  end
-
-  ### FITLER FIELD TYPES
-
-  def string_field(time, attribute_value_class, value, html_options)
-    text_field_tag("filters[attributes][#{time}][value]",
-      value,
-      html_options.merge(class: "form-control form-control-sm string_field #{attribute_value_class}"))
-  end
-
-  def country_select_field(time, attribute_value_class, value, html_options)
-    country_select("filters[attributes][#{time}]",
-      "value",
-      {priority_countries: Settings.countries.prioritized,
-       selected: value,
-       include_blank: ""},
-      html_options.merge(class: "form-select form-select-sm country_select_field #{attribute_value_class}"))
-  end
-
-  def integer_field(time, attribute_value_class, value, html_options)
-    text_field_tag("filters[attributes][#{time}][value]",
-      value,
-      html_options.merge(class: "form-control form-control-sm integer_field #{attribute_value_class}", type: "number"))
-  end
-
-  def date_field(time, attribute_value_class, value, html_options)
-    text_field_tag("filters[attributes][#{time}][value]",
-      value,
-      html_options.merge(class: "form-control form-control-sm date date_field #{attribute_value_class}"))
-  end
-
-  def gender_select_field(time, attribute_value_class, value, html_options)
-    select("filters[attributes][#{time}][value]",
-      value,
-      (Person::GENDERS + [""]).collect { |g| [Person.new.gender_label(g), g] },
-      {},
-      html_options.merge(class: "form-select form-select-sm gender_select_field #{attribute_value_class}"))
+  def people_filter_attribute_control(attr, count, html_options = {})
+    Person::Filter::AttributeControl.new(self, attr, count, html_options).to_s
   end
 end

--- a/app/helpers/people_filter_helper.rb
+++ b/app/helpers/people_filter_helper.rb
@@ -29,51 +29,106 @@ module PeopleFilterHelper
     type = Person.filter_attrs[key.to_sym][:type] if key
     time = (Time.zone.now.to_f * 1000).to_i + count
 
-    filters = [[t(".equal"), :equal]]
-    if type != :integer && type != :date
-      filters += [[t(".match"), :match], [t(".not_match"), :not_match]]
-    end
-    if key.blank? || type == :integer || type == :date
-      filters += [[t(".smaller"), :smaller], [t(".greater"), :greater]]
-    end
-
-    filters += [[t(".blank"), :blank]]
-
     content_tag(:div,
       class: 'people_filter_attribute_form d-flex align-items-center
                         justify-content-between mb-2 controls controls-row') do
-      content = hidden_field_tag("filters[attributes][#{time}][key]",
-        key,
-        disabled: attr.blank?,
-        class: "attribute_key_hidden_field")
+      content = attribute_key_hidden_field(key, time, disabled: attr.blank?)
+      content << attribute_key_field(key, time, html_options)
+      content << attribute_constraint_field(key, constraint, type, time, html_options)
 
-      content << content_tag(:div, class: "flex-none") do
-        select_tag("filters[attributes][#{time}][key]",
-          options_from_collection_for_select(people_filter_attributes_for_select, :last, :first, key),
-          html_options.merge(disabled: true,
-            class: 'attribute_key_dropdown form-select
-                                                  form-select-sm'))
-      end
-
-      content << content_tag(:div, class: "flex-none") do
-        select_tag("filters[attributes][#{time}][constraint]",
-          options_from_collection_for_select(filters, :last, :first, constraint),
-          html_options.merge(class:
-                             'attribute_constraint_dropdown
-                                         ms-3 form-select form-select-sm'))
-      end
-
-      attribute_value_class = "form-control form-control-sm ms-3
-                               #{(constraint == "blank") ? " invisible" : ""}
-                               attribute_value_input #{(type == :date) ? " date" : ""}"
-      content << content_tag(:div, class: "flex-none") do
-        text_field_tag("filters[attributes][#{time}][value]",
-          value,
-          html_options.merge(class: attribute_value_class))
+      attribute_value_class = "#{(constraint == "blank") ? " invisible" : ""} attribute_value_input"
+      content << content_tag(:div, class: "col") do
+        if type
+          send(:"#{type}_field", time, attribute_value_class, value, html_options)
+        else
+          all_field_types(time, attribute_value_class, value, html_options)
+        end
       end
 
       content << link_to(icon(:"trash-alt", filled: false), "#",
-        class: "remove_filter_attribute flex-auto lh-lg ms-3")
+        class: "remove_filter_attribute col lh-lg ms-5")
     end
+  end
+
+  def attribute_key_hidden_field(key, time, disabled: false)
+    hidden_field_tag("filters[attributes][#{time}][key]",
+      key,
+      disabled: disabled,
+      class: "attribute_key_hidden_field")
+  end
+
+  def attribute_key_field(key, time, html_options)
+    content_tag(:div, class: "col") do
+      select_tag("filters[attributes][#{time}][key]",
+        options_from_collection_for_select(people_filter_attributes_for_select, :last, :first, key),
+        html_options.merge(disabled: true,
+          class: 'attribute_key_dropdown form-select
+                                                form-select-sm'))
+    end
+  end
+
+  def attribute_constraint_field(key, constraint, type, time, html_options)
+    content_tag(:div, class: "col") do
+      select_tag("filters[attributes][#{time}][constraint]",
+        options_from_collection_for_select(constraint_options_for(type, key), :last, :first, constraint),
+        html_options.merge(class:
+                           'attribute_constraint_dropdown
+                                       ms-3 form-select form-select-sm'))
+    end
+  end
+
+  def all_field_types(time, attribute_value_class, value, html_options)
+    safe_join([
+      string_field(time, attribute_value_class, value, html_options),
+      country_select_field(time, attribute_value_class, value, html_options),
+      integer_field(time, attribute_value_class, value, html_options),
+      date_field(time, attribute_value_class, value, html_options),
+      gender_select_field(time, attribute_value_class, value, html_options)
+    ])
+  end
+
+  def constraint_options_for(type, key)
+    filters = [[t(".equal"), :equal], [t(".blank"), :blank]]
+    filters += [[t(".match"), :match], [t(".not_match"), :not_match]] if type == :string || key.blank?
+    filters += [[t(".smaller"), :smaller], [t(".greater"), :greater]] if type == :integer || key.blank?
+    filters += [[t(".before"), :before], [t(".after"), :after]] if type == :date || key.blank?
+    filters
+  end
+
+  ### FITLER FIELD TYPES
+
+  def string_field(time, attribute_value_class, value, html_options)
+    text_field_tag("filters[attributes][#{time}][value]",
+      value,
+      html_options.merge(class: "form-control form-control-sm string_field #{attribute_value_class}"))
+  end
+
+  def country_select_field(time, attribute_value_class, value, html_options)
+    country_select("filters[attributes][#{time}]",
+      "value",
+      {priority_countries: Settings.countries.prioritized,
+       selected: value,
+       include_blank: ""},
+      html_options.merge(class: "form-select form-select-sm country_select_field #{attribute_value_class}"))
+  end
+
+  def integer_field(time, attribute_value_class, value, html_options)
+    text_field_tag("filters[attributes][#{time}][value]",
+      value,
+      html_options.merge(class: "form-control form-control-sm integer_field #{attribute_value_class}", type: "number"))
+  end
+
+  def date_field(time, attribute_value_class, value, html_options)
+    text_field_tag("filters[attributes][#{time}][value]",
+      value,
+      html_options.merge(class: "form-control form-control-sm date date_field #{attribute_value_class}"))
+  end
+
+  def gender_select_field(time, attribute_value_class, value, html_options)
+    select("filters[attributes][#{time}][value]",
+      value,
+      (Person::GENDERS + [""]).collect { |g| [Person.new.gender_label(g), g] },
+      {},
+      html_options.merge(class: "form-select form-select-sm gender_select_field #{attribute_value_class}"))
   end
 end

--- a/app/helpers/person/filter/attribute_control.rb
+++ b/app/helpers/person/filter/attribute_control.rb
@@ -1,0 +1,126 @@
+#  Copyright (c) 2012-2024, Schweizer Blasmusikverband. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class Person::Filter::AttributeControl
+  CONTROL_CLASSES = "form-control form-control-sm"
+
+  SELECT_CLASSES = "form-select form-select-sm"
+
+  delegate :select_tag, :hidden_field_tag, :text_field_tag, :options_from_collection_for_select, :country_select,
+    :select, :safe_join, :link_to, :content_tag, :t, :icon,
+    :people_filter_attributes_for_select, :people_filter_types_for_data_attribute, to: :template
+
+  # rubocop:disable Rails/HelperInstanceVariable
+  def initialize(template, attr, count, html_options = {})
+    @template = template
+    @attr = attr
+    @count = count
+    @html_options = html_options
+    @time = (Time.zone.now.to_f * 1000).to_i + count
+  end
+  # rubocop:enable Rails/HelperInstanceVariable
+
+  def to_s
+    key, constraint, value = attr.to_h.symbolize_keys.slice(:key, :constraint, :value).values
+    type = Person.filter_attrs[key.to_sym][:type] if key
+
+    content_tag(:div,
+      class: 'people_filter_attribute_form d-flex align-items-center
+                        justify-content-between mb-2 controls controls-row') do
+      content = attribute_key_hidden_field(key, time, disabled: attr.blank?)
+      content << attribute_key_field(key, time, html_options)
+      content << attribute_constraint_field(key, constraint, type, time, html_options)
+
+      attribute_value_class = "#{(constraint == "blank") ? " invisible" : ""} attribute_value_input"
+      content << content_tag(:div, class: "col") do
+        if type
+          send(:"#{type}_field", time, attribute_value_class, value, html_options)
+        else
+          all_field_types(time, attribute_value_class, value, html_options)
+        end
+      end
+
+      content << link_to(icon(:"trash-alt", filled: false), "#",
+        class: "remove_filter_attribute col lh-lg ms-5")
+    end
+  end
+
+  private
+
+  attr_reader :attr, :count, :template, :time, :html_options
+
+  def all_field_types(time, attribute_value_class, value, html_options)
+    safe_join([
+      string_field(time, attribute_value_class, value, html_options),
+      country_select_field(time, attribute_value_class, value, html_options),
+      integer_field(time, attribute_value_class, value, html_options),
+      date_field(time, attribute_value_class, value, html_options),
+      gender_select_field(time, attribute_value_class, value, html_options)
+    ])
+  end
+
+  def attribute_key_hidden_field(key, time, disabled: false)
+    hidden_field_tag("#{filter_name_prefix}[key]", key, disabled: disabled, class: "attribute_key_hidden_field")
+  end
+
+  def attribute_key_field(key, time, html_options)
+    content_tag(:div, class: "col") do
+      select_tag("#{filter_name_prefix}[key]",
+        options_from_collection_for_select(people_filter_attributes_for_select, :last, :first, key),
+        html_options.merge(disabled: true, class: "attribute_key_dropdown form-select form-select-sm"))
+    end
+  end
+
+  def attribute_constraint_field(key, constraint, type, time, html_options)
+    content_tag(:div, class: "col") do
+      select_tag("#{filter_name_prefix}[constraint]",
+        options_from_collection_for_select(constraint_options_for(type, key), :last, :first, constraint),
+        html_options.merge(class: "attribute_constraint_dropdown ms-3 form-select form-select-sm"))
+    end
+  end
+
+  def constraint_options_for(type, key)
+    filters = [[t(".equal"), :equal], [t(".blank"), :blank]]
+    filters += [[t(".match"), :match], [t(".not_match"), :not_match]] if type == :string || key.blank?
+    filters += [[t(".smaller"), :smaller], [t(".greater"), :greater]] if type == :integer || key.blank?
+    filters += [[t(".before"), :before], [t(".after"), :after]] if type == :date || key.blank?
+    filters
+  end
+
+  def string_field(time, attribute_value_class, value, html_options)
+    text_field_tag("#{filter_name_prefix}[value]",
+      value,
+      html_options.merge(class: "#{CONTROL_CLASSES} string_field #{attribute_value_class}"))
+  end
+
+  def country_select_field(time, attribute_value_class, value, html_options)
+    country_select(filter_name_prefix,
+      "value",
+      {priority_countries: Settings.countries.prioritized, selected: value, include_blank: ""},
+      html_options.merge(class: "form-select form-select-sm country_select_field #{attribute_value_class}"))
+  end
+
+  def integer_field(time, attribute_value_class, value, html_options)
+    text_field_tag("#{filter_name_prefix}[value]",
+      value,
+      html_options.merge(class: "#{CONTROL_CLASSES} integer_field #{attribute_value_class}", type: "number"))
+  end
+
+  def date_field(time, attribute_value_class, value, html_options)
+    text_field_tag("#{filter_name_prefix}[value]",
+      value,
+      html_options.merge(class: "#{CONTROL_CLASSES} date date_field #{attribute_value_class}"))
+  end
+
+  def gender_select_field(time, attribute_value_class, value, html_options)
+    select("#{filter_name_prefix}[value]",
+      value,
+      (Person::GENDERS + [""]).collect { |g| [Person.new.gender_label(g), g] },
+      {},
+      html_options.merge(class: "#{SELECT_CLASSES} gender_select_field #{attribute_value_class}"))
+  end
+
+  def filter_name_prefix = "filters[attributes][#{time}]"
+end

--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -162,6 +162,19 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
     end
   end
 
+  # Render a select dropdown for countries
+  def country_field(attr, html_options = {})
+    html_options[:class] = [
+      html_options[:class], "form-select", "form-select-sm", "tom-select"
+    ].compact.join(" ")
+    html_options[:data] = {placeholder: " ", chosen_no_results: I18n.t("global.chosen_no_results")}
+    country_select(attr,
+      {priority_countries: Settings.countries.prioritized,
+       selected: @object.nationality,
+       include_blank: ""},
+      html_options)
+  end
+
   def date_value(attr)
     # Can also be serialized column
     raw = @object.timeliness_cache_attribute(attr) if @object.is_a?(ActiveRecord::Base)

--- a/app/javascript/javascripts/modules/people/people_filter_attribute.js.coffee
+++ b/app/javascript/javascripts/modules/people/people_filter_attribute.js.coffee
@@ -43,12 +43,13 @@ app.PeopleFilterAttribute = {
     field = form.find('.attribute_key_hidden_field').attr('value')
     type  = form.closest('[data-types]').data('types')[field]
 
-    form.find('option[value=greater], option[value=smaller]').remove() unless (type == 'integer' || type == 'date')
-    form.find('option[value=match], option[value=not_match]').remove() if (type == 'integer' || type == 'date')
+    form.find('option[value=greater], option[value=smaller]').remove() unless (type == 'integer')
+    form.find('option[value=before], option[value=after]').remove() unless (type == 'date')
+    form.find('option[value=match], option[value=not_match]').remove() unless (type == 'string')
     form.find('.attribute_key_hidden_field').removeAttr('disabled')
     form.find('.attribute_constraint_dropdown').removeAttr('disabled')
-    form.find('.attribute_value_input').removeAttr('disabled')
-    form.find('.attribute_value_input').addClass('date') if type == 'date'
+    Array.from(form.find('.attribute_value_input:not(.' + type + '_field)')).forEach((element) => element.remove(););
+    form.find('.' + type + '_field').removeAttr('disabled')
 
   toggleValueVisibility: (e) ->
     input = $(e.target).closest(".people_filter_attribute_form").find(".attribute_value_input")

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -112,7 +112,7 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
 
   FILTER_ATTRS = [ # rubocop:disable Style/MutableConstant meant to be extended in wagons
     :first_name, :last_name, :nickname, :company_name, :email, :address_care_of, :street,
-    :housenumber, :postbox, :zip_code, :town, :country, :gender, [:years, :integer], :birthday
+    :housenumber, :postbox, :zip_code, :town, [:country, :country_select], [:gender, :gender_select], [:years, :integer], :birthday
   ]
 
   SEARCHABLE_ATTRS = [

--- a/app/views/people_filters/_attributes.html.haml
+++ b/app/views/people_filters/_attributes.html.haml
@@ -6,10 +6,10 @@
 - filter = entry.filter_chain[:attributes]
 
 .people_filter_attribute_form_template.d-none
-  = people_filter_attribute_form_template
+  = people_filter_attribute_control_template
 .control_group{data: { types: people_filter_types_for_data_attribute } }
   #people_filter_attribute_forms
-    = people_filter_attribute_forms(filter)
+    = people_filter_attribute_controls(filter)
 
   = select(:attribute, :filter, people_filter_attributes_for_select, { include_blank: "" }, { class: "form-select form-select-sm" })
 

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -1810,6 +1810,8 @@ de:
       equal: ist genau
       greater: grösser als
       smaller: kleiner als
+      before: vor dem
+      after: nach dem
       blank: ist leer
 
     language:

--- a/spec/domain/person/filter/attributes_spec.rb
+++ b/spec/domain/person/filter/attributes_spec.rb
@@ -336,7 +336,7 @@ describe Person::Filter::Attributes do
       end
 
       context "smaller" do
-        let(:constraint) { "smaller" }
+        let(:constraint) { "before" }
         let(:value) { 32.years.ago.to_date.to_s }
 
         it "returns people with matching attribute" do
@@ -346,7 +346,7 @@ describe Person::Filter::Attributes do
       end
 
       context "greater" do
-        let(:constraint) { "greater" }
+        let(:constraint) { "after" }
         let(:value) { 32.years.ago.to_date.to_s }
 
         it "returns people with matching attribute" do

--- a/spec/features/person/people_filter_spec.rb
+++ b/spec/features/person/people_filter_spec.rb
@@ -181,6 +181,26 @@ describe PeopleController, js: true do
       find(".attribute_constraint_dropdown option", text: "ist leer").click
       expect(page).not_to have_css ".attribute_value_input"
     end
+
+    it "has country select dropdown for country attrs" do
+      find("#attribute_filter option", text: "Land").click
+      expect(page).to have_css ".country_select_field"
+    end
+
+    it "has integer type field for number fields" do
+      find("#attribute_filter option", text: "Alter").click
+      expect(page).to have_css ".integer_field"
+    end
+
+    it "has date field for date attrs" do
+      find("#attribute_filter option", text: "Geburtstag").click
+      expect(page).to have_css ".date_field"
+    end
+
+    it "has gender field for gender attrs" do
+      find("#attribute_filter option", text: "Geschlecht").click
+      expect(page).to have_css ".gender_select_field"
+    end
   end
 
   def sign_in_and_create_filter

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -651,8 +651,8 @@ describe Person do
     expect(attrs[:postbox]).to eq(label: "Postfach", type: :string)
     expect(attrs[:zip_code]).to eq(label: "PLZ", type: :string)
     expect(attrs[:town]).to eq(label: "Ort", type: :string)
-    expect(attrs[:country]).to eq(label: "Land", type: :string)
-    expect(attrs[:gender]).to eq(label: "Geschlecht", type: :string)
+    expect(attrs[:country]).to eq(label: "Land", type: :country_select)
+    expect(attrs[:gender]).to eq(label: "Geschlecht", type: :gender_select)
     expect(attrs[:years]).to eq(label: "Alter", type: :integer)
 
     expect(Person.filter_attrs.count).to eq(Person::FILTER_ATTRS.count)


### PR DESCRIPTION
This pull request adds the option to have different input field types in person filter, the country_select is for https://github.com/hitobito/hitobito_swb/issues/20 but also just for the country attibute in core, that users dont have to match for "CH" in a string field, I also added an integer field, with type integer. Date and string fields still work the same.