### PR TITLE
Do not require remote_path param since that is not used in SAC

### DIFF
--- a/app/domain/sftp/config_contract.rb
+++ b/app/domain/sftp/config_contract.rb
@@ -12,7 +12,7 @@ class Sftp::ConfigContract < Dry::Validation::Contract
     required(:user).filled(:string)
     optional(:password).maybe(:string)
     optional(:private_key).maybe(:string)
-    required(:remote_path).filled(:string)
+    optional(:remote_path).maybe(:string)
   end
 
   rule(:port) do

--- a/spec/domain/sftp/config_contract_spec.rb
+++ b/spec/domain/sftp/config_contract_spec.rb
@@ -47,15 +47,14 @@ describe Sftp::ConfigContract do
       {
         host: "sftp.example.com",
         user: "testuser",
-        password: "secret123",
-        remote_path: "/uploads"
+        password: "secret123"
       }
     end
 
     it { is_expected.to be_success }
   end
 
-  %i[host user remote_path].each do |field|
+  %i[host user].each do |field|
     context "when #{field} is missing" do
       let(:params) { valid_params.except(field) }
 


### PR DESCRIPTION
see Export::BackupMitgliederExportJob

Fixes: https://glitchtip.puzzle.ch/hitobito/issues/9728/events/76b5ca599945422488eb5a5edb2e2354