### PR TITLE
Do not validate each member on household update

### DIFF
--- a/app/controllers/households_controller.rb
+++ b/app/controllers/households_controller.rb
@@ -27,7 +27,7 @@ class HouseholdsController < ApplicationController
   def update
     assign_and_validate if params.key?(:member_ids)
 
-    if entry.save
+    if entry.save(context: :update_address)
       action = entry.members.empty? ? :destroy : action_name
       redirect_to parents, notice: success_message(action: action)
     else

--- a/app/models/household.rb
+++ b/app/models/household.rb
@@ -160,7 +160,7 @@ class Household
 
     # generate a fresh key if we don't have one yet
     @household_key ||= next_key
-    people.each { |person| person.update!(address_attrs.merge(household_key:)) }
+    people.each { |person| person.update_columns(address_attrs.merge(household_key:)) }
     # reload the reference_person as this is a different reference to the same person in `people`
     # which does not know the updated attributes yet.
     @reference_person.reload

--- a/spec/controllers/households_controller_spec.rb
+++ b/spec/controllers/households_controller_spec.rb
@@ -150,6 +150,13 @@ describe HouseholdsController do
       expect(person.reload.household_key).to be_nil
     end
 
+    it "does not raise error when some person in household is invalid" do
+      person.update_columns(first_name: nil, last_name: nil)
+      expect do
+        put :update, params: params.merge(member_ids: [person.id, bottom_member.id])
+      end.not_to raise_error
+    end
+
     describe "non writable person" do
       let(:group) { groups(:bottom_layer_one) }
       let(:bottom_leader) { Fabricate(Group::BottomLayer::Leader.sti_name, group: group).person }


### PR DESCRIPTION
https://sentry.puzzle.ch/pitc/hitobito-backend/issues/76103

```
people.each do |person|
      person.assign_attributes(address_attrs.merge(household_key:))

      # do not create paper trail version when address stayed the same
      if address_attrs.keys.any? { |key| person.attribute_changed?(key) }
        person.save(validate: false)
      end
end
```

Neues Ticket mit anderem Ansatz: https://github.com/hitobito/hitobito/issues/3390