### PR TITLE
Add config option to exclude tags in post address sync (hitobito/hitobito_sac_cas#2207)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ config/environments/*.local.yml
 config/*.sphinx.conf
 Wagonfile
 config/mail.yml
+config/post-address-sync.yml
 
 # uploaded pictures
 public/uploads

--- a/app/domain/synchronize/addresses/swiss_post/config.rb
+++ b/app/domain/synchronize/addresses/swiss_post/config.rb
@@ -13,7 +13,8 @@ module Synchronize::Addresses::SwissPost
     LOG_CATEGORY = "cleanup"
 
     FILE_PATH = Rails.root.join("config", "post-address-sync.yml")
-    KEYS = %w[host path username password query_key batch_key person_constraints role_types].freeze
+    KEYS = %w[host path username password query_key batch_key
+      person_constraints role_types excluded_tags].freeze
 
     class << self
       def exist?

--- a/config/post-address-sync.example.yml
+++ b/config/post-address-sync.example.yml
@@ -7,3 +7,4 @@ post-address-sync:
   batch_key:
   person_constraints:
   role_types:
+  excluded_tags:


### PR DESCRIPTION
Das `config/post-address-sync.yml` muss wie folgt angepasst werden:

```yaml
  person_constraints: >
    people.country = 'CH' AND
    (roles.beitragskategorie IS NULL OR
     roles.beitragskategorie != 'family' OR
     people.sac_family_main_person)
  excluded_tags:
    - Postabgleich inaktiv
```

