### PR TITLE
Allow for unicode in encrypted passwords

### DIFF
--- a/app/utils/encryption_service.rb
+++ b/app/utils/encryption_service.rb
@@ -27,7 +27,7 @@ class EncryptionService
       cipher.iv = base64_decode(iv)
       decrypted_data = cipher.update(base64_decode(encrypted_data))
       decrypted_data << cipher.final
-      decrypted_data.force_encoding('utf-8')
+      decrypted_data.force_encoding("utf-8")
     end
 
     private

--- a/app/utils/encryption_service.rb
+++ b/app/utils/encryption_service.rb
@@ -27,7 +27,7 @@ class EncryptionService
       cipher.iv = base64_decode(iv)
       decrypted_data = cipher.update(base64_decode(encrypted_data))
       decrypted_data << cipher.final
-      decrypted_data
+      decrypted_data.force_encoding('utf-8')
     end
 
     private

--- a/spec/models/payment_provider_config_spec.rb
+++ b/spec/models/payment_provider_config_spec.rb
@@ -39,12 +39,12 @@ describe PaymentProviderConfig do
   end
 
   it "encrypts password" do
-    postfinance_config.password = "password"
+    postfinance_config.password = "passwördli13!"
 
     expect(postfinance_config.encrypted_password[:encrypted_value]).to be_present
     expect(postfinance_config.encrypted_password[:iv]).to be_present
     expect(postfinance_config.encrypted_password[:encrypted_value]).to_not eq("password")
-    expect(postfinance_config.password).to eq("password")
+    expect(postfinance_config.password).to eq("passwördli13!")
 
     expect(postfinance_config.save).to be(true)
   end


### PR DESCRIPTION
Sentry: https://sentry.puzzle.ch/pitc/hitobito-backend/issues/76101

The decrypted value have an unknown encoding. As we only accept utf-8 for input-values, the resulting value (that we stored ourselves) needs be set to utf-8.