### PR TITLE
Fix failing person duplicates list spec

### DIFF
--- a/spec/views/person_duplicates/_list.html.haml_spec.rb
+++ b/spec/views/person_duplicates/_list.html.haml_spec.rb
@@ -11,19 +11,12 @@ describe "person_duplicates/_list.html.haml" do
     Capybara::Node::Simple.new(@rendered)
   }
 
-  let(:params) do
-    {"action" => "index",
-     "controller" => "person_dublicates",
-     "group_id" => top.id}
-  end
-
   before do
     assign(:group, Group.new(id: 1))
     allow(view).to receive(:entries).and_return(PersonDuplicate.none.page(1))
   end
 
   it "navigates outside of frame" do
-    login_as(people(:top_leader))
     expect(dom).to have_css("turbo-frame#search_results[target=_top]")
   end
 end


### PR DESCRIPTION
The test failed on CI since `login_as` is not defined. The spec was copied from `spec/views/event/participations/_list.html.haml_spec.rb`, where `login_as` is defined.

For me, the spec passed locally, because I didn't exclude the feature specs (`--tag ~type:feature`). When excluding the feature specs, the warden helper method `login_as` is not included, see https://github.com/hitobito/hitobito/blob/544cbb3dfb4a1650ca12250f6359170cb35d9ba0/spec/spec_helper.rb#L174-L179

Since the `login_as` call is not needed anyway, I just removed it.