### PR TITLE
Fix issue when imap does not return messages (hitobito#3453)

### DIFF
--- a/app/utils/imap/connector.rb
+++ b/app/utils/imap/connector.rb
@@ -52,7 +52,7 @@ class Imap::Connector
       select_mailbox(mailbox)
 
       fetch_data = @imap.uid_fetch(uid, attributes)
-      return nil if fetch_data.nil?
+      return nil if fetch_data.blank?
 
       Imap::Mail.build(fetch_data.first)
     end

--- a/spec/utils/imap/connector_spec.rb
+++ b/spec/utils/imap/connector_spec.rb
@@ -231,7 +231,7 @@ describe Imap::Connector do
       expect(net_imap).to receive(:select).with("INBOX")
 
       # fetch
-      expect(net_imap).to receive(:uid_fetch).with(42, fetch_attributes).and_return(nil)
+      expect(net_imap).to receive(:uid_fetch).with(42, fetch_attributes).and_return([])
 
       # disconnect
       expect(net_imap).to receive(:close)


### PR DESCRIPTION
As described [here](https://github.com/ruby/net-imap/pull/192), some imap functions now return an empty array and not anymore `nil`. This is also the case for the used function `uid_fetch`.

Now, we check correctly for `.blank?` instead of `.nil?`.

I didn't find other occurences where the changed API has an impact.

fixes #3453 3453