### PR TITLE
Use event participation as model_class for participation exports (#3353)

### DIFF
--- a/app/domain/export/tabular/event/participations/table_displays.rb
+++ b/app/domain/export/tabular/event/participations/table_displays.rb
@@ -7,11 +7,15 @@
 
 module Export::Tabular::Event::Participations
   class TableDisplays < Export::Tabular::People::TableDisplays
-    self.model_class = ::Person
+    self.model_class = ::Event::Participation
     self.row_class = TableDisplayRow
 
     def public_account_labels(accounts, klass)
       account_labels(list.map(&:person).map(&accounts).flatten.select(&:public?), klass)
+    end
+
+    def human_attribute(attr)
+      Person.human_attribute_name(attr)
     end
   end
 end

--- a/spec/domain/export/tabular/people/table_displays_spec.rb
+++ b/spec/domain/export/tabular/people/table_displays_spec.rb
@@ -40,6 +40,10 @@ describe Export::Tabular::People::TableDisplays do
         :layer_group, :roles]
     end
 
+    it "model class is actually person" do
+      expect(people_list.class.model_class).to eq Person
+    end
+
     it "does not allow accessing unregistered columns" do
       table_display.selected = [:years]
       expect(people_list.labels.last).to eq "Rollen"
@@ -139,6 +143,10 @@ describe Export::Tabular::People::TableDisplays do
       should == [:first_name, :last_name, :nickname, :company_name, :company, :email,
         :address_care_of, :street, :housenumber, :postbox, :zip_code, :town, :country,
         :layer_group, :roles]
+    end
+
+    it "model class is actually participation" do
+      expect(people_list.class.model_class).to eq Event::Participation
     end
 
     it "includes additional person attributes if configured" do


### PR DESCRIPTION
We don't want person table attrs inside our participation query :exploding_head: 