### PR TITLE
Activate skipped mail relay spec

### DIFF
--- a/spec/jobs/mail_relay_job_spec.rb
+++ b/spec/jobs/mail_relay_job_spec.rb
@@ -5,7 +5,7 @@
 
 require "spec_helper"
 
-xdescribe MailRelayJob do
+describe MailRelayJob do
   subject { MailRelayJob.new }
 
   it "relays mails and gets rescheduled" do


### PR DESCRIPTION
Maybe you have some background why the spec was disabled? https://github.com/hitobito/hitobito/commit/b6571f4eb57244d94ef769433ad2bb44c24af105