### PR TITLE
Remove case_insensitive_emails collation (#3153)

### DIFF
--- a/app/domain/people/duplicate_conditions.rb
+++ b/app/domain/people/duplicate_conditions.rb
@@ -50,7 +50,7 @@ class People::DuplicateConditions
     else
       "email = ?"
     end
-    args << attrs[:email]
+    args << attrs[:email]&.downcase
   end
 
   def parse_birthday

--- a/app/domain/person/filter/attributes.rb
+++ b/app/domain/person/filter/attributes.rb
@@ -94,14 +94,12 @@ class Person::Filter::Attributes < Person::Filter::Base
     else "people.#{key} #{sql_comparator(constraint)} ?"
     end
 
-    ActiveRecord::Base.sanitize_sql_array([sql_string, sql_value(value, constraint)])
+    ActiveRecord::Base.sanitize_sql_array([sql_string, sql_value(key, value, constraint)])
   end
 
   def match_search_sql(key, value, constraint)
     if value.is_a?(Numeric)
       "CAST(people.#{key} AS TEXT) #{sql_comparator(constraint)} ?"
-    elsif Person.columns_hash[key].collation == "case_insensitive_emails"
-      %(people.#{key} COLLATE "unicode" #{sql_comparator(constraint)} ?)
     else
       "people.#{key} #{sql_comparator(constraint)} ?"
     end
@@ -118,12 +116,12 @@ class Person::Filter::Attributes < Person::Filter::Base
     end
   end
 
-  def sql_value(value, constraint)
+  def sql_value(key, value, constraint)
     case constraint.to_s
     when "match", "not_match"
       "%#{ActiveRecord::Base.send(:sanitize_sql_like, value.to_s.strip)}%"
     when "blank" then ""
-    when "equal", "greater", "smaller", "before", "after" then value
+    when "equal", "greater", "smaller", "before", "after" then (key == "email") ? value.downcase : value
     else raise("unexpected constraint: #{constraint.inspect}")
     end
   end

--- a/app/domain/search_strategies/sql_condition_builder/matcher.rb
+++ b/app/domain/search_strategies/sql_condition_builder/matcher.rb
@@ -33,8 +33,6 @@ class SearchStrategies::SqlConditionBuilder
 
       if arel_column.type == :integer
         Arel::Nodes::SqlLiteral.new("#{table.name}." + "#{table[@field].name}::text")
-      elsif arel_column.collation == "case_insensitive_emails"
-        Arel::Nodes::SqlLiteral.new(%(#{table.name}.#{table[@field].name} COLLATE "unicode"))
       else
         table[@field]
       end

--- a/app/models/additional_email.rb
+++ b/app/models/additional_email.rb
@@ -33,6 +33,8 @@ class AdditionalEmail < ActiveRecord::Base
   # A dot at the end is invalid due to translation purpose
   validates :label, format: {without: /[.]$\z/}
 
+  normalizes :email, with: ->(attribute) { attribute.downcase }
+
   class << self
     def predefined_labels
       Settings.additional_email.predefined_labels

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -191,6 +191,8 @@ class Group < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   validates :logo, dimension: {width: {max: 8_000}, height: {max: 8_000}},
     content_type: ["image/jpeg", "image/gif", "image/png"]
 
+  normalizes :email, :self_registration_notification_email, with: ->(attribute) { attribute.downcase }
+
   scope :without_archived, -> { where(archived_at: nil) }
 
   ### CLASS METHODS

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -95,6 +95,8 @@ class Invoice < ActiveRecord::Base
   validates :invoice_items, presence: true, if: -> { (issued? || sent?) && !invoice_list }
   validate :assert_sendable?, unless: :recipient_id?
 
+  normalizes :recipient_email, with: ->(attribute) { attribute.downcase }
+
   before_create :set_recipient_fields, if: :recipient
   after_create :increment_sequence_number
 

--- a/app/models/invoice_config.rb
+++ b/app/models/invoice_config.rb
@@ -81,6 +81,8 @@ class InvoiceConfig < ActiveRecord::Base
 
   validates :reference_prefix, length: {minimum: 5, maximum: 7, allow_blank: true}
 
+  normalizes :email, with: ->(attribute) { attribute.downcase }
+
   accepts_nested_attributes_for :payment_reminder_configs, :payment_provider_configs
   accepts_nested_attributes_for :message_templates, allow_destroy: true
 

--- a/app/models/mail_log.rb
+++ b/app/models/mail_log.rb
@@ -44,6 +44,8 @@ class MailLog < ActiveRecord::Base
 
   validates :mail_hash, uniqueness: {case_sensitive: false}
 
+  normalizes :mail_from, with: ->(attribute) { attribute.downcase }
+
   scope :list, -> { order(updated_at: :desc) }
 
   before_update :update_message_state, if: :status_changed?

--- a/app/models/mailing_list.rb
+++ b/app/models/mailing_list.rb
@@ -74,6 +74,8 @@ class MailingList < ActiveRecord::Base
   validates :subscribable_for, inclusion: {in: SUBSCRIBABLE_FORS}
   validates :subscribable_mode, inclusion: {in: SUBSCRIBABLE_MODES}, if: :subscribable?
 
+  normalizes :additional_sender, with: ->(attribute) { attribute.downcase }
+
   after_destroy :schedule_mailchimp_destroy, if: :mailchimp?
   after_save :schedule_opt_in_cleanup, if: :opt_in?
 

--- a/app/models/message_recipient.rb
+++ b/app/models/message_recipient.rb
@@ -49,5 +49,7 @@ class MessageRecipient < ActiveRecord::Base
   validates_by_schema
   validates :state, inclusion: {in: STATES}, allow_nil: true
 
+  normalizes :email, with: ->(attribute) { attribute.downcase }
+
   scope :list, -> { order(:dispatched_at) }
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -277,6 +277,8 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
     content_type: ["image/jpeg", "image/gif", "image/png"]
   # more validations defined by devise
 
+  normalizes :email, :unconfirmed_email, with: ->(attribute) { attribute.downcase }
+
   ### CALLBACKS
 
   before_validation :override_blank_email

--- a/app/views/contactable/_additional_address_fields.html.haml
+++ b/app/views/contactable/_additional_address_fields.html.haml
@@ -1,0 +1,14 @@
+-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+%div.d-flex.flex-wrap.w-100.align-items-center
+  %div.col-11.col-md-11.col-lg-5.col-xl-5.col-xxl-4.me-3
+    = f.input_field(:housenumber,
+                    placeholder: ('.placeholder_value'))
+  %div.col-11.col-md-11.col-lg-5.col-xl-5.col-xxl-3.d-flex.flex-row.me-3.mt-1
+    = f.input_field(:translated_label,
+                    placeholder: ('.placeholder_type'),
+                    data: {provide: :typeahead, source: AdditionalEmail.available_labels})
+  = render 'contactable/public_check_box', f: f

--- a/db/migrate/20250409131142_remove_case_insensitve_collation.rb
+++ b/db/migrate/20250409131142_remove_case_insensitve_collation.rb
@@ -1,0 +1,52 @@
+class RemoveCaseInsensitveCollation < ActiveRecord::Migration[7.1]
+  def up
+    list_of_affected_search_columns.each do |table|
+      remove_column table, :search_column, if_exists: true
+    end
+
+    say_with_time "removing the collation from tables" do
+      list_of_email_columns.each do |table, column|
+        execute "ALTER TABLE #{table} ALTER COLUMN #{column} SET DATA TYPE varchar;"
+        execute "UPDATE #{table} SET #{column} = LOWER(#{column})"
+      end
+    end
+
+    say_with_time "dropping collation" do
+      execute "DROP COLLATION case_insensitive_emails;"
+    end
+  end
+
+  def down
+
+    say_with_time "creating collation" do
+      execute "CREATE COLLATION IF NOT EXISTS case_insensitive_emails (provider = icu, locale = 'und-u-ka-noignore-ks-level2', deterministic = false);"
+    end
+
+    say_with_time "setting the case-insensitive collation" do
+      list_of_email_columns.each do |table, column|
+        execute "ALTER TABLE #{table} ALTER COLUMN #{column} SET DATA TYPE varchar COLLATE case_insensitive_emails;"
+      end
+    end
+  end
+
+  private
+
+  def list_of_email_columns
+    [
+      [:additional_emails, :email],
+      [:groups, :email],
+      [:groups, :self_registration_notification_email],
+      [:invoice_configs, :email],
+      [:invoices, :recipient_email],
+      [:mail_logs, :mail_from],
+      [:mailing_lists, :additional_sender],
+      [:message_recipients, :email],
+      [:people, :email],
+      [:people, :unconfirmed_email],
+    ]
+  end
+
+  def list_of_affected_search_columns
+    [:additional_emails, :people, :groups]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_28_124658) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_09_131142) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  # Please do not delete this, the SQL schema does not know about this
-  # but the application and this schema needs it
-  execute "CREATE COLLATION IF NOT EXISTS case_insensitive_emails (provider = icu, deterministic = false, locale = 'und-u-ka-noignore-ks-level2');"
-
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -60,7 +55,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_28_124658) do
   create_table "additional_emails", id: :serial, force: :cascade do |t|
     t.string "contactable_type", null: false
     t.integer "contactable_id", null: false
-    t.string "email", null: false, collation: "case_insensitive_emails"
+    t.string "email", null: false
     t.string "label"
     t.boolean "public", default: true, null: false
     t.boolean "mailings", default: true, null: false
@@ -434,7 +429,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_28_124658) do
     t.string "name"
     t.string "short_name", limit: 31
     t.string "type", null: false
-    t.string "email", collation: "case_insensitive_emails"
+    t.string "email"
     t.integer "zip_code"
     t.string "town"
     t.string "country"
@@ -450,7 +445,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_28_124658) do
     t.text "description"
     t.datetime "archived_at", precision: nil
     t.string "self_registration_role_type"
-    t.string "self_registration_notification_email", collation: "case_insensitive_emails"
+    t.string "self_registration_notification_email"
     t.string "privacy_policy"
     t.string "nextcloud_url"
     t.boolean "main_self_registration_group", default: false, null: false
@@ -528,7 +523,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_28_124658) do
     t.text "beneficiary"
     t.text "payee"
     t.string "participant_number"
-    t.string "email", collation: "case_insensitive_emails"
+    t.string "email"
     t.string "vat_number"
     t.string "currency", default: "CHF", null: false
     t.integer "donation_calculation_year_amount"
@@ -580,7 +575,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_28_124658) do
     t.string "state", default: "draft", null: false
     t.string "esr_number", null: false
     t.text "description"
-    t.string "recipient_email", collation: "case_insensitive_emails"
+    t.string "recipient_email"
     t.text "recipient_address"
     t.date "sent_at"
     t.date "due_at"
@@ -645,7 +640,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_28_124658) do
   end
 
   create_table "mail_logs", id: :serial, force: :cascade do |t|
-    t.string "mail_from", collation: "case_insensitive_emails"
+    t.string "mail_from"
     t.string "mail_hash"
     t.integer "status", default: 0
     t.string "mailing_list_name"
@@ -662,7 +657,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_28_124658) do
     t.text "description"
     t.string "publisher"
     t.string "mail_name"
-    t.string "additional_sender", collation: "case_insensitive_emails"
+    t.string "additional_sender"
     t.boolean "subscribers_may_post", default: false, null: false
     t.boolean "anyone_may_post", default: false, null: false
     t.string "preferred_labels"
@@ -685,7 +680,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_28_124658) do
     t.bigint "message_id", null: false
     t.bigint "person_id"
     t.string "phone_number"
-    t.string "email", collation: "case_insensitive_emails"
+    t.string "email"
     t.text "address"
     t.datetime "created_at", precision: nil
     t.datetime "failed_at", precision: nil
@@ -881,7 +876,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_28_124658) do
     t.string "company_name"
     t.string "nickname"
     t.boolean "company", default: false, null: false
-    t.string "email", collation: "case_insensitive_emails"
+    t.string "email"
     t.string "zip_code"
     t.string "town"
     t.string "country"
@@ -915,7 +910,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_28_124658) do
     t.string "confirmation_token"
     t.datetime "confirmed_at", precision: nil
     t.datetime "confirmation_sent_at", precision: nil
-    t.string "unconfirmed_email", collation: "case_insensitive_emails"
+    t.string "unconfirmed_email"
     t.string "reset_password_sent_to"
     t.integer "two_factor_authentication"
     t.text "encrypted_two_fa_secret"

--- a/spec/api/people/index_spec.rb
+++ b/spec/api/people/index_spec.rb
@@ -34,5 +34,17 @@ RSpec.describe "people#index", type: :request do
         expect(response.body).to include("Unsupported include parameter")
       end
     end
+
+    describe "email matching" do
+      let(:params) { {filter: {email: {match: people(:top_leader).email}}} }
+
+      it "works" do
+        expect(PersonResource).to receive(:all).and_call_original
+        make_request
+        expect(response.status).to eq(200), response.body
+        expect(d.map(&:jsonapi_type).uniq).to match_array(["people"])
+        expect(d.map(&:id)).to match_array([people(:top_leader).id])
+      end
+    end
   end
 end

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -592,11 +592,11 @@ describe PeopleController do
           expect(emails.size).to eq(2)
           a = emails.first
           expect(a.label).to eq "Arbeit"
-          expect(a.email).to eq "Housi1@example.com"
+          expect(a.email).to eq "housi1@example.com"
           expect(a.public).to be_truthy
           tw = emails.second
           expect(tw.label).to eq "Mutter"
-          expect(tw.email).to eq "John@example.com"
+          expect(tw.email).to eq "john@example.com"
           expect(tw.public).to be_falsey
         end
       end

--- a/spec/domain/people/duplicate_conditions_spec.rb
+++ b/spec/domain/people/duplicate_conditions_spec.rb
@@ -59,6 +59,10 @@ describe People::DuplicateConditions do
       expect(build({email: "test"})).to eq ["email = ?", "test"]
     end
 
+    it "downcases email value if present if invalid" do
+      expect(build({email: "tESt"})).to eq ["email = ?", "test"]
+    end
+
     it "is combined with OR with other conditions" do
       expect(build({first_name: "first", email: "test"})).to eq ["(first_name = ?) OR email = ?", "first", "test"]
       expect(build({first_name: "first", email: "test", birthday: "2000-1-1"})).to eq ["(first_name = ? AND (birthday = ? OR birthday IS NULL)) OR email = ?", "first", Date.new(2000), "test"]

--- a/spec/models/additional_email_spec.rb
+++ b/spec/models/additional_email_spec.rb
@@ -70,6 +70,15 @@ describe AdditionalEmail do
     end
   end
 
+  describe "normalization" do
+    let(:add_email) { Fabricate(:additional_email, label: "Foo") }
+
+    it "downcases email" do
+      add_email.email = "TesTer@gMaiL.com"
+      expect(add_email.email).to eq "tester@gmail.com"
+    end
+  end
+
   context "#translated_label" do
     it "should return untranslated label as-is" do
       I18n.locale = :fr

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -599,6 +599,20 @@ describe Group do
     end
   end
 
+  describe "normalization" do
+    let(:group) { groups(:top_layer) }
+
+    it "downcases email" do
+      group.email = "TesTer@gMaiL.com"
+      expect(group.email).to eq "tester@gmail.com"
+    end
+
+    it "downcases self_registration_notification_email" do
+      group.self_registration_notification_email = "TesTer@gMaiL.com"
+      expect(group.self_registration_notification_email).to eq "tester@gmail.com"
+    end
+  end
+
   context "archived: " do
     subject(:archived_group) do
       groups(:bottom_group_one_two).tap { |g| g.update(archived_at: 1.day.ago) }

--- a/spec/models/invoice_config_spec.rb
+++ b/spec/models/invoice_config_spec.rb
@@ -172,6 +172,13 @@ describe InvoiceConfig do
     end
   end
 
+  describe "normalization" do
+    it "downcases email" do
+      invoice_config.email = "TesTer@gMaiL.com"
+      expect(invoice_config.email).to eq "tester@gmail.com"
+    end
+  end
+
   context "#logo_enabled?" do
     context "with logo attached" do
       before { invoice_config.logo.attach(fixture_file_upload("images/logo.png")) }

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -91,6 +91,14 @@ describe Invoice do
     expect(invoice.errors.full_messages).to include(/Rechnungsposten muss ausgefüllt werden/)
   end
 
+  describe "normalization" do
+    it "downcases recipient_email" do
+      invoice = create_invoice
+      invoice.recipient_email = "TesTer@gMaiL.com"
+      expect(invoice.recipient_email).to eq "tester@gmail.com"
+    end
+  end
+
   it "accepts that an invoice in state issued or sent has no items if  part of an invoice_list" do
     invoice = create_invoice
     invoice.update(invoice_list: InvoiceList.create!(group: group, title: "list"))

--- a/spec/models/mail_log_spec.rb
+++ b/spec/models/mail_log_spec.rb
@@ -27,6 +27,13 @@ describe MailLog do
     log
   end
 
+  describe "normalization" do
+    it "downcases mail_from" do
+      mail_log.mail_from = "TesTer@gMaiL.com"
+      expect(mail_log.mail_from).to eq "tester@gmail.com"
+    end
+  end
+
   context "mail=" do
     it "assigns bulk mail message" do
       log = MailLog.new

--- a/spec/models/mailing_list_spec.rb
+++ b/spec/models/mailing_list_spec.rb
@@ -118,6 +118,13 @@ describe MailingList do
     end
   end
 
+  describe "normalization" do
+    it "downcases additional_sender" do
+      list.additional_sender = "TesTer@gMaiL.com"
+      expect(list.additional_sender).to eq "tester@gmail.com"
+    end
+  end
+
   it "#subscribed? delegates to MailingLists::Subscribers" do
     create_subscription(person)
     expect_any_instance_of(MailingLists::Subscribers).to receive(:subscribed?)

--- a/spec/models/message_recipient_spec.rb
+++ b/spec/models/message_recipient_spec.rb
@@ -1,0 +1,17 @@
+#  Copyright (c) 2025, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+describe MessageRecipient do
+  let(:recipient) { Fabricate(:message_recipient) }
+
+  describe "normalization" do
+    it "downcases email" do
+      recipient.email = "TesTer@gMaiL.com"
+      expect(recipient.email).to eq "tester@gmail.com"
+    end
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -784,6 +784,20 @@ describe Person do
     end
   end
 
+  describe "normalization" do
+    let(:person) { people(:top_leader) }
+
+    it "downcases email" do
+      person.email = "TesTer@gMaiL.com"
+      expect(person.email).to eq "tester@gmail.com"
+    end
+
+    it "downcases email" do
+      person.unconfirmed_email = "TesTer@gMaiL.com"
+      expect(person.unconfirmed_email).to eq "tester@gmail.com"
+    end
+  end
+
   describe "invalid e-mail tags" do
     let(:person) { people(:top_leader) }
     let(:taggings) do


### PR DESCRIPTION
Downcasing all the current emails is still missing in the migration currently.