### PR TITLE
Allow editing all organizer groups

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -122,6 +122,16 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
     p.permit(globalized_permitted_attrs)
   end
 
+  def return_path
+    super.then do |r|
+      next r if r.present? || entry.id.nil?
+      group_event_path(
+        entry.groups.find { |g| can?(:create, g.events.build) } || entry.groups.first,
+        entry
+      )
+    end
+  end
+
   def group
     parent
   end
@@ -134,7 +144,7 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
     master = @event.groups.first
     @groups = master.self_and_sister_groups.reorder(:name)
     # union to include assigned deleted events
-    @groups = (@groups | @event.groups) - [group]
+    @groups = (@groups | @event.groups)
   end
 
   def load_kinds

--- a/app/views/events/_group_fields.html.haml
+++ b/app/views/events/_group_fields.html.haml
@@ -7,7 +7,5 @@
   - if @groups.present?
     = field_set_tag t('event.run_by') do
       = f.labeled(:group_ids, '&nbsp;'.html_safe) do
-        = hidden_field_tag('event[group_ids][]', @group.id)
-        = f.inline_check_box(:group_ids, @group.id, @group.to_s, disabled: true)
         - @groups.each do |group|
           = f.inline_check_box(:group_ids, group.id, group.to_s)

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -82,7 +82,7 @@ de:
         at_least_one_present: Mindestens eine %{model_name} muss aufgefüllt werden
         type_not_allowed: kann hier nicht erstellt werden
         must_be_after_opening: muss nach dem Anmeldebeginn sein
-        must_have_same_type: müssen von denselbem Typ sein
+        must_have_same_type: müssen von demselben Typ sein
         greater_than: muss grösser als %{count} sein
         greater_than_or_equal_to: muss grösser oder gleich %{count} sein
         must_exist: müssen vorhanden sein

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -242,7 +242,7 @@ describe EventsController do
 
         get :new, params: {group_id: group.id, event: {type: "Event"}}
 
-        expect(assigns(:groups)).to eq([group3, group2])
+        expect(assigns(:groups)).to eq([group3, group2, group])
       end
 
       it "does not load deleted kinds" do

--- a/spec/features/event/events_controller_spec.rb
+++ b/spec/features/event/events_controller_spec.rb
@@ -14,6 +14,10 @@ describe EventsController, js: true do
     event
   end
 
+  def click_save
+    all("form .btn-group").first.click_button "Speichern"
+  end
+
   context "contacts" do
     NOTIFICATION_CHECKBOX_SELECTOR = "#event_notify_contact_on_participations"
 
@@ -33,10 +37,6 @@ describe EventsController, js: true do
 
     def notification_checkbox
       find(NOTIFICATION_CHECKBOX_SELECTOR)
-    end
-
-    def click_save
-      all("form .btn-group").first.click_button "Speichern"
     end
 
     it "may set and remove contact from event" do
@@ -97,6 +97,32 @@ describe EventsController, js: true do
 
       visit edit_path
       expect(notification_checkbox).to be_checked
+    end
+  end
+
+  context "group_ids" do
+    let(:group1) { groups(:bottom_layer_one) }
+    let(:group2) { groups(:bottom_layer_two) }
+    let(:event) do
+      event = Fabricate(:course, kind: event_kinds(:slk), groups: [group1])
+      event.dates.create!(start_at: 10.days.from_now, finish_at: 15.days.from_now)
+      event
+    end
+
+    let(:edit_path) { edit_group_event_path(event.group_ids.first, event.id) }
+
+    it "may change master organizer groups of course" do
+      sign_in
+      visit edit_path
+
+      # change organizer group
+      uncheck group1.name
+      check group2.name
+      click_save
+
+      expect(page).to have_current_path(group_event_path(group2, event.id))
+      expect(page).to have_content("Durchgeführt von\n#{group2.name}")
+      expect(page).not_to have_content(group1.name)
     end
   end
 


### PR DESCRIPTION
Vorher: 
<img width="651" height="105" alt="image" src="https://github.com/user-attachments/assets/0a3165af-ce13-492d-8901-bf0603431e10" />

Nachher:
<img width="651" height="105" alt="image" src="https://github.com/user-attachments/assets/9dd681cf-08ac-4773-826e-5a299b2140cf" />

Dies ist bereits seit langem ein Feature Request bzw. Problem bzw. Beschwerde von Usern. Zuordnung zu mehreren Organisator-Gruppen ist grundsätzlich nur bei Kursen aktiviert. Intern gehört der Event gleich fest zu allen Gruppen, daher behaupte ich wir verlieren hier keine echte Funktionalität, nur eine arbiträre Limitierung wird aufgehoben.

Fixes #2124
Refs https://github.com/hitobito/hitobito_pbs/issues/438

Eine Validierung, dass man sich nicht selber die Bearbeitungsrechte auf einem Event wegnimmt, ist derzeit nicht möglich, bis https://help.puzzle.ch/#ticket/zoom/10645 gelöst ist.