### PR TITLE
Populate translations of derived questions in events_controller

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -236,7 +236,18 @@ class EventsController < CrudController
   def assign_attributes
     assign_contact_attrs
     assign_visible_contact_attrs
-    super
+    super.tap do |attrs|
+      assign_global_question_translations
+    end
+  end
+
+  # NOTE - as form only sends translations for current locale, we manually add other translations
+  def assign_global_question_translations
+    (entry.admin_questions + entry.application_questions).select(&:derived?).each do |q|
+      template = Event::Question.find(q.derived_from_question_id)
+      q.question_translations = template.question_translations
+      q.choices_translations = template.choices_translations
+    end
   end
 
   def assign_contact_attrs

--- a/spec/fixtures/event/question_translations.yml
+++ b/spec/fixtures/event/question_translations.yml
@@ -48,6 +48,14 @@ ga_de:
   created_at: <%= Time.zone.now %>
   updated_at: <%= Time.zone.now %>
 
+ga_fr:
+  event_question_id: <%= ActiveRecord::FixtureSet.identify(:ga) %>
+  locale: fr
+  question: J'ai l'abonnement de transports publics suivant
+  choices: AG, demi-tarif / moins de 16 ans, pas de réduction
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>
+
 vegi_de:
   event_question_id: <%= ActiveRecord::FixtureSet.identify(:vegi) %>
   locale: de

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -501,12 +501,31 @@ describe Event do
   end
 
   describe "#init_questions" do
+    let(:global_questions) { Event::Question.global }
+
     it "adds 3 default questions" do
       e = Event.new
       e.init_questions
-      global_questions = Event::Question.global
       expect(global_questions.size).to eq(3)
       expect(e.application_questions.size).to eq(global_questions.size)
+    end
+
+    it "adds default questions with available translations" do
+      e = Fabricate.build(:event, dates_attributes: [{start_at: Time.zone.today}])
+      e.init_questions
+      e.save!
+
+      q = e.questions.find_by(derived_from_question_id: event_questions(:ga).id)
+
+      expect(q.question_translations).to eq({
+        "de" => "Ich habe folgendes ÖV Abo",
+        "fr" => "J'ai l'abonnement de transports publics suivant"
+      })
+
+      expect(q.choices_translations).to eq({
+        "de" => "GA, Halbtax / unter 16, keine Vergünstigung",
+        "fr" => "AG, demi-tarif / moins de 16 ans, pas de réduction"
+      })
     end
   end
 


### PR DESCRIPTION
Bis wir eine Lösung fürs UI haben befülllen wir die Übersetzungen manuell im controller

refs hitobito/hitobito_swb#74