### PR TITLE
Allow locale "de" to be translated on transifex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,8 @@ RUN    bundle config set --local deployment 'true' \
     && bundle config set --local without ${BUNDLE_WITHOUT_GROUPS} \
     && bundle install \
     && bundle clean \
-    && bundle exec bootsnap precompile --gemfile
+    && bundle exec bootsnap precompile --gemfile \
+    && bundle exec rails locales:patch_de
 
 # only copy things needed for yarning
 # COPY package.json yarn.lock ./

--- a/doc/architecture/wagons/README.md
+++ b/doc/architecture/wagons/README.md
@@ -78,6 +78,8 @@ If the wagon is the main wagon for a new organization structure, you can additio
 * Configure e-mail-adress for the root account in `config/settings.yml`.
 * If the application is multilingual:
   * create a project in [Transifex](https://www.transifex.com/) (e.g. hitobito_pbs)
+  * if the customer should have the option to define the german texts himself, then add a german variant locale to the
+    transifex project (e.g. `de_CH` for Switzerland)
   * make sure there is all required locale files in the wagon's config/locales folder (all non default language files can be empty on init)
   * create .tx/config and add all files (you might copy it from [here](https://github.com/hitobito/hitobito_die_mitte/blob/master/.tx/config) or use rake tx:init)
 

--- a/doc/developer/guidelines.md
+++ b/doc/developer/guidelines.md
@@ -96,6 +96,9 @@ Folgende Punkte müssen beim Erstellen eines Wagons beachtet werden:
 einsprachig, wird Transifex nicht gebraucht.
 * Transifex Projekt Name muss gleich wie der Gem Name des Wagons sein.
 * Die Ursprungssprache ist Deutsch (diese kann über Transifex nicht bearbeitet werden)
+* Falls die deutschen Texte auch über Transifex angepasst werden sollen, dann muss im Transifex
+  Projekt eine Deutsch Variante wie `de_CH` hinzugefügt werden. Diese werden im build Prozess 
+  automatisch für die locale `de` übernommen.
 * Damit Ein-/Mehrzahlformen in allen Sprachen angegeben werden können, müssen in den deutschen
 Localefiles immer die Keys `one` und `other` angegeben werden, auch wenn diese (im Deutschen)
 identisch sind.
@@ -130,6 +133,10 @@ treten in der laufenden Applikation Fehler auf.
 der Texte und sollten bei den entsprechenden Teilen ebenfalls genau so übernommen werden. Auf jedes
 öffnende Tag (`<b>`) muss zwingend ein entsprechendes schliessendes Tag mit Schrägstrich folgen
 (`</b>`).
+* Deutsche Texte können im Transifex angepasst werden, wenn im Projekt eine deutsch Variante locale
+  konfiguriert ist (z.B. `de_CH`). Diese werden im build Prozess automatisch für die locale
+  `de` übernommen. Dies geschieht mit dem rake Task `rails locales:patch_de`. Im development Environment
+  können die deutschen Texte von transifex übernommen werden, indem der Task lokal ausgeführt wird.
 
 
 ### Lizenzen

--- a/lib/tasks/locales.rake
+++ b/lib/tasks/locales.rake
@@ -1,0 +1,23 @@
+namespace :locales do
+  desc "Copy german variant locale files to 'de' locale if they exist (e.g., de_CH to de)"
+  task :patch_de do
+    search_paths = [Rails.root] + Wagons.all.map(&:root)
+
+    search_paths.each do |path|
+      locale_dir = path.join("config", "locales")
+
+      # Find all YAML files for de locale variants (e.g., *.de_CH.yml)
+      locale_dir.glob("*.de_??.yml").each do |source_file|
+        source_locale = source_file.to_s[/(de_..)\.yml$/, 1]
+
+        # Read the source file and replace the locale key (e.g., 'de_CH:') with 'de:'
+        i18n_data = source_file.read.sub(/^#{source_locale}:/, "de:")
+
+        # Write the modified content to the file with the 'de' locale suffix
+        target_file = source_file.to_s.sub(".#{source_locale}.yml", ".de.yml")
+        puts "Writing patched #{source_file} to #{target_file}"
+        File.write(target_file, i18n_data)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is achived by translating de to a variant like de_CH.
The build process patches the variant translations to de locale without variant
and overwrites the de locale file with this.

refs hitobito/hitobito_sac_cas#1889
