### PR TITLE
Feature/person name extensions

### DIFF
--- a/app/views/contactable/_contact_data.html.haml
+++ b/app/views/contactable/_contact_data.html.haml
@@ -7,7 +7,7 @@
 
 %address
   = contactable.contact_name
-  = render_extensions :person_attrs
+  = render_extensions :contact_name_attrs
   = contactable.complete_address if postal
   = contact.primary_email
   = contact.all_additional_emails(only_public)


### PR DESCRIPTION
Allows the extension of person name attributes in contact data. This allows for extensions to expand on person name attributes, such as pronouns. (ref: [pbs issue #416](https://github.com/hitobito/hitobito_pbs/issues/416))