### PR TITLE
Fix group merging

### DIFF
--- a/app/controllers/group/merge_controller.rb
+++ b/app/controllers/group/merge_controller.rb
@@ -19,6 +19,10 @@ class Group::MergeController < ApplicationController
     else
       respond_failure
     end
+  rescue RuntimeError => err
+    respond_error err.message
+  rescue ActiveRecord::RecordInvalid => err
+    respond_error err.record.errors.full_messages.join(", ")
   end
 
   private
@@ -31,6 +35,11 @@ class Group::MergeController < ApplicationController
 
   def respond_failure
     flash[:alert] = merger.errors ? merger.errors.to_sentence : translate(:failure)
+    redirect_to merge_group_path(group)
+  end
+
+  def respond_error(message = nil)
+    flash[:alert] = message || translate(:failure)
     redirect_to merge_group_path(group)
   end
 

--- a/app/controllers/group/merge_controller.rb
+++ b/app/controllers/group/merge_controller.rb
@@ -43,7 +43,7 @@ class Group::MergeController < ApplicationController
   end
 
   def candidates
-    groups = group.sister_groups
+    groups = group.sister_groups.without_archived
     @candidates = groups.select { |g| can?(:update, g) }
     if @candidates.empty?
       flash[:alert] = translate(:no_candidates)

--- a/app/domain/group/merger.rb
+++ b/app/domain/group/merger.rb
@@ -13,7 +13,9 @@ class Group::Merger
   end
 
   def merge!
-    raise("Cannot merge these Groups") unless group2_valid?
+    raise "Cannot merge these groups" unless group2_valid?
+    raise "Cannot merge archived groups" if archived?
+    raise "Cannot merge deleted groups" if deleted?
 
     ::Group.transaction do
       if create_new_group
@@ -31,6 +33,14 @@ class Group::Merger
   end
 
   private
+
+  def archived?
+    group1.archived? || group2.archived?
+  end
+
+  def deleted?
+    group1.deleted? || group2.deleted?
+  end
 
   def create_new_group
     new_group = build_new_group

--- a/app/domain/group/merger.rb
+++ b/app/domain/group/merger.rb
@@ -55,7 +55,7 @@ class Group::Merger
     events = (group1.events + group2.events).uniq
     events.each do |event|
       event.groups << new_group
-      event.save!
+      event.save!(validate: false)
     end
   end
 
@@ -64,7 +64,7 @@ class Group::Merger
     children.each do |child|
       child.parent_id = new_group.id
       child.parent.reload
-      child.save!
+      child.save!(validate: false)
     end
   end
 
@@ -73,7 +73,7 @@ class Group::Merger
     roles.each do |role|
       new_role = role.dup
       new_role.group_id = new_group.id
-      new_role.save!
+      new_role.save!(validate: false)
     end
   end
 

--- a/app/domain/group/merger.rb
+++ b/app/domain/group/merger.rb
@@ -81,13 +81,19 @@ class Group::Merger
     invoices = group1.invoices + group2.invoices
     invoices.each do |invoice|
       invoice.group_id = new_group.id
-      invoice.save!
+      invoice.save!(validate: false)
     end
 
     invoice_articles = group1.invoice_articles + group2.invoice_articles
     invoice_articles.each do |invoice_article|
       invoice_article.group_id = new_group.id
-      invoice_article.save!
+      invoice_article.save!(validate: false)
+    end
+
+    invoice_lists = group1.invoice_lists + group2.invoice_lists
+    invoice_lists.each do |invoice_list|
+      invoice_list.group_id = new_group.id
+      invoice_list.save!(validate: false)
     end
   end
 

--- a/spec/controllers/group/merge_controller_spec.rb
+++ b/spec/controllers/group/merge_controller_spec.rb
@@ -17,6 +17,30 @@ describe Group::MergeController do
       expect(flash[:alert]).to match(/Es sind keine gleichen Gruppen zum Fusionieren vorhanden/)
       is_expected.to redirect_to(group_path(group))
     end
+
+    it "should not offer deleted sibling groups" do
+      group = groups(:bottom_layer_one)
+      groups(:bottom_layer_two).update_attribute(:deleted_at, 1.day.ago)
+
+      sign_in(people(:top_leader))
+
+      get :select, params: {id: group.id}
+
+      expect(flash[:alert]).to match(/Es sind keine gleichen Gruppen zum Fusionieren vorhanden/)
+      is_expected.to redirect_to(group_path(group))
+    end
+
+    it "should not offer archived sibling groups" do
+      group = groups(:bottom_layer_one)
+      groups(:bottom_layer_two).update_attribute(:archived_at, 1.day.ago)
+
+      sign_in(people(:top_leader))
+
+      get :select, params: {id: group.id}
+
+      expect(flash[:alert]).to match(/Es sind keine gleichen Gruppen zum Fusionieren vorhanden/)
+      is_expected.to redirect_to(group_path(group))
+    end
   end
 
   # TODO test paths inside perform action


### PR DESCRIPTION
Refs #3475

Noch offen: Datenmigrationen im youth und pbs Wagon, um die tatsächlichen invaliden Events aufzuräumen, siehe Auflistung im Issue