### PR TITLE
Check event invitations supported for layer_full permission as well

### DIFF
--- a/app/abilities/event_ability.rb
+++ b/app/abilities/event_ability.rb
@@ -33,7 +33,7 @@ class EventAbility < AbilityDsl::Base
     permission(:layer_full).may(:index_participations,
       :qualifications_read, :show)
       .in_same_layer
-    permission(:layer_full).may(:index_invitations).in_same_layer
+    permission(:layer_full).may(:index_invitations).in_same_layer_and_invitations_supported
     permission(:layer_full).may(:update, :create, :destroy, :application_market, :qualify,
       :manage_tags, :manage_attachments)
       .in_same_layer_if_active


### PR DESCRIPTION
Seems like the layer_full permission was missed when checking for supported invitations was introduced.