### PR TITLE
Improve message dispatch

### DIFF
--- a/app/domain/invoice/batch_create.rb
+++ b/app/domain/invoice/batch_create.rb
@@ -39,10 +39,13 @@ class Invoice::BatchCreate
   private
 
   def create_invoices
-    receivers.each do |receiver|
-      success = create_invoice(receiver)
-      invalid << receiver.id unless success
-      results << success
+    receivers.each_slice(1000) do |slice|
+      slice.each do |receiver|
+        success = create_invoice(receiver)
+        invalid << receiver.id unless success
+        results << success
+      end
+
       update_invoice_list
     end
   end

--- a/app/domain/invoice/batch_create.rb
+++ b/app/domain/invoice/batch_create.rb
@@ -7,20 +7,19 @@ class Invoice::BatchCreate
   attr_reader :invoice_list, :invoice, :results, :invalid
 
   def self.call(invoice_list, limit = InvoiceListsController::LIMIT_CREATE)
-    invoice_parameters = invoice_list.invoice_parameters
     if invoice_list.recipient_ids_count < limit
-      create(invoice_list, invoice_parameters)
+      create(invoice_list)
     else
-      create_async(invoice_list, invoice_parameters)
+      create_async(invoice_list)
     end
   end
 
-  def self.create(invoice_list, invoice_parameters)
+  def self.create(invoice_list)
     Invoice::BatchCreate.new(invoice_list).call
   end
 
-  def self.create_async(invoice_list, invoice_parameters)
-    Invoice::BatchCreateJob.new(invoice_list.id, invoice_parameters).enqueue!
+  def self.create_async(invoice_list)
+    Invoice::BatchCreateJob.new(invoice_list.id, invoice_list.invoice_parameters).enqueue!
   end
 
   def initialize(invoice_list, people = nil)

--- a/app/domain/invoice/batch_create.rb
+++ b/app/domain/invoice/batch_create.rb
@@ -6,8 +6,6 @@
 class Invoice::BatchCreate
   attr_reader :invoice_list, :invoice, :results, :invalid
 
-  delegate :fixed_fee, to: :invoice_list
-
   def self.call(invoice_list, limit = InvoiceListsController::LIMIT_CREATE)
     invoice_parameters = invoice_list.invoice_parameters
     if invoice_list.recipient_ids_count < limit
@@ -51,7 +49,7 @@ class Invoice::BatchCreate
 
   def create_invoice(recipient)
     invoice_attrs = invoice.attributes.merge(
-      title: fixed_fee ? title_with_layer(recipient.layer_group_id) : invoice.title,
+      title: invoice_list.fixed_fee ? title_with_layer(recipient.layer_group_id) : invoice.title,
       creator_id: invoice_list.creator_id,
       invoice_list_id: invoice_list.id,
       recipient_id: recipient.id
@@ -63,8 +61,8 @@ class Invoice::BatchCreate
   end
 
   def add_invoice_items(invoice, recipient)
-    if fixed_fee
-      invoice.invoice_items = InvoiceLists::FixedFee.for(fixed_fee, recipient.layer_group_id).invoice_items
+    if invoice_list.fixed_fee
+      invoice.invoice_items = InvoiceLists::FixedFee.for(invoice_list.fixed_fee, recipient.layer_group_id).invoice_items
     else
       invoice.invoice_items_attributes = invoice_items_attributes(recipient.id)
     end

--- a/app/domain/invoice/batch_create.rb
+++ b/app/domain/invoice/batch_create.rb
@@ -3,6 +3,11 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
+# Create actual invoices for a given invoice-list.
+#
+# The main worker method is #create_invoices.
+# The Invoice-List ist updated with success/failure counts
+# Failures are invoices without invoice-items or any other more specific validation error.
 class Invoice::BatchCreate
   attr_reader :invoice_list, :invoice, :results, :invalid
 

--- a/app/domain/invoice/batch_update.rb
+++ b/app/domain/invoice/batch_update.rb
@@ -4,11 +4,12 @@
 #  https://github.com/hitobito/hitobito.
 
 class Invoice::BatchUpdate
-  attr_reader :invoices, :sender
+  attr_reader :invoices, :sender, :result
 
   def initialize(invoices, sender = nil)
     @invoices = invoices
     @sender = sender
+    @result = Invoice::BatchUpdateResult.new
   end
 
   def call # rubocop:disable Metrics/MethodLength
@@ -86,9 +87,5 @@ class Invoice::BatchUpdate
 
   def send_email?
     sender.present?
-  end
-
-  def result
-    @result ||= Invoice::BatchUpdateResult.new
   end
 end

--- a/app/domain/messages/letter_dispatch.rb
+++ b/app/domain/messages/letter_dispatch.rb
@@ -7,8 +7,6 @@
 
 module Messages
   class LetterDispatch
-    delegate :update!, :success_count, :send_to_households?, :salutation, to: "@message"
-
     def initialize(message, options = {})
       @message = message
       @options = options
@@ -27,6 +25,11 @@ module Messages
 
     private
 
+    # meant to be customized/overridden in subclasses
+    def send_to_households?
+      @message.send_to_households?
+    end
+
     def people
       @people ||= @message.mailing_list.people.with_address.select(:household_key)
     end
@@ -38,7 +41,7 @@ module Messages
     def create_for_people!
       limit(people, @options[:recipient_limit]).find_in_batches do |batch|
         count = create_recipient_entries(batch)
-        update!(success_count: count)
+        @message.update!(success_count: count)
       end
     end
 
@@ -49,13 +52,13 @@ module Messages
       # first, run a separate batch for people that are grouped in households, because that's slower
       household_list.only_households_in_batches do |batch|
         create_recipient_entries(batch)
-        update!(success_count: success_count + batch.size)
+        @message.update!(success_count: @message.success_count + batch.size)
       end
 
       # batch run for people without household
       household_list.people_without_household_in_batches do |batch|
         count = create_recipient_entries(batch)
-        update!(success_count: success_count + count)
+        @message.update!(success_count: @message.success_count + count)
       end
     end
 
@@ -96,9 +99,9 @@ module Messages
 
     def salutation_for_letter(person, housemates)
       if send_to_households? && housemates.count > 1
-        Salutation.new(person, salutation).value_for_household(housemates)
+        Salutation.new(person, @message.salutation).value_for_household(housemates)
       else
-        Salutation.new(person, salutation).value
+        Salutation.new(person, @message.salutation).value
       end
     end
   end

--- a/app/domain/messages/letter_dispatch.rb
+++ b/app/domain/messages/letter_dispatch.rb
@@ -14,6 +14,8 @@ module Messages
     end
 
     def run
+      @message.update!(success_count: 0, failed_count: 0)
+
       if send_to_households?
         create_for_households!
       else
@@ -41,7 +43,7 @@ module Messages
     def create_for_people!
       limit(people, @options[:recipient_limit]).find_in_batches do |batch|
         count = create_recipient_entries(batch)
-        @message.update!(success_count: count)
+        @message.update!(success_count: @message.success_count + count)
       end
     end
 

--- a/app/domain/messages/letter_with_invoice_dispatch.rb
+++ b/app/domain/messages/letter_with_invoice_dispatch.rb
@@ -15,9 +15,10 @@ module Messages
 
     def run
       super
+
       @message.update!(invoice_list_id: @invoice_list.id)
       batch_create
-      Invoice::BatchUpdate.new(@invoice_list.reload.invoices).call
+      batch_update
       DispatchResult.finished
     end
 
@@ -25,8 +26,14 @@ module Messages
       batch_create = Invoice::BatchCreate.new(@invoice_list, @people)
       batch_create.call
 
-      update!(success_count: batch_create.results.count(true),
-        failed_count: batch_create.results.count(false))
+      @message.update!(
+        success_count: batch_create.results.count(true),
+        failed_count: batch_create.results.count(false)
+      )
+    end
+
+    def batch_update
+      Invoice::BatchUpdate.new(@invoice_list.reload.invoices).call
     end
 
     # disable household addresses for letter with invoice

--- a/app/domain/messages/letter_with_invoice_dispatch.rb
+++ b/app/domain/messages/letter_with_invoice_dispatch.rb
@@ -17,8 +17,8 @@ module Messages
       super
 
       @message.update!(invoice_list_id: @invoice_list.id)
-      batch_create
-      batch_update
+      batch_create # create invoices for all people on the invoice list
+      batch_update # update invoices by advancing their state, sending mail and create reminders if needed
       DispatchResult.finished
     end
 

--- a/doc/developer/messages/dispatch.md
+++ b/doc/developer/messages/dispatch.md
@@ -10,5 +10,8 @@ When sending via SMS, all recipient numbers are first collected and stored in th
 ## `LetterDispatch`
 Generates all MessageRecipient entries with the postal address of the recipient. A corresponding PDF is then generated based on these entries.
 
+## `LetterWithInvoiceDispatch`
+First, the PDF from the LetterDispatch is generated. After that, the Invoices for a given InvoiceList are generated and sent.
+
 ## Print shop
 A print shop has its own access to Hitobito and can therefore download letters for dispatch as PDFs.


### PR DESCRIPTION
Updating the invoice-list with every created invoice add a lot of callback-overhead. Going over the list in batches (well, slices) allows us to do this only after 1000 invoices. This update takes more than a second, so the benefit of doing this more seldom should be clear.

While at it, this also fixes the success-count in the LetterDispatch which is shown in the UI.