### PR TITLE
Validate at least one invoice item for invoice messages (hitobito#3342)

### DIFF
--- a/app/models/message/letter_with_invoice.rb
+++ b/app/models/message/letter_with_invoice.rb
@@ -102,7 +102,9 @@ class Message::LetterWithInvoice < Message::Letter
   end
 
   def assert_valid_invoice_items
-    unless invoice.invoice_items.all?(&:valid?)
+    if invoice.invoice_items.empty?
+      errors.add(:base, :invoice_items_required)
+    elsif !invoice.invoice_items.all?(&:valid?)
       errors.add(:base, :invoice_items_invalid)
     end
   end

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -132,7 +132,8 @@ de:
         message/letter_with_invoice:
           attributes:
             base:
-              invoice_items_invalid: Mindestens ein Rechnungsposten ist ungültig.
+              invoice_items_required: Mindestens ein Rechnungsposten ist erforderlich
+              invoice_items_invalid: Mindestens ein Rechnungsposten ist ungültig
         oauth/application:
           attributes:
             scopes:

--- a/config/locales/models.en.yml
+++ b/config/locales/models.en.yml
@@ -131,7 +131,8 @@ en:
         message/letter_with_invoice:
           attributes:
             base:
-              invoice_items_invalid: Mindestens ein Rechnungsposten ist ungültig.
+              invoice_items_required: Mindestens ein Rechnungsposten ist erforderlich
+              invoice_items_invalid: Mindestens ein Rechnungsposten ist ungültig
         oauth/application:
           attributes:
             scopes:

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -133,7 +133,8 @@ fr:
         message/letter_with_invoice:
           attributes:
             base:
-              invoice_items_invalid: Au moins un poste budgétaire est invalide.
+              invoice_items_required: Au moins un poste budgétaire est requis
+              invoice_items_invalid: Au moins un poste budgétaire est invalide
         oauth/application:
           attributes:
             scopes:

--- a/config/locales/models.it.yml
+++ b/config/locales/models.it.yml
@@ -133,7 +133,8 @@ it:
         message/letter_with_invoice:
           attributes:
             base:
-              invoice_items_invalid: Almeno una voce di un conto non è valida.
+              invoice_items_required: È richiesta almeno una voce di un conto
+              invoice_items_invalid: Almeno una voce di un conto non è valida
         oauth/application:
           attributes:
             scopes:

--- a/spec/models/message/letter_with_invoice_spec.rb
+++ b/spec/models/message/letter_with_invoice_spec.rb
@@ -116,7 +116,18 @@ describe Message::LetterWithInvoice do
 
     it "validates invoice items" do
       letter.invoice_attributes["invoice_items_attributes"][2] = invalid_invoice_item_attrs
+
       expect(letter).not_to be_valid
+
+      expect(letter.errors.map(&:type)).to eq [:invoice_items_invalid]
+    end
+
+    it "requires at least one item" do
+      letter.invoice_attributes = {}
+
+      expect(letter).not_to be_valid
+
+      expect(letter.errors.map(&:type)).to eq [:invoice_items_required]
     end
   end
 end


### PR DESCRIPTION
fixes hitobito#3342

Der Fehler ist aufgetreten wenn man ein PDF eines Rechnungsbriefes ohne Rechnungsposten erstellen wollte.