### PR TITLE
Automate running all wagon tests on core changes #3442

### DIFF
--- a/.github/workflows/run-all-wagon-tests.yml
+++ b/.github/workflows/run-all-wagon-tests.yml
@@ -1,0 +1,86 @@
+name: 'Run the tests in all wagons with a specific core revision'
+
+on:
+  workflow_dispatch:
+    inputs:
+      core_ref:
+        description: Use a specific version of the core for the workflow run. Defaults to master.
+        default: ""
+      wagon_dependency_ref:
+        description: Use a specific version of the wagon dependency for the workflow run. Defaults to master.
+        default: ""
+      wagon_ref:
+        description: Use a specific version of the wagon dependency for the workflow run. Defaults to master.
+        default: "master"
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+  secrets:
+    WAGON_TESTS_GITHUB_TOKEN:
+      description: 'Token with repo and actions:read and actions:write for running the tests in all wagon repos'
+      required: true
+
+jobs:
+  find-wagons:
+    name: 'Find all Puzzle-managed wagons'
+    runs-on: 'ubuntu-latest'
+    outputs:
+      wagons: ${{ steps.list-wagon-repositories.outputs.wagons }}
+
+    steps:
+      - name: 'List wagon repositories'
+        id: list-wagon-repositories
+        run: |
+          WAGONS=$(gh repo list hitobito -L 100 --no-archived --json owner,name | \
+            jq 'map(select(.name | test("^hitobito_"))) | map({ owner: .owner.login, repo: .name, name: .name | match("^hitobito_(.+)$").captures[0].string })')
+          echo "wagons=$WAGONS" | tr -d "\n" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.WAGON_TESTS_GITHUB_TOKEN }}
+
+  run-wagon-tests:
+    name: 'Run ${{ matrix.wagon.name }} wagon tests'
+    runs-on: 'ubuntu-latest'
+    needs:
+      - find-wagons
+    strategy:
+      fail-fast: false
+      matrix:
+        wagon: ${{ fromJSON(needs.find-wagons.outputs.wagons) }}
+    steps:
+      - run: echo $JSON
+        env:
+          JSON: |
+            {
+              "core_ref": "${{ inputs.core_ref || github.ref || 'master' }}",
+              "wagon_dependency_ref": "${{ inputs.wagon_dependency_ref || 'master' }}"
+            }
+
+      - name: Trigger ${{ matrix.wagon.name }} wagon tests
+        uses: Codex-/return-dispatch@v2
+        id: run-wagon-tests
+        with:
+          token: ${{ secrets.WAGON_TESTS_GITHUB_TOKEN }}
+          repo: ${{ matrix.wagon.repo }}
+          owner: ${{ matrix.wagon.owner }}
+          ref: master
+          workflow: tests.yml
+          workflow_inputs: |
+            {
+              "core_ref": "${{ inputs.core_ref || github.ref || 'master' }}",
+              "wagon_dependency_ref": "${{ inputs.wagon_dependency_ref || 'master' }}"
+            }
+      - name: Wait for ${{ matrix.wagon.name }} wagon tests result
+        uses: Codex-/await-remote-run@v1.0.0
+        with:
+          token: ${{ secrets.WAGON_TESTS_GITHUB_TOKEN }}
+          repo: ${{ matrix.wagon.repo }}
+          owner: ${{ matrix.wagon.owner }}
+          run_id: ${{ steps.run-wagon-tests.outputs.run_id }}
+          run_timeout_seconds: 21600 # wait for up to 6 hours
+          poll_interval_ms: 5000 # poll every 5 seconds

--- a/.github/workflows/run-all-wagon-tests.yml
+++ b/.github/workflows/run-all-wagon-tests.yml
@@ -17,10 +17,12 @@ on:
     paths-ignore:
       - 'doc/**'
       - '**.md'
+      - 'VERSION'
   pull_request:
     paths-ignore:
       - 'doc/**'
       - '**.md'
+      - 'VERSION'
   secrets:
     WAGON_TESTS_GITHUB_TOKEN:
       description: 'Token with repo and actions:read and actions:write for running the tests in all wagon repos'

--- a/.github/workflows/run-all-wagon-tests.yml
+++ b/.github/workflows/run-all-wagon-tests.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           WAGONS=$(gh repo list hitobito -L 100 --no-archived --json owner,name | \
             jq 'map(select(.name | test("^hitobito_"))) | map({ owner: .owner.login, repo: .name, name: .name | match("^hitobito_(.+)$").captures[0].string })')
+          echo $WAGONS
           echo "wagons=$WAGONS" | tr -d "\n" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.WAGON_TESTS_GITHUB_TOKEN }}
@@ -55,14 +56,6 @@ jobs:
       matrix:
         wagon: ${{ fromJSON(needs.find-wagons.outputs.wagons) }}
     steps:
-      - run: echo $JSON
-        env:
-          JSON: |
-            {
-              "core_ref": "${{ inputs.core_ref || github.ref || 'master' }}",
-              "wagon_dependency_ref": "${{ inputs.wagon_dependency_ref || 'master' }}"
-            }
-
       - name: Trigger ${{ matrix.wagon.name }} wagon tests
         uses: Codex-/return-dispatch@v2
         id: run-wagon-tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,10 +7,12 @@ on:
     paths-ignore:
       - 'doc/**'
       - '**.md'
+      - 'VERSION'
   pull_request:
     paths-ignore:
       - 'doc/**'
       - '**.md'
+      - 'VERSION'
 
 jobs:
   rubocop:


### PR DESCRIPTION
Before merging, this needs slight modifications to the tests.yml workflows in each wagon, i.e. add a distinct_id parameter and pass it to the reusable workflow, and also accept the wagon_dependency_ref parameter, even if it is unused.
- [x] [youth](https://github.com/hitobito/hitobito_youth/commit/5ee3927560c890e169597e6e0f3e39334d77a638)
- [x] [pbs](https://github.com/hitobito/hitobito_pbs/commit/62d49bc90bfb0bb2b4d262aa809700c0f8bbe517)
- [x] all other wagons
- [x] Remove the nightly trigger for running all wagon tests (have to do this in all wagons too)

To test this new workflow locally, I used the [act](https://nektosact.com/) plugin for github CLI:
```bash
# One-time setup
gh extension install https://github.com/nektos/gh-act
docker pull catthehacker/ubuntu:full-latest # caution: takes up a lot of disk space!

# Run this to test the workflow
gh act push -P ubuntu-latest=catthehacker/ubuntu:full-latest --pull=false -W .github/workflows/run-all-wagon-tests.yml -s WAGON_TESTS_GITHUB_TOKEN=github_pat_<redacted>
```