### PR TITLE
Store guest limit on events

### DIFF
--- a/db/migrate/20250709164311_add_guest_limit_to_events.rb
+++ b/db/migrate/20250709164311_add_guest_limit_to_events.rb
@@ -1,0 +1,5 @@
+class AddGuestLimitToEvents < ActiveRecord::Migration[7.1]
+  def change
+    add_column :events, :guest_limit, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -445,6 +445,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_30_120000) do
     t.integer "minimum_participants"
     t.boolean "automatic_assignment", default: false, null: false
     t.string "visible_contact_attributes", default: "[\"name\", \"address\", \"phone_number\", \"email\", \"social_account\"]"
+    t.integer "guest_limit", default: 0, null: false
     t.index ["kind_id"], name: "index_events_on_kind_id"
     t.index ["shared_access_token"], name: "index_events_on_shared_access_token"
   end


### PR DESCRIPTION
There were some local leftovers in the schema.rb. I added them here as a separte commit. Maybe rebasing will remove that fixup, if not, it should leave a clean schema.rb in the future. If this results in problems, it is at least contained in a explanatory separate commit.

In other news, this adds a column to store the guest limit on events.

Fixes hitobito/hitobito_sww#260