### PR TITLE
Switch deployment to the stable branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,9 @@ on:
         required: false
         type: string
       target_branch:
-        description: "Branch of individual repos, mostly: master"
+        description: "Release a specific branch of the core and wagons. Leave empty for intelligent defaults"
         required: false
         type: string
-        default: master
       extra_packages:
         description: "List of additional OS-packages to be installed, space-separated"
         required: false
@@ -73,10 +72,9 @@ on:
         required: true
         type: string
       target_branch:
-        description: "Branch of individual repos, mostly: master"
+        description: "Release a specific branch of the core and wagons. Leave empty for intelligent defaults"
         required: false
         type: string
-        default: master
       extra_packages:
         description: "List of additional OS-packages to be installed, space-separated"
         required: false
@@ -106,6 +104,7 @@ jobs:
     with:
       repository: ${{ inputs.composition }}
       stage: ${{ inputs.stage }}
+      target_branch: ${{ inputs.target_branch }}
       release_type: ${{ inputs.release_type }}
       prevent_prepare: ${{ inputs.prevent_prepare }}
       prevent_push: ${{ inputs.prevent_push }}
@@ -131,7 +130,7 @@ jobs:
       composition_branch: ${{ needs.settings.outputs.composition_branch }}
       version: ${{ needs.version.outputs.version }}
       stage: ${{ needs.settings.outputs.release_stage }}
-      target_branch: ${{ inputs.target_branch }}
+      target_branch: ${{ needs.settings.outputs.target_branch }}
       dry_run: ${{ needs.settings.outputs.dry_run }}
     secrets: inherit
 

--- a/.github/workflows/stage-settings.yml
+++ b/.github/workflows/stage-settings.yml
@@ -11,6 +11,10 @@ on:
         description: "Stage of release to be prepared, e.g. integration"
         required: true
         type: string
+      target_branch:
+        description: "Release a specific branch of the core and wagons. Leave empty for intelligent defaults"
+        required: false
+        type: string
       release_type:
         description: "Type of Release: regular, patch or custom"
         required: false
@@ -41,6 +45,8 @@ on:
         value: ${{ jobs.settings.outputs.repo_url }}
       composition_branch:
         value: ${{ jobs.settings.outputs.composition_branch }}
+      target_branch:
+        value: ${{ jobs.settings.outputs.target_branch }}
       release_stage:
         value: ${{ jobs.settings.outputs.release_stage }}
       release_type:
@@ -63,6 +69,7 @@ jobs:
       repo_name: ${{ steps.determine.outputs.repo_name }}
       repo_url: ${{ steps.determine.outputs.repo_url }}
       composition_branch: ${{ steps.determine.outputs.branch }}
+      target_branch: ${{ steps.determine.outputs.target_branch }}
       release_stage: ${{ steps.determine.outputs.stage }}
       release_type: ${{ steps.determine.outputs.release_type }}
       namespace_name: ${{ steps.determine.outputs.namespace_name }}
@@ -77,6 +84,8 @@ jobs:
           STAGE: ${{ inputs.stage }}
           REPO: ${{ inputs.repository }}
           RELEASE_TYPE: ${{ inputs.release_type }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          INTEGRATION_DEPLOY_BRANCH: ${{ values.INTEGRATION_DEPLOY_BRANCH }}
           DRY_RUN: ${{ inputs.prevent_prepare }}
           DRY_PUSH: ${{ inputs.prevent_push }}
           DRY_DEPLOY: ${{ inputs.prevent_deployment }}
@@ -108,12 +117,14 @@ jobs:
           case $STAGE in
             production)
               echo "branch=production" >> "$GITHUB_OUTPUT"
+              echo "target_branch=${TARGET_BRANCH:-stable}" >> "$GITHUB_OUTPUT"
               echo "release_type=${RELEASE_TYPE}" >> "$GITHUB_OUTPUT"
               echo "namespace_name=hit-${project//_/-}-prod" >> "$GITHUB_OUTPUT"
             ;;
 
             integration)
               echo "branch=devel" >> "$GITHUB_OUTPUT"
+              echo "target_branch=${TARGET_BRANCH:-${INTEGRATION_DEPLOY_BRANCH:-master}}" >> "$GITHUB_OUTPUT"
               echo "release_type=integration" >> "$GITHUB_OUTPUT"
               echo "namespace_name=hit-${project//_/-}-int" >> "$GITHUB_OUTPUT"
             ;;

--- a/.github/workflows/update-productions.yml
+++ b/.github/workflows/update-productions.yml
@@ -20,11 +20,10 @@ on:
         type: string
         description: "next version number, if Release is custom"
         required: false
-      branch:
-        type: string
-        description: "Branch to be released"
+      target_branch:
+        description: "Release a specific branch of the core and wagons. Leave empty for intelligent defaults"
         required: false
-        default: "master"
+        type: string
 
 permissions:
   contents: write
@@ -58,5 +57,5 @@ jobs:
       release_type: ${{ inputs.release }}
       next_version: ${{ inputs.version }}
       stage: production
-      target_branch: ${{ inputs.branch }}
+      target_branch: ${{ inputs.target_branch }}
     secrets: inherit


### PR DESCRIPTION
Wir müssen noch in allen Composition Repositories in den update-integration und update-production Workflows das `default: master` und `|| 'master'` rausnehmen. Es ist sowieso viel flexibler, den Default-Wert erst spät im `version` Skript zu berechnen, anstatt bei jedem Zwischenschritt einen Fallback eingebaut zu haben.

Die Steuerung, ob `stable` oder `master` auf Integration deployed wird, kann in Zukunft unter https://github.com/organizations/hitobito/settings/variables/actions zentral für alle Integrationen gesetzt werden. Falls wir vorübergehend für eine Integration einen abweichenden Wert brauchen, müssen wir dies weiterhin im entsprechenden Composition Repo im Workflow hartcodieren.