### PR TITLE
Fix ability when participation has no person

### DIFF
--- a/app/abilities/event/participation_ability.rb
+++ b/app/abilities/event/participation_ability.rb
@@ -106,7 +106,8 @@ class Event::ParticipationAbility < AbilityDsl::Base
   end
 
   def manager
-    contains_any?([user.id], person.managers.pluck(:id))
+    manager_ids = person&.managers&.pluck(:id) || []
+    contains_any?([user.id], manager_ids)
   end
 
   def person


### PR DESCRIPTION
This lead to a exception in the sww specs, due to the new Elternzugang which was moved to the core.

https://github.com/hitobito/hitobito_sww/actions/runs/19433516234/job/55598218251