### PR TITLE
Allow wagons to define title for contact on custom events show

### DIFF
--- a/app/views/events/_attrs_contact.html.haml
+++ b/app/views/events/_attrs_contact.html.haml
@@ -1,4 +1,9 @@
+-#  Copyright (c) 2012-2025, Jungwacht Blauring Schweiz. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
 - if entry.contact
-  = section Event.human_attribute_name(:contact) do
+  = section entry.event.class.human_attribute_name(:contact) do
     %dl.dl-horizontal
       = entry.complete_contact_attributes


### PR DESCRIPTION
As needed for fundraisings, see https://github.com/hitobito/hitobito_dsj/issues/34#issuecomment-3233101810