### PR TITLE
Fix random failing qualification spec

### DIFF
--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -23,7 +23,7 @@
 require "spec_helper"
 
 describe Qualification do
-  let(:qualification) { Fabricate(:qualification, person: person) }
+  let(:qualification) { Fabricate(:qualification, person: person, start_at: 1.months.ago) }
   let(:person) { Fabricate(:person) }
 
   describe ".order_by_date" do


### PR DESCRIPTION
Sometimes the created qualification had an old date "2022-03-22". This is very unexpected, since the fabricator picks a date between 0 and 24 months ago. The root cause is still unclear.

Fixed by explicitly setting the `start_at` date, though I'm not sure if that actually fixes the problem.

fyi @amaierhofer 