### PR TITLE
Disable pull_request trigger for now

### DIFF
--- a/.github/workflows/run-all-wagon-tests.yml
+++ b/.github/workflows/run-all-wagon-tests.yml
@@ -18,11 +18,11 @@ on:
       - 'doc/**'
       - '**.md'
       - 'VERSION'
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-      - '**.md'
-      - 'VERSION'
+  #pull_request: # this trigger is disabled for now, because it caused our CI runners to be occupied too often
+  #  paths-ignore:
+  #    - 'doc/**'
+  #    - '**.md'
+  #    - 'VERSION'
   pull_request_target:
     types: [labeled]
 


### PR DESCRIPTION
After this change, it is the responsibility of the devs to trigger the wagon tests on each PR whenever they feel like it is the right time for it, by adding the `run-wagon-tests!` label. We will also install branch protection rules to ensure this happens before every merge.
(Overriding these rules will still be possible, and the wagon tests will still run on each push to master)
![image](https://github.com/user-attachments/assets/8f9fb034-6547-49c9-904f-1602e558e45d)
