### PR TITLE
Clean guest-data if no longer needed

### DIFF
--- a/app/models/event/participation.rb
+++ b/app/models/event/participation.rb
@@ -72,6 +72,7 @@ class Event::Participation < ActiveRecord::Base
   before_validation :init, on: :create
   before_validation :set_self_in_nested
   before_create :reset_person_minimized_at
+  before_destroy :destroy_guest_record
 
   # There may be old participations without roles, so they must
   # update the count directly.
@@ -177,5 +178,9 @@ class Event::Participation < ActiveRecord::Base
 
   def directly_to_waiting_list?(event)
     !event.places_available? && event.waiting_list_available?
+  end
+
+  def destroy_guest_record
+    participant.destroy if participant_type == "Event::Guest"
   end
 end

--- a/spec/models/event/participation_spec.rb
+++ b/spec/models/event/participation_spec.rb
@@ -112,10 +112,24 @@ describe Event::Participation do
   end
 
   context "#destroy" do
-    it "destroy roles as well" do
+    it "destroys roles as well" do
       expect do
         event_participations(:top).destroy
       end.to change { Event::Role.count }.by(-1)
+    end
+
+    it "destroys guest-participants as well" do
+      guest_participation = Fabricate(:event_participation, participant: Fabricate(:event_guest))
+
+      expect do
+        guest_participation.destroy
+      end.to change { Event::Guest.count }.by(-1)
+    end
+
+    it "does not destroy person participants" do
+      expect do
+        event_participations(:top).destroy
+      end.to not_change { Person.count }
     end
   end
 


### PR DESCRIPTION
It is not directly possible to only sometimes cascade deletes of polymorphic associations. Therefore, this change sits on the participation, not the event. But Specs hopefully show conclusively that it works as intended.

As a bonus, the guest-data is deleted as soon as it is not needed for a participation anymore. This seems to be the most privacy-respecting solution.

fixes hitobito/hitobito_sww#259