### PR TITLE
Return false for group_read_in_this_group? when group is not set

### DIFF
--- a/app/abilities/person_readables.rb
+++ b/app/abilities/person_readables.rb
@@ -92,6 +92,8 @@ class PersonReadables < GroupBasedReadables
   end
 
   def group_read_in_this_group?
+    return false unless group
+
     permission_group_ids(:group_read).include?(group.id)
   end
 


### PR DESCRIPTION
Sentry Issue: https://sentry.puzzle.ch/pitc/hitobito-backend/issues/75718/

GLP checks this method in some extra call for `donor_visible?` expecting the group to be set, the search is global tho and not group based so in the case of the group not being set we return false