### PR TITLE
Downgrade caxlsx to fix corrupted xlsx files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "bcrypt"
 gem "bleib"
 gem "bootsnap", require: false
 gem "cancancan"
-gem "caxlsx"
+gem "caxlsx", "< 4.3.0" # 4.3.0 and upwards produces corrupted xlsx files
 gem "charlock_holmes"
 gem "commonmarker"
 gem "config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,11 +173,11 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
-    caxlsx (4.4.0)
+    caxlsx (4.2.0)
       htmlentities (~> 4.3, >= 4.3.4)
       marcel (~> 1.0)
       nokogiri (~> 1.10, >= 1.10.4)
-      rubyzip (>= 2.4, < 4)
+      rubyzip (>= 1.3.0, < 3)
     cgi (0.5.0)
     charlock_holmes (0.7.9)
     childprocess (5.1.0)
@@ -351,7 +351,7 @@ GEM
     hashery (2.1.2)
     headless (3.0.0)
     hirb (0.7.3)
-    htmlentities (4.3.4)
+    htmlentities (4.4.2)
     http-accept (1.7.0)
     http-cookie (1.1.0)
       domain_name (~> 0.5)
@@ -692,7 +692,7 @@ GEM
       ffi (~> 1.12)
       logger
     ruby2_keywords (0.0.5)
-    rubyzip (3.2.0)
+    rubyzip (2.4.1)
     securerandom (0.4.1)
     seed-fu (2.3.9)
       activerecord (>= 3.1)
@@ -850,7 +850,7 @@ DEPENDENCIES
   cancancan
   capybara
   capybara-screenshot
-  caxlsx
+  caxlsx (< 4.3.0)
   charlock_holmes
   ci_reporter_rspec
   cmdparse


### PR DESCRIPTION
Changes between 4.2.0 and 4.3.0: https://github.com/caxlsx/caxlsx/compare/v4.2.0...v4.3.0
Nothing obvious, maybe it's just the updated rubyzip version...