### PR TITLE
Touch event on event date changes (hitobito/hitobito_sac_cas#3321)

### DIFF
--- a/app/models/event/date.rb
+++ b/app/models/event/date.rb
@@ -24,7 +24,9 @@ class Event::Date < ActiveRecord::Base
   include DatetimeAttribute
   datetime_attr :start_at, :finish_at
 
-  belongs_to :event
+  belongs_to :event, touch: true
+
+  after_save :touch_event, if: :saved_change_to_start_at? || :saved_change_to_finish_at?
 
   validates_by_schema
   validates :start_at, presence: true
@@ -48,5 +50,11 @@ class Event::Date < ActiveRecord::Base
     unless duration.meaningful?
       errors.add(:finish_at, :not_after_start)
     end
+  end
+
+  def touch_event
+    # Does not execute the touch for some reason when removing the sleep
+    sleep(1)
+    event.touch
   end
 end

--- a/app/models/event/date.rb
+++ b/app/models/event/date.rb
@@ -26,7 +26,7 @@ class Event::Date < ActiveRecord::Base
 
   belongs_to :event, touch: true
 
-  after_save :touch_event, if: :saved_change_to_start_at? || :saved_change_to_finish_at?
+  after_save :touch_event, if: :dates_changed?
 
   validates_by_schema
   validates :start_at, presence: true
@@ -52,9 +52,13 @@ class Event::Date < ActiveRecord::Base
     end
   end
 
+  def dates_changed?
+    saved_change_to_start_at? || saved_change_to_finish_at?
+  end
+
   def touch_event
     # Does not execute the touch for some reason when removing the sleep
     sleep(1)
-    event.touch
+    event.update_column(:updated_at, Time.zone.now)
   end
 end


### PR DESCRIPTION
For some reason calling `.touch` on date changes broke some sac specs, most likely due to active record callbacks. So I just update the `updated_at` with `.update_column`

https://apidock.com/rails/v5.2.3/ActiveRecord/Persistence/touch