### PR TITLE
Allow override `enforce_required_answers` for participations (hitobito#3691)

### DIFF
--- a/app/controllers/event/participations_controller.rb
+++ b/app/controllers/event/participations_controller.rb
@@ -314,7 +314,7 @@ class Event::ParticipationsController < CrudController # rubocop:disable Metrics
   def assign_attributes
     super
 
-    entry.enforce_required_answers = for_current_user?
+    entry.enforce_required_answers = enforce_required_answers?
   end
 
   def init_answers
@@ -388,6 +388,10 @@ class Event::ParticipationsController < CrudController # rubocop:disable Metrics
   end
 
   def current_user_interested_in_mail?
+    for_current_user? # extended in wagon
+  end
+
+  def enforce_required_answers?
     for_current_user? # extended in wagon
   end
 


### PR DESCRIPTION
This is necessary in the youth wagon, when a manager registers a child.

Fixes https://github.com/hitobito/hitobito/issues/3691