### PR TITLE
Add tests for nil primary_group

### DIFF
--- a/spec/domain/table_displays/people/primary_group_column_spec.rb
+++ b/spec/domain/table_displays/people/primary_group_column_spec.rb
@@ -25,4 +25,36 @@ describe TableDisplays::People::PrimaryGroupColumn, type: :helper do
     value: "TopGroup",
     permission: :show
   }
+
+  context "when the person has no primary group set" do
+    subject(:display) { described_class.new(ability, table: table, model_class: Person) }
+
+    subject(:node) { Capybara::Node::Simple.new(table.to_html) }
+
+    before do
+      allow(table).to receive(:template).at_least(:once).and_return(view)
+      person.update_column(:primary_group_id, nil)
+    end
+
+    it "view renders nothing as value" do
+      display.render(:primary_group_id)
+      expect(node.find("td").all("*").length).to eq 0
+      expect(node.find("td").text).to eq ""
+    end
+
+    it "export uses empty value if person has no primary group set" do
+      expect(resolve_export_value(:primary_group_id).to_s).to eq("")
+    end
+  end
+
+  # helper method to imitate resolving of attr usually done in TableDisplayRow
+  def resolve_export_value(column)
+    display.value_for(person.object, column) do |target, target_attr|
+      if respond_to?(target_attr, true)
+        send(target_attr)
+      elsif target.respond_to?(target_attr)
+        target.public_send(target_attr)
+      end
+    end
+  end
 end


### PR DESCRIPTION
One example how to get an empty primary_group is when someone signs up to an external event. This person then has no roles, hence the primary_group is not set.
There must be some other cases though, since this happened when displaying a person list of a group, i.e. the people all have at least one role.
Refs https://sentry.puzzle.ch/pitc/hitobito-backend/issues/76687/?query=is%3Aunresolved%20is%3Aunassigned