### PR TITLE
Jobs worker: Reload code before performing job in dev env

### DIFF
--- a/app/domain/background_jobs/reloader.rb
+++ b/app/domain/background_jobs/reloader.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
+module BackgroundJobs
+  class Reloader < Delayed::Plugin
+    callbacks do |lifecycle|
+      lifecycle.before(:perform) do |*|
+        Rails.application.reloader.reload!
+      end
+    end
+  end
+end

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -9,6 +9,7 @@ Rails.application.reloader.to_prepare do
   # Therefore we use a high value here to allow for exceptionally long running jobs.
   # By default, BaseJobs have a shorter max_run_time configured.
   Delayed::Worker.max_run_time = 24.hours
+  Delayed::Worker.plugins << BackgroundJobs::Reloader if Rails.env.development?
   Delayed::Worker.plugins << BackgroundJobs::Logging
   Delayed::Worker.plugins << BackgroundJobs::LimitConcurrentExecutions
   Delayed::Worker.plugins << BackgroundJobs::PaperTrailed


### PR DESCRIPTION
Teach delayed job workers to reload the code before performing a job in the development environment.