### PR TITLE
Run the wagon tests directly in the core

### DIFF
--- a/.github/workflows/run-all-wagon-tests.yml
+++ b/.github/workflows/run-all-wagon-tests.yml
@@ -52,7 +52,6 @@ jobs:
 
   run-wagon-tests:
     name: 'Run ${{ matrix.wagon.name }} wagon tests'
-    runs-on: 'ubuntu-latest'
     needs:
       - find-wagons
     strategy:
@@ -60,27 +59,12 @@ jobs:
       matrix:
         wagon: ${{ fromJSON(needs.find-wagons.outputs.wagons) }}
       max-parallel: 5 # needed so we don't occupy all the runners with core waiting jobs and the wagon tests can never start
-    # steps:
-    #   - name: "Determine common branch and set branch name for wagon"
-    #     env:
-    #       INPUT_WAGON_REF: ${{ inputs.wagon_ref }}
-    #     run: |
-    #       COMMON_BRANCH_NAME="${{github.head_ref || github.ref_name}}"
-    #       if [ -z "$INPUT_WAGON_REF" ]; then
-    #         WAGON_REF=$(git ls-remote --heads https://github.com/${{matrix.wagon.owner}}/${{matrix.wagon.repo}} | cut -d/ -f3- | grep -x "$COMMON_BRANCH_NAME" || echo 'master')
-    #       fi
-    #
-    #       echo "WAGON_REF=$WAGON_REF" >> $GITHUB_ENV
-    #     shell: bash
-    #
-    #  core_ref: env.WAGON_REF
-    #  wagon_dependency_ref: env.WAGON_REF
 
     uses: hitobito/hitobito/.github/workflows/wagon-tests.yml@master
     with:
       wagon_repository: ${{ github.event.repository.name }}
-      core_ref: ${{ github.ref || inputs.core_ref || 'sac-master' }}
-      wagon_dependency_ref: ${{ inputs.wagon_dependency_ref || 'sac-master' }}
+      core_ref: ${{ github.ref || inputs.core_ref || '' }}
+      wagon_dependency_ref: ${{ inputs.wagon_dependency_ref || '' }}
     secrets:
       HEARTBEAT_URL: ${{ secrets.HEARTBEAT_URL }}
       HEARTBEAT_TOKEN: ${{ secrets.HEARTBEAT_TOKEN }}

--- a/.github/workflows/run-all-wagon-tests.yml
+++ b/.github/workflows/run-all-wagon-tests.yml
@@ -43,7 +43,7 @@ jobs:
         id: list-wagon-repositories
         run: |
           WAGONS=$(gh repo list hitobito -L 100 --no-archived --json owner,name | \
-            jq 'map(select(.name | test("^hitobito_"))) | map({ owner: .owner.login, repo: .name, name: .name | match("^hitobito_((?!zss)(?!dav).+)$").captures[0].string })')
+            jq 'map(select(.name | test("^hitobito_"))) | map({ owner: .owner.login, repo: .name, name: .name | match("^hitobito_((?!bdp)(?!dpsg)(?!pfadi_de).+)$").captures[0].string })')
           echo $WAGONS
           echo "wagons=$WAGONS" | tr -d "\n" >> $GITHUB_OUTPUT
         env:
@@ -60,51 +60,27 @@ jobs:
       matrix:
         wagon: ${{ fromJSON(needs.find-wagons.outputs.wagons) }}
       max-parallel: 5 # needed so we don't occupy all the runners with core waiting jobs and the wagon tests can never start
-    steps:
-      - name: "Determine common branch and set branch name for wagon"
-        env:
-          INPUT_WAGON_REF: ${{ inputs.wagon_ref }}
-        run: |
-          COMMON_BRANCH_NAME="${{github.head_ref || github.ref_name}}"
-          if [ -z "$INPUT_WAGON_REF" ]; then
-            WAGON_REF=$(git ls-remote --heads https://github.com/${{matrix.wagon.owner}}/${{matrix.wagon.repo}} | cut -d/ -f3- | grep -x "$COMMON_BRANCH_NAME" || echo 'master')
-          fi
+    # steps:
+    #   - name: "Determine common branch and set branch name for wagon"
+    #     env:
+    #       INPUT_WAGON_REF: ${{ inputs.wagon_ref }}
+    #     run: |
+    #       COMMON_BRANCH_NAME="${{github.head_ref || github.ref_name}}"
+    #       if [ -z "$INPUT_WAGON_REF" ]; then
+    #         WAGON_REF=$(git ls-remote --heads https://github.com/${{matrix.wagon.owner}}/${{matrix.wagon.repo}} | cut -d/ -f3- | grep -x "$COMMON_BRANCH_NAME" || echo 'master')
+    #       fi
+    #
+    #       echo "WAGON_REF=$WAGON_REF" >> $GITHUB_ENV
+    #     shell: bash
+    #
+    #  core_ref: env.WAGON_REF
+    #  wagon_dependency_ref: env.WAGON_REF
 
-          echo "WAGON_REF=$WAGON_REF" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Trigger ${{ matrix.wagon.name }} wagon tests
-        uses: Codex-/return-dispatch@v2.1.0
-        id: run-wagon-tests
-        with:
-          token: ${{ secrets.WAGON_TESTS_GITHUB_TOKEN }}
-          repo: ${{ matrix.wagon.repo }}
-          owner: ${{ matrix.wagon.owner }}
-          ref: ${{ env.WAGON_REF }}
-          workflow: tests.yml
-          workflow_timeout_seconds: 21600 # wait for up to 6 hours
-          workflow_job_steps_retry_seconds: 10 # default is 5, set it higher to not strain the API limit too much
-          workflow_inputs: |
-            {
-              "core_ref": "${{ github.ref || inputs.core_ref }}",
-              "wagon_dependency_ref": "${{ inputs.wagon_dependency_ref }}"
-            }
-
-      - name: Link to the triggered wagon tests run
-        run: 'echo "${{ matrix.wagon.name }} tests triggered: ${{ steps.run-wagon-tests.outputs.run_url }}"'
-
-      - name: Wait for ${{ matrix.wagon.name }} wagon tests result
-        uses: carlobeltrame/await-remote-run@conditional-api-requests
-        with:
-          token: ${{ secrets.WAGON_TESTS_GITHUB_TOKEN }}
-          repo: ${{ matrix.wagon.repo }}
-          owner: ${{ matrix.wagon.owner }}
-          run_id: ${{ steps.run-wagon-tests.outputs.run_id }}
-          run_timeout_seconds: 21600 # wait for up to 6 hours
-          poll_interval_ms: 10000 # poll every 10 seconds
-
-      - name: Cancel ${{ matrix.wagon.name }} wagon tests
-        if: ${{ cancelled() && steps.run-wagon-tests.outputs.run_id }}
-        run: 'gh api --method POST -H "Accept: application/vnd.github+json" /repos/${{ matrix.wagon.owner }}/${{ matrix.wagon.repo }}/actions/runs/${{ steps.run-wagon-tests.outputs.run_id }}/cancel'
-        env:
-          GH_TOKEN: ${{ secrets.WAGON_TESTS_GITHUB_TOKEN }}
+    uses: hitobito/hitobito/.github/workflows/wagon-tests.yml@master
+    with:
+      wagon_repository: ${{ github.event.repository.name }}
+      core_ref: ${{ github.ref || inputs.core_ref || 'sac-master' }}
+      wagon_dependency_ref: ${{ inputs.wagon_dependency_ref || 'sac-master' }}
+    secrets:
+      HEARTBEAT_URL: ${{ secrets.HEARTBEAT_URL }}
+      HEARTBEAT_TOKEN: ${{ secrets.HEARTBEAT_TOKEN }}

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -7,7 +7,7 @@ on:
         description: "Wagon repository, e.g. hitobito_pbs"
         type: string
       wagon_dependency_repository:
-        description: A wagon this wagon depends on, e.g. hitobito_youth
+        description: Deprecated parameter. The wagon dependency is now automatically detected.
         required: false
         default: ""
         type: string
@@ -41,6 +41,9 @@ defaults:
     working-directory: hitobito
 
 jobs:
+  detect_wagon_dependency:
+    # TODO
+
   wagon_rubocop:
     name: rubocop
     runs-on: "ubuntu-22.04"
@@ -66,7 +69,7 @@ jobs:
           migrations: false
           assets: false
           wagon_repository: ${{ inputs.wagon_repository }}
-          wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
+          wagon_dependency_repository: ${{ needs.detect_wagon_dependency.outputs.wagon_dependency_repository }}
           core_ref: ${{ inputs.core_ref }}
           wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
 

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -7,7 +7,7 @@ on:
         description: "Wagon repository, e.g. hitobito_pbs"
         type: string
       wagon_dependency_repository:
-        description: Deprecated parameter. The wagon dependency is now automatically detected.
+        description: Deprecated and ignored parameter. The wagon dependency is now automatically detected from the gemspec.
         required: false
         default: ""
         type: string
@@ -42,13 +42,33 @@ defaults:
 
 jobs:
   detect_wagon_dependency:
-    # TODO
+    runs-on: ubuntu-latest
+
+    outputs:
+      wagon_dependency_repository: ${{ steps.determine.outputs.dependency_repo }}
+
+    steps:
+      - name: Determine dependency-repo
+        id: determine
+        env:
+          REPO: ${{ inputs.wagon_repository }}
+
+        working-directory: "."
+        run: |
+          gemspec_source="https://raw.githubusercontent.com/hitobito/${REPO}/master/${REPO}.gemspec"
+          curl --silent -k  "$gemspec_source" > ./gemspec
+
+          dependency_repo=$(grep 'add_dependency.*hitobito_' ./gemspec | sed 's/.*\(hitobito_[-_a-z]*\).*/\1/')
+          echo "dependency_repo=${dependency_repo}" >> "$GITHUB_OUTPUT"
 
   wagon_rubocop:
     name: rubocop
     runs-on: "ubuntu-22.04"
     env:
       RAILS_DB_ADAPTER: nulldb
+
+    needs:
+      - detect_wagon_dependency
 
     steps:
       - name: echo distinct ID ${{ inputs.distinct_id }}
@@ -146,6 +166,9 @@ jobs:
       RAILS_ENV: development
       DISABLE_TEST_SCHEMA_MAINTENANCE: true
 
+    needs:
+      - detect_wagon_dependency
+
     # only run seeds on master
     if: ${{ github.ref_name == 'master' }}
     services:
@@ -176,7 +199,7 @@ jobs:
         with:
           assets: false
           wagon_repository: ${{ inputs.wagon_repository }}
-          wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
+          wagon_dependency_repository: ${{ needs.detect_wagon_dependency.outputs.wagon_dependency_repository }}
           core_ref: ${{ inputs.core_ref }}
           wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
 
@@ -198,6 +221,9 @@ jobs:
       RAILS_TEST_DB_NAME: hitobito_test
       RAILS_ENV: test
       DISABLE_TEST_SCHEMA_MAINTENANCE: true
+
+    needs:
+      - detect_wagon_dependency
 
     services:
       postgres:
@@ -230,7 +256,7 @@ jobs:
         uses: ./.hitobito_core_repo/.github/actions/wagon-ci-setup
         with:
           wagon_repository: ${{ inputs.wagon_repository }}
-          wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
+          wagon_dependency_repository: ${{ needs.detect_wagon_dependency.outputs.wagon_dependency_repository }}
           core_ref: ${{ inputs.core_ref }}
           wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
 
@@ -253,6 +279,9 @@ jobs:
       RAILS_TEST_DB_NAME: hitobito_test
       RAILS_ENV: test
       DISABLE_TEST_SCHEMA_MAINTENANCE: true
+
+    needs:
+      - detect_wagon_dependency
 
     services:
       postgres:
@@ -285,7 +314,7 @@ jobs:
         uses: ./.hitobito_core_repo/.github/actions/wagon-ci-setup
         with:
           wagon_repository: ${{ inputs.wagon_repository }}
-          wagon_dependency_repository: ${{ inputs.wagon_dependency_repository }}
+          wagon_dependency_repository: ${{ needs.detect_wagon_dependency.outputs.wagon_dependency_repository }}
           core_ref: ${{ inputs.core_ref }}
           wagon_dependency_ref: ${{ inputs.wagon_dependency_ref }}
 


### PR DESCRIPTION
Not triggering and awaiting them in the remote repository means fewer job runners just idling to wait for some other job to complete.

~~To be solved is the detection of the wagon dependency repository. Also, this change is thus far untested.~~