### PR TITLE
Fix event visibility for events upwards in the layer hierarchy

### DIFF
--- a/app/abilities/event_ability.rb
+++ b/app/abilities/event_ability.rb
@@ -12,7 +12,7 @@ class EventAbility < AbilityDsl::Base
   on(Event) do
     class_side(:list_available, :typeahead).if_any_role
 
-    permission(:any).may(:show).in_same_layer_or_globally_visible_or_participating
+    permission(:any).may(:show).in_upward_hierarchy_or_globally_visible_or_participating
 
     permission(:any)
       .may(:index_participations)
@@ -76,9 +76,9 @@ class EventAbility < AbilityDsl::Base
     class_side(:export_list).if_layer_and_below_full_on_root
   end
 
-  def in_same_layer_or_globally_visible_or_participating
+  def in_upward_hierarchy_or_globally_visible_or_participating
     if_globally_visible_or_participating ||
-      contains_any?(user.groups.map(&:layer_group_id), subject.groups.map(&:layer_group_id))
+      contains_any?(user.groups.flat_map(&:layer_hierarchy).map(&:id), subject.groups.map(&:layer_group_id))
   end
 
   def if_globally_visible_or_participating


### PR DESCRIPTION
Leftover von #1047
Zitat aus Mail:
> Also ein Anlass eines KVs soll auch für alle Leute in Abteilungen dieses KVs sichtbar sein, aber nicht für Leute die nur in anderen KVs und deren Abteilungen sind.

> Ja, so stelle ich mir das vor. Dasselbe gilt auch für Lager!

> Wie ists denn umgekehrt: Soll ein Anlass der Abteilung auch im KV und für die Bundesebene sichtbar sein, oder gilt die Einschränkung sowohl "seitwärts" als auch "aufwärts" in der Layer-Hierarchie?

> Aufwärts soll das Berechtigungssystem wie überall sonst greifen. Also zum Beispiel “layer_and_below_read” kann nach unten lesen, “group_read” nicht. (Das stimmt ja so wie es ist)

> Und bist du dich bewusst dass dann alle Anlässe z.B. in Komissionen (in Untergruppen eines Layers) automatisch für alle Abteilungen und Wölfli (untergeordnete Layers und deren Gruppen) sichtbar sind?

> Wenn ich mich recht erinnere, war das vor dem November-Release auch so, als Anlässe noch in der ganzen DB sichtbar waren. Was ich mir ergänzend noch vorstellen würde, wäre die Checkbox «Selbst-Anmeldung erlaubt» analog den Lagern. Dann kann eine Kommission auch mal verhindern, dass sich das Wölfli selber für einen Anlass anmeldet.