### PR TITLE
Allow to set custom current_user for draper_with_helpers (hitobito/hitobito_sww#284)

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,7 +117,7 @@ RSpec.configure do |config|
     request = ActionDispatch::TestRequest.new({})
     request.host = "test.host" # ensure to not remove the test-host
     c.request = request
-    allow(c).to receive(:current_person) { people(:top_leader) }
+    allow(c).to receive(:current_person) { try(:current_user) || people(:top_leader) }
     Draper::ViewContext.current = c.view_context
   end
 


### PR DESCRIPTION
Else, we can not use the helper in a wagon, when the used fixture (people(:top_leader)) does not exist.

Fixes https://github.com/hitobito/hitobito_sww/issues/284