### PR TITLE
Convenient way to view (most) method callbacks in pry

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -12,7 +12,7 @@
 #   list_callbacks(PeopleController)
 #
 def list_callbacks(klass, skip_procs: true, skip_validations: true)
-  klass.__callbacks.each_with_object(Hash.new({ [] })) do |(k, callbacks), result|
+  klass.__callbacks.each_with_object(Hash.new { [] }) do |(k, callbacks), result|
     next if skip_validations && k == :validate # ignore validations
     callbacks.each do |c|
       next if skip_procs && c.filter.is_a?(Proc)


### PR DESCRIPTION
Hilft vielleicht mal wieder bei der Suche 

```
[11] pry(main)> list_callbacks(Person)
=> {"after_validation"=>[:record_validation_run],
 "before_validation"=>
  [:normalize_changed_in_place_attributes,
   :downcase_keys,
   :strip_whitespace,
   :set_self_in_nested,
   :set_updater_attribute,
   :set_creator_attribute,
   :override_blank_email],
 "after_save"=>[:check_data_quality, :update_household_address, :save_owned_tags, :save_tags, :reset_validation_run_cache],
 "around_save"=>[:around_save_collection_association],
 "before_save"=>[:set_digital_correspondence, :clear_legacy_password_attributes],
 "after_create"=>[:skip_reconfirmation_in_callback!],
 "before_create"=>[:generate_confirmation_token],
 "after_update"=>
  [:schedule_duplicate_locator,
   :remove_validation_tags,
   :send_password_change_notification,
   :send_email_changed_notification],
 "before_update"=>[:clear_reset_password_token, :postpone_email_change_until_confirmation_and_regenerate_confirmation_token],
 "before_destroy"=>[:destroy_roles, :destroy_person_duplicates],
 "after_commit"=>[:transmit_data_to_abacus, :send_reconfirmation_instructions, :send_on_create_confirmation_instructions]}
```