### PR TITLE
Improve wagon github workflow template

### DIFF
--- a/lib/templates/wagon/github/workflows/tests.yml.tt
+++ b/lib/templates/wagon/github/workflows/tests.yml.tt
@@ -2,6 +2,7 @@ name: 'Lint and test'
 
 on:
   push:
+    branches: [ master ]
     paths-ignore:
       - 'doc/**'
       - '**.md'


### PR DESCRIPTION
Trigger `Lint and test` on push only for the master branch. Else, when pushing to a branch and creating a PR, duplicate jobs are triggered.