### PR TITLE
Restore: quote strings for inserts

### DIFF
--- a/lib/tasks/restore.rake
+++ b/lib/tasks/restore.rake
@@ -248,7 +248,10 @@ namespace :restore do
         values = attrs.values.map do |val|
           case val
           when NilClass then "NULL"
-          when String, Time then "'#{val.inspect.delete_prefix('"').delete_suffix('"')}'"
+          when String, Time
+            object.class.connection.quote(
+              val.inspect.delete_prefix('"').delete_suffix('"')
+            )
           else val
           end
         end

--- a/lib/tasks/restore.rake
+++ b/lib/tasks/restore.rake
@@ -245,7 +245,7 @@ namespace :restore do
         attrs = object.attributes_before_type_cast.slice(*db_columns).except("search_column")
 
         columns = attrs.keys
-        values = attrs.values.map do |val|
+        values = attrs.map do |_key, val|
           case val
           when NilClass then "NULL"
           when String, Time


### PR DESCRIPTION
This helps mostly with french content as strings in postgres are being single-quoted.