### PR TITLE
Reply-To should only be set if it differs from To

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -32,6 +32,8 @@ class ApplicationMailer < ActionMailer::Base
     content = CustomContent.get(content_key, context:)
     headers[:to] = Array(use_mailing_emails(recipients)).reject { |email| Bounce.blocked?(email) }
     headers[:subject] ||= unescape_html(content.subject_with_values(values))
+    headers.delete(:reply_to) if headers[:to].include?(headers[:reply_to])
+
     mail(headers) do |format|
       format.html { render html: content.body_with_values(values), layout: true }
     end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -166,6 +166,12 @@ RSpec.describe ApplicationMailer, type: :mailer do
       it "has the sender per locale defined in the translation" do
         check_sender { Person::LoginMailer.login(recipient, sender, "abcdef") }
       end
+
+      it "does not include reply-to if it is already in the to-header" do
+        mail = Person::LoginMailer.login(recipient, recipient, "abcdef")
+
+        expect(mail.reply_to).to be_nil
+      end
     end
 
     describe Person::UserPasswordOverrideMailer do


### PR DESCRIPTION
This popped up in a Spam-Header while reviewing something else mail-related. 