### PR TITLE
Revert "Use structured address on invoices (hitobito#3423)"

### DIFF
--- a/app/domain/person/address.rb
+++ b/app/domain/person/address.rb
@@ -22,7 +22,7 @@ class Person::Address
   # Use to populate invoices#recipient_address, might be overriden in wagons
   def for_invoice
     @addressable = additional_addresses.find(&:invoices?) || person
-    (person_and_company_name + full_address).compact.join("\n")
+    (person_and_company_name + short_address).compact.join("\n")
   end
 
   def for_household_letter(members)
@@ -52,7 +52,7 @@ class Person::Address
   delegate :company?, :additional_addresses, to: :person
 
   def person_and_company_name
-    return [name].compact_blank if addressable.is_a?(AdditionalAddress)
+    return [name, address_care_of].compact_blank if addressable.is_a?(AdditionalAddress)
 
     if company?
       [@person.company_name.to_s.squish, @person.full_name.to_s.squish].uniq.compact_blank

--- a/spec/domain/person/address_spec.rb
+++ b/spec/domain/person/address_spec.rb
@@ -206,7 +206,7 @@ describe Person::Address do
       {label: nil, street: "Lagistrasse", housenumber: "12a", zip_code: 1080, town: "Jamestown", invoices: true}
     }
 
-    it_behaves_like "common address behaviour", country_label: false, postbox: true, company: :adds,
+    it_behaves_like "common address behaviour", country_label: false, postbox: false, company: :adds,
       label_handling: false
 
     it "uses invoice address if additional address with invoice flag exists" do


### PR DESCRIPTION
This reverts commit 3f7cd2bd19f36378bc9b4255f0189561d3fd98c2.

We can not (yet) use the full address on the invoice, because the recipient_address string is "parsed" and used for the QR code generation as well. Therefore, with this change, the QR code would include the postbox, if there is one.