### PR TITLE
Spec'n'fix NilArrayCoder

### DIFF
--- a/app/domain/nil_array_coder.rb
+++ b/app/domain/nil_array_coder.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+#  Copyright (c) 2025-2025, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
 class NilArrayCoder
   def self.dump(object)
     object.to_json # Convert Ruby array to JSON string

--- a/app/domain/nil_array_coder.rb
+++ b/app/domain/nil_array_coder.rb
@@ -10,11 +10,10 @@ class NilArrayCoder
     object.to_json # Convert Ruby array to JSON string
   end
 
+  # Convert JSON or YAML string to array; rescue invalid data
   def self.load(data)
-    begin
-      YAML.parse(data).to_ruby.to_a # always return an array, even for nil
-    rescue
-      []
-    end # Convert JSON or YAML string to array; rescue invalid data
+    YAML.parse(data).to_ruby.to_a # always return an array, even for nil
+  rescue
+    []
   end
 end

--- a/app/domain/nil_array_coder.rb
+++ b/app/domain/nil_array_coder.rb
@@ -13,9 +13,9 @@ class NilArrayCoder
   def self.load(data)
     return [] if data.nil? # Handle NULL values from the database
     begin
-      JSON.parse(data)
+      YAML.parse(data).to_ruby
     rescue
       []
-    end # Convert JSON string to array; rescue invalid data
+    end # Convert JSON or YAML string to array; rescue invalid data
   end
 end

--- a/app/domain/nil_array_coder.rb
+++ b/app/domain/nil_array_coder.rb
@@ -11,9 +11,8 @@ class NilArrayCoder
   end
 
   def self.load(data)
-    return [] if data.nil? # Handle NULL values from the database
     begin
-      YAML.parse(data).to_ruby
+      YAML.parse(data).to_ruby.to_a # always return an array, even for nil
     rescue
       []
     end # Convert JSON or YAML string to array; rescue invalid data

--- a/spec/domain/nil_array_coder_spec.rb
+++ b/spec/domain/nil_array_coder_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025-2025, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+describe NilArrayCoder do
+  subject { described_class } # only class-methods
+
+  it "can dump nil" do
+    expect(subject.dump(nil)).to eql "null"
+  end
+
+  it "can dump an empty Array" do
+    expect(subject.dump([])).to eql "[]"
+  end
+
+  it "can dump a filled Array" do
+    expect(subject.dump(%w[street zip_code town])).to eql '["street","zip_code","town"]'
+  end
+
+  it "loads nil as an empty Array" do
+    expect(subject.load(nil)).to eql []
+  end
+
+  it "loads NULL from the DB as an empty Array" do
+    expect(subject.load(nil)).to eql []
+  end
+
+  it "loads JSON-null as an empty Array" do
+    expect(subject.load("null")).to eql []
+  end
+
+  it "can load an Array in YAML-Format" do
+    yaml_string = <<~YAML
+      ---
+      - street
+      - zip_code
+      - town
+
+    YAML
+
+    expect(subject.load(yaml_string)).to eql %w(street zip_code town)
+  end
+
+  it "can load an Array in JSON-Format" do
+    expect(subject.load('["street","zip_code","town"]')).to eql %w[street zip_code town]
+  end
+end

--- a/spec/domain/nil_array_coder_spec.rb
+++ b/spec/domain/nil_array_coder_spec.rb
@@ -43,7 +43,7 @@ describe NilArrayCoder do
 
     YAML
 
-    expect(subject.load(yaml_string)).to eql %w(street zip_code town)
+    expect(subject.load(yaml_string)).to eql %w[street zip_code town]
   end
 
   it "can load an Array in JSON-Format" do


### PR DESCRIPTION
The columns for required and hidden contact attributes in events are serialized with this Coder. Previously, rails stored the data as YAML, the coder handles the data as JSON.

Since YAML is a superset of JSON, we can just use YAML to read everything and store new values as JSON.

See #3252 