### PR TITLE
Remove maybe unneeded code

### DIFF
--- a/app/domain/mailing_lists/subscribers.rb
+++ b/app/domain/mailing_lists/subscribers.rb
@@ -26,7 +26,7 @@ class MailingLists::Subscribers
   end
 
   def subscribed?(person)
-    subscribed = people_as_configured.where(id: person.id).exists? && unfiltered_people_as_configured.present?
+    subscribed = people_as_configured.where(id: person.id).exists?
     return subscribed unless opt_in? && subscribable_for_configured?
 
     subscribed && subscriptions.people.where(id: person.id).exists?


### PR DESCRIPTION
If this is not needed (as defined by spec-coverage), this removal would allow a the subscriber-exclusion to work on huge mailing_lists again.