### PR TITLE
Do not display empty label table display columns

### DIFF
--- a/app/helpers/dropdown/table_displays.rb
+++ b/app/helpers/dropdown/table_displays.rb
@@ -36,10 +36,11 @@ module Dropdown
       options = {class: "dropdown-menu float-end", data: {turbo_permanent: true}, role: "menu"}
 
       content_tag(:ul, options) do
-        sorted = table_display.available(@list).sort_by { |c| table_display.column_for(c).label(c) }
-        items = sorted.collect do |column|
-          render_item("selected[]", table_display.column_for(column), column)
-        end
+        items = table_display
+          .available(@list)
+          .select { |c| table_display.column_for(c).label(c) }
+          .sort_by { |c| table_display.column_for(c).label(c) }
+          .map { |column| render_item("selected[]", table_display.column_for(column), column) }
 
         safe_join(items)
       end


### PR DESCRIPTION
https://sentry.puzzle.ch/pitc/hitobito-backend/issues/75649

Basically this error is possible when the event has an event question with an empty (nil) question. I would say we don't want to display those questions in the table displays