### PR TITLE
Use InvoiceController as parent class for Contactable::InvoiceController

### DIFF
--- a/app/controllers/contactables/invoices_controller.rb
+++ b/app/controllers/contactables/invoices_controller.rb
@@ -3,7 +3,7 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
 
-class Contactables::InvoicesController < ListController
+class Contactables::InvoicesController < InvoicesController
   self.sort_mappings = {recipient: "people.order_name ASC"}
   self.search_columns = [:title, :sequence_number]
 


### PR DESCRIPTION
https://github.com/hitobito/hitobito/commit/9ad31fad192876e42cc62d067fb168205ca1a12a broke the view page for invoices on person (and groups in the future) because filter_params is not defined in the `contactable/invoices_controller`. I fixed it by just using the `InvoiceController` as a parent class instead of directly using the `ListController`. This fixes the issue and also makes much more sense in my Opinion, instead of completly seperating the invoice controllers, maybe it has a specific reason why, in that case we would have to define the filter_params in the controller seperatly.