### PR TITLE
Local dev with a known user and no prefilled jobs is easier

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ web: bundle exec rails s -b 0.0.0.0 -p 3000
 worker: bundle exec rake jobs:work
 mail: mailcatcher -f --smtp-port 2025
 webpack: bundle exec bin/webpack-dev-server
-migrate: echo "Migrating core" && bundle exec rails db:migrate && echo "Migrating wagons" && bundle exec rails wagon:migrate
+migrate: echo "Migrating core" && bundle exec rails db:migrate && echo "Migrating wagons" && bundle exec rails wagon:migrate && echo "Tweak local dev-setup" && bundle exec rails delayed_job:clear dev:local:admin


### PR DESCRIPTION
If needed, the delayed_jobs can be easily scheduled. In most cases, they create unneeded churn in the log and the local system.