### PR TITLE
bug/2274-delete-tags

### DIFF
--- a/spec/controllers/person/tags_controller_spec.rb
+++ b/spec/controllers/person/tags_controller_spec.rb
@@ -166,6 +166,24 @@ describe Person::TagsController do
       expect(bottom_member.tags.count).to eq(0)
       is_expected.to redirect_to group_person_path(bottom_member.groups.first, bottom_member)
     end
+
+    let!(:test_tag) { ActsAsTaggableOn::Tag.create!(name: "Test") }
+    let!(:test_tagging) { ActsAsTaggableOn::Tagging.create!(tag_id: test_tag.id, taggable_type: "Person", taggable_id: bottom_member.id, context: "tags") }
+    let!(:subscription_tag) { SubscriptionTag.create!(excluded: false, subscription_id: Subscription.first.id, tag_id: test_tag.id) }
+
+    it "does delete tag if no other person uses it" do
+      expect do
+        delete :destroy, params: {
+          group_id: bottom_member.groups.first.id,
+          person_id: bottom_member.id,
+          name: test_tag.name
+        }
+      end
+        .not_to raise_error
+
+      expect(bottom_member.tags.count).to eq(0)
+      is_expected.to redirect_to group_person_path(bottom_member.groups.first, bottom_member)
+    end
   end
 
   private

--- a/spec/controllers/person/tags_controller_spec.rb
+++ b/spec/controllers/person/tags_controller_spec.rb
@@ -8,7 +8,6 @@ require "spec_helper"
 describe Person::TagsController do
   let(:top_leader) { people(:top_leader) }
   let(:bottom_member) { people(:bottom_member) }
-  let(:top_leader) { people(:top_leader) }
 
   before { sign_in(top_leader) }
 
@@ -172,7 +171,7 @@ describe Person::TagsController do
       is_expected.to redirect_to group_person_path(bottom_member.groups.first, bottom_member)
     end
 
-    it "does delete tag if no other person uses it" do
+    it "does not raise error when last taggable association of tag was deleted" do
       expect do
         delete :destroy, params: {
           group_id: top_leader.groups.first.id,
@@ -181,9 +180,6 @@ describe Person::TagsController do
         }
       end
         .not_to raise_error
-
-      expect(top_leader.tags.count).to eq(0)
-      is_expected.to redirect_to group_person_path(top_leader.groups.first, top_leader)
     end
   end
 

--- a/spec/controllers/person/tags_controller_spec.rb
+++ b/spec/controllers/person/tags_controller_spec.rb
@@ -135,6 +135,10 @@ describe Person::TagsController do
   end
 
   describe "DELETE #destroy" do
+    let!(:subscription_tag) { SubscriptionTag.create!(excluded: false, subscription_id: Subscription.first.id, tag_id: test_tag.id) }
+    let!(:test_tagging) { ActsAsTaggableOn::Tagging.create!(tag_id: test_tag.id, taggable_type: "Person", taggable_id: bottom_member.id, context: "tags") }
+    let!(:test_tag) { ActsAsTaggableOn::Tag.create!(name: "Test") }
+
     it "deletes person taggging/assignment" do
       bottom_member.tag_list.add("lorem")
       bottom_member.save!
@@ -166,10 +170,6 @@ describe Person::TagsController do
       expect(bottom_member.tags.count).to eq(0)
       is_expected.to redirect_to group_person_path(bottom_member.groups.first, bottom_member)
     end
-
-    let!(:test_tag) { ActsAsTaggableOn::Tag.create!(name: "Test") }
-    let!(:test_tagging) { ActsAsTaggableOn::Tagging.create!(tag_id: test_tag.id, taggable_type: "Person", taggable_id: bottom_member.id, context: "tags") }
-    let!(:subscription_tag) { SubscriptionTag.create!(excluded: false, subscription_id: Subscription.first.id, tag_id: test_tag.id) }
 
     it "does delete tag if no other person uses it" do
       expect do

--- a/spec/controllers/person/tags_controller_spec.rb
+++ b/spec/controllers/person/tags_controller_spec.rb
@@ -8,6 +8,7 @@ require "spec_helper"
 describe Person::TagsController do
   let(:top_leader) { people(:top_leader) }
   let(:bottom_member) { people(:bottom_member) }
+  let(:top_leader) { people(:top_leader) }
 
   before { sign_in(top_leader) }
 
@@ -136,7 +137,7 @@ describe Person::TagsController do
 
   describe "DELETE #destroy" do
     let!(:subscription_tag) { SubscriptionTag.create!(excluded: false, subscription_id: Subscription.first.id, tag_id: test_tag.id) }
-    let!(:test_tagging) { ActsAsTaggableOn::Tagging.create!(tag_id: test_tag.id, taggable_type: "Person", taggable_id: bottom_member.id, context: "tags") }
+    let!(:test_tagging) { ActsAsTaggableOn::Tagging.create!(tag_id: test_tag.id, taggable_type: "Person", taggable_id: top_leader.id, context: "tags") }
     let!(:test_tag) { ActsAsTaggableOn::Tag.create!(name: "Test") }
 
     it "deletes person taggging/assignment" do
@@ -174,15 +175,15 @@ describe Person::TagsController do
     it "does delete tag if no other person uses it" do
       expect do
         delete :destroy, params: {
-          group_id: bottom_member.groups.first.id,
-          person_id: bottom_member.id,
+          group_id: top_leader.groups.first.id,
+          person_id: top_leader.id,
           name: test_tag.name
         }
       end
         .not_to raise_error
 
-      expect(bottom_member.tags.count).to eq(0)
-      is_expected.to redirect_to group_person_path(bottom_member.groups.first, bottom_member)
+      expect(top_leader.tags.count).to eq(0)
+      is_expected.to redirect_to group_person_path(top_leader.groups.first, top_leader)
     end
   end
 

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -93,10 +93,6 @@ describe TagsController do
   describe "DELETE #destroy" do
     let!(:tag) { ActsAsTaggableOn::Tag.create!(name: "supertag42", taggings_count: 4200) }
 
-    let!(:test_tag) { ActsAsTaggableOn::Tag.create!(name: "Test", taggings_count: 1) }
-    let!(:test_tagging) { ActsAsTaggableOn::Tagging.create!(tag_id: test_tag.id, taggable_type: "Person", taggable_id: top_leader.id, context: "tags") }
-    let!(:subscription_tag) { SubscriptionTag.create!(excluded: false, subscription_id: Subscription.first.id, tag_id: test_tag.id) }
-
     it "deletes given tag" do
       expect do
         delete :destroy, params: {id: tag.id}
@@ -112,10 +108,6 @@ describe TagsController do
         end.to change { ActsAsTaggableOn::Tag.count }.by(0)
           .and raise_error(CanCan::AccessDenied)
       end
-    end
-
-    it "deletes tag connected to supscription tag" do
-      expect { delete :destroy, params: {id: test_tag.id} }.not_to raise_error
     end
   end
 end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -93,6 +93,10 @@ describe TagsController do
   describe "DELETE #destroy" do
     let!(:tag) { ActsAsTaggableOn::Tag.create!(name: "supertag42", taggings_count: 4200) }
 
+    let!(:test_tag) { ActsAsTaggableOn::Tag.create!(name: "Test", taggings_count: 1) }
+    let!(:test_tagging) { ActsAsTaggableOn::Tagging.create!(tag_id: test_tag.id, taggable_type: "Person", taggable_id: top_leader.id, context: "tags") }
+    let!(:subscription_tag) { SubscriptionTag.create!(excluded: false, subscription_id: Subscription.first.id, tag_id: test_tag.id) }
+
     it "deletes given tag" do
       expect do
         delete :destroy, params: {id: tag.id}
@@ -108,6 +112,10 @@ describe TagsController do
         end.to change { ActsAsTaggableOn::Tag.count }.by(0)
           .and raise_error(CanCan::AccessDenied)
       end
+    end
+
+    it "deletes tag connected to supscription tag" do
+      expect { delete :destroy, params: { id: test_tag.id } }.not_to raise_error
     end
   end
 end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -115,7 +115,7 @@ describe TagsController do
     end
 
     it "deletes tag connected to supscription tag" do
-      expect { delete :destroy, params: { id: test_tag.id } }.not_to raise_error
+      expect { delete :destroy, params: {id: test_tag.id} }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Bug ist nicht mehr relevant durch die Änderung: https://github.com/hitobito/hitobito/blob/bdbd4b7a73420b87df38266ebe287e89a65d6c50/config/initializers/acts_as_taggable_on.rb#L7

Siehe: https://github.com/mbleigh/acts-as-taggable-on/blob/master/lib/acts-as-taggable-on/tagging.rb

Durch das Setzen von `ActsAsTaggableOn.remove_unused_tags = false` wird das Tag nach dem Entfernen des letzten Taggings nicht mehr gelöscht.

Zur Überprüfung dieses Verhaltens wurde ein Test hinzugefügt.

Fixes: #2274 