### PR TITLE
Clear remember_me on password reset (hitobito/hitobito_sww#310)

### DIFF
--- a/app/controllers/person/security_tools_controller.rb
+++ b/app/controllers/person/security_tools_controller.rb
@@ -41,6 +41,7 @@ class Person::SecurityToolsController < ApplicationController
 
   def password_override
     person.encrypted_password = nil
+    person.forget_me!
     person.save
     notify
     if herself?


### PR DESCRIPTION
An error ocurred when the password of a logged in user (with remember_me) was resetted and the user opened a page with the old cookie.

An further improvement would be, to properly handle the bad state in the controller.

For now, we just try to avoid the bad state and cleanup existing data:

```
Person.where(encrypted_password: nil).where.not(remember_created_at: nil).update_all remember_created_at: nil
```