### PR TITLE
Validate numericality of mailchimp list id

### DIFF
--- a/app/models/mailing_list.rb
+++ b/app/models/mailing_list.rb
@@ -75,7 +75,8 @@ class MailingList < ActiveRecord::Base
   validates :subscribable_mode,
     inclusion: {in: SUBSCRIBABLE_MODES},
     if: :subscribable_for_configured?
-  validates :mailchimp_list_id, uniqueness: true, allow_blank: true
+  validates :mailchimp_list_id, uniqueness: true, numericality: {only_integer: true},
+    allow_blank: true
   validates :mailchimp_api_key, format: {with: /\A[a-z0-9]+-[a-z0-9]+\z/i}, allow_blank: true
 
   normalizes :additional_sender, with: ->(attribute) { attribute.downcase }

--- a/spec/models/mailing_list_spec.rb
+++ b/spec/models/mailing_list_spec.rb
@@ -131,6 +131,14 @@ describe MailingList do
       expect(list).to be_valid
     end
 
+    it "validates numericality of mailchimp_list_id" do
+      list.mailchimp_list_id = " 2"
+      expect(list).to have(1).error_on(:mailchimp_list_id)
+
+      list.mailchimp_list_id = "2"
+      expect(list).to be_valid
+    end
+
     it "fails with duplicate mailchimp_list_id" do
       Fabricate(:mailing_list, mailchimp_list_id: 42, group: groups(:bottom_layer_one))
       list.mailchimp_list_id = 42


### PR DESCRIPTION
Vorschlag für einen Fix für https://sentry.puzzle.ch/pitc/hitobito-backend/issues/79734

Wir könnten stattdessen auch `before_save` das Feld `.strip`pen. Oder die Datenbankspalte auf Number migrieren. Erst im Mailchimp Client zu `.strip`pen geht nicht, dann könnte man damit die uniqueness aushebeln. Meinungen?