### PR TITLE
Distinct people on invoice_list receiver

### DIFF
--- a/app/models/invoice_list.rb
+++ b/app/models/invoice_list.rb
@@ -75,15 +75,19 @@ class InvoiceList < ActiveRecord::Base
   end
 
   def recipient_ids_count
-    receiver ? receiver.people.unscope(:select).count : recipient_ids.count
+    receiver ? receiver_people.unscope(:select).count : recipient_ids.count
   end
 
   def first_recipient
-    receiver ? receiver.people.first : Person.find(recipient_ids.first)
+    receiver ? receiver_people.first : Person.find(recipient_ids.first)
   end
 
   def recipients
-    receiver ? receiver.people : Person.where(id: recipient_ids)
+    receiver ? receiver_people : Person.where(id: recipient_ids)
+  end
+
+  def receiver_people
+    receiver.people.distinct
   end
 
   def invoice_config

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -288,7 +288,7 @@ class Role < ActiveRecord::Base
   end
 
   def old_enough_to_archive?
-    (Time.zone.now - created_at) > Settings.role.minimum_days_to_archive.days
+    created_at < Settings.role.minimum_days_to_archive.days.ago
   end
 
   def prevent_changes

--- a/spec/domain/invoice/batch_create_spec.rb
+++ b/spec/domain/invoice/batch_create_spec.rb
@@ -36,6 +36,35 @@ describe Invoice::BatchCreate do
     expect(list.amount_paid).to eq 0
   end
 
+  it "#call creates invoices for group distinct people regardless of role count" do
+    group = groups(:bottom_layer_one)
+    group.invoices.destroy_all
+
+    Fabricate(Group::BottomLayer::Leader.sti_name.to_sym, person: other_person, group: group) # second role for other_person
+    2.times do
+      Fabricate(Group::BottomLayer::Member.sti_name.to_sym, group: group)
+    end
+    expect(group.roles.size).to eq(4)
+    expect(group.people.size).to eq(4) # people relation goes via roles and are currently not distinct
+
+    list = InvoiceList.create!(receiver: group, group: group, title: :title)
+
+    invoice = Invoice.new(title: "invoice", group: group)
+    invoice.invoice_items.build(name: "pens", unit_cost: 1.5)
+    invoice.invoice_items.build(name: "pins", unit_cost: 0.5, count: 2)
+    list.invoice = invoice
+
+    expect do
+      Invoice::BatchCreate.call(list)
+    end.to change { [group.invoices.count, group.invoice_items.count] }.by([3, 6])
+    expect(list.reload).to have(3).invoices
+    expect(list.receiver).to eq group
+    expect(list.recipients_total).to eq 3
+    expect(list.recipients_paid).to eq 0
+    expect(list.amount_total).to eq 7.5
+    expect(list.amount_paid).to eq 0
+  end
+
   it "#call offloads to job when recipients exceed limit" do
     Fabricate(Group::TopGroup::Leader.sti_name, group: groups(:top_group))
     Subscription.create!(mailing_list: mailing_list,


### PR DESCRIPTION
This prevents sending multiple invoices to a single person with multiple roles in group

Refs: hitobito/hitobito_sww#235