### PR TITLE
Revert "Use a single shared version number for all simultaneously deployed instances (#3777)"

### DIFF
--- a/.github/workflows/next-version.yml
+++ b/.github/workflows/next-version.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           repository: ${{ inputs.composition_repo }}
           ref: ${{ inputs.composition_ref }}
-          submodules: true
 
       - name: "Set up Ruby"
         uses: ruby/setup-ruby@v1
@@ -48,14 +47,24 @@ jobs:
         run: |
           gem install cmdparse
 
+      - name: "Get all tags from repo to determine the version"
+        run: |
+          git fetch --tags
+
+      - name: 'Install helper-script'
+        env:
+          VERSION_SOURCE: "https://raw.githubusercontent.com/hitobito/hitobito/master/bin/version"
+        run: |
+          mkdir -p bin
+          curl --silent -k  "$VERSION_SOURCE" > bin/version
+          chmod a+x bin/version
+
       - name: "Determine next version"
         id: determine
         env:
           RELEASE_TYPE: ${{ inputs.release_type }}
           NEXT_VERSION: ${{ inputs.next_version }}
-        working-directory: hitobito
         run: |
-          git fetch --tags
           echo "Requesting next '$RELEASE_TYPE'-version"
           next_version=$(bin/version suggest "$RELEASE_TYPE" "$NEXT_VERSION")
 

--- a/.github/workflows/update-productions.yml
+++ b/.github/workflows/update-productions.yml
@@ -52,21 +52,11 @@ jobs:
           echo $INSTANCES
           echo "instances=$INSTANCES" | tr -d "\n" >> $GITHUB_OUTPUT
 
-  version:
-    name: Determine the new version number for all selected instances
-    uses: ./.github/workflows/next-version.yml
-    with:
-      composition_repo: hitobito/ose_composition_demo # any composition repo would work, what matters are the tags present in the core
-      composition_ref: production
-      release_type: ${{ inputs.release }}
-      next_version: ${{ inputs.version }}
-
   release:
-    name: Update ${{ matrix.instance }} production to ${{ needs.version.outputs.version }}
+    name: Update ${{ matrix.instance }} production
     needs:
       - check-release-type
       - find-instances
-      - version
     strategy:
       fail-fast: false
       matrix:
@@ -75,8 +65,8 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       composition: hitobito/ose_composition_${{ matrix.instance }}
-      release_type: custom
-      next_version: ${{ needs.version.outputs.version }}
+      release_type: ${{ inputs.release }}
+      next_version: ${{ inputs.version }}
       stage: production
       target_branch: ${{ inputs.target_branch }}
     secrets: inherit


### PR DESCRIPTION
This commit causes that only one depoyment per day is possible. This might be ok for production, but not for integration.

This reverts commit 145e8a4fee53b491ff95e4159dc0e83c3cb715e3.

