### PR TITLE
[skip ci] Push wagon translations before pull them (#3772)

### DIFF
--- a/lib/release/commands.rb
+++ b/lib/release/commands.rb
@@ -66,8 +66,8 @@ module Release
 
           ["hitobito", *(@all_wagons.map { |wgn| "hitobito_#{wgn}" })].each do |dir|
             in_dir(dir) do
-              update_translations
               upload_translation_sources
+              update_translations
               push
             end
           end


### PR DESCRIPTION
Damit funktioniert hoffentlich der in  https://github.com/hitobito/hitobito/blob/master/doc/architecture/adr/011_deutsche-texte-auf-transifex-uebersetzbar.md beschriebene Approach weiterhin. Zudem sollten damit hoffentlich auch beim erstmalige Deployment von einem Commit mit locale changes (ohne kunden spezifische Übersetzungen der default sprache) die Übersetzungen aus dem Commit erhalten bleiben