### PR TITLE
Fix 404 when creating assignment after validation error (hitobito#1292)

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -24,7 +24,7 @@ class AssignmentsController < CrudController
   end
 
   def path_args(entry)
-    (action_name.eql?("new") || entry.person_id.blank?) ? super : entry.path_args
+    entry.persisted? ? entry.path_args : super
   end
 
   def assign_attributes

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -141,5 +141,23 @@ describe AssignmentsController do
         }
       end.to raise_error(CanCan::AccessDenied)
     end
+
+    describe "validation" do
+      render_views
+
+      it "works after validation error" do
+        post :create, params: {
+          assignment: {
+            title: "",
+            description: "test description",
+            attachment_id: messages(:letter).id,
+            person_id: bottom_member.id
+          }
+        }
+
+        expect(response).to render_template(:new)
+        expect(response.body).to include('action="/assignments"')
+      end
+    end
   end
 end


### PR DESCRIPTION
There is some custom path_args logic in the `AssignmentsController` which returns a different path for new and already existing assignments. After a validation error, the wrong path was returned, why it lead to a 404.

fixes hitobito#1292