### PR TITLE
Avoid empty translations by reusing the source

### DIFF
--- a/lib/release/highlevel.rb
+++ b/lib/release/highlevel.rb
@@ -43,7 +43,9 @@ module Release
       return unless translations_configured?
 
       notify "Pulling translation from transifex"
-      execute "tx pull -f"
+      # The mode sourceastranslation replaces missing translations
+      # with the source-string.
+      execute "tx pull -f --mode sourceastranslation"
       add "config/locales/*.yml"
 
       return unless translations_changed?

--- a/lib/tasks/transifex.rake
+++ b/lib/tasks/transifex.rake
@@ -39,7 +39,10 @@ namespace :tx do
   task :pull do
     # force pull because git locale file timestamps
     # will be newer than transifex files during rpm build.
-    TransifexHelper.with_tx { sh "tx pull -f" }
+    #
+    # The mode sourceastranslation replaces missing translations
+    # with the source-string
+    TransifexHelper.with_tx { sh "tx pull -f --mode sourceastranslation" }
   end
 
   # desc 'Save transifex credentials from env into .transifexrc'


### PR DESCRIPTION
The mode 'onlytranslated' omits reviewed translations. Therefore, we use the mode 'sourceastranslation' to avoid empty translations.