### PR TITLE
Allow to display groups with only global roles in the role type list

### DIFF
--- a/app/domain/role/type_list.rb
+++ b/app/domain/role/type_list.rb
@@ -8,8 +8,9 @@ class Role
   class TypeList
     attr_reader :root, :role_types
 
-    def initialize(root_type)
+    def initialize(root_type, include_empty: false)
       @root = root_type
+      @include_empty = include_empty
       compose
     end
 
@@ -61,7 +62,7 @@ class Role
     def set_role_types(layer, group)
       layer_types = @role_types[layer.label]
       types = layer_types.delete(group.label).presence || local_role_types(group)
-      layer_types[group.label] = types if types.present?
+      layer_types[group.label] = types if types.present? || @include_empty
     end
 
     def compose_global_role_list

--- a/lib/tasks/hitobito.rake
+++ b/lib/tasks/hitobito.rake
@@ -15,7 +15,7 @@ namespace :hitobito do
       [label, klass.children.map(&:label)]
     }.to_h
 
-    Role::TypeList.new(Group.root_types.first).each do |layer, groups|
+    Role::TypeList.new(Group.root_types.first, include_empty: true).each do |layer, groups|
       super_layers = group_tree.select { |_key, list| list.include?(layer) }.keys
       super_layer_tag = " < #{super_layers.join(", ")}" if super_layers.any?
 

--- a/spec/domain/role/type_list_spec.rb
+++ b/spec/domain/role/type_list_spec.rb
@@ -30,6 +30,33 @@ describe Role::TypeList do
     ])
   end
 
+  it "contains all roles and empty groups for top layer" do
+    list = Role::TypeList.new(Group::TopLayer, include_empty: true)
+    expect(list.to_enum.to_a).to eq([
+      ["Top Layer",
+        {"Top Layer" => [Group::TopLayer::TopAdmin],
+         "Top Group" => [Group::TopGroup::Leader, Group::TopGroup::LocalGuide,
+           Group::TopGroup::Secretary, Group::TopGroup::LocalSecretary,
+           Group::TopGroup::GroupManager, Group::TopGroup::Member,
+           Group::TopGroup::InvisiblePeopleManager]}],
+
+      ["Bottom Layer",
+        {"Bottom Layer" => [Group::BottomLayer::Leader, Group::BottomLayer::LocalGuide,
+          Group::BottomLayer::Member, Group::BottomLayer::BasicPermissionsOnly],
+         "A De" => [],
+         "B De" => [],
+         "Bottom Group" => [Group::BottomGroup::Leader, Group::BottomGroup::Member,
+           Group::BottomGroup::NoPermissions],
+         "Mounted Attrs Group" => []}],
+
+      ["Global",
+        {
+          "Global Group" => [Group::GlobalGroup::Leader, Group::GlobalGroup::Member],
+          "Global" => [Role::External]
+        }]
+    ])
+  end
+
   it "contains all roles for bottom layer" do
     list = Role::TypeList.new(Group::BottomLayer)
     expect(list.to_enum.to_a).to eq([


### PR DESCRIPTION
hitobito/hitobito_pfadi_de#14

If multiple subgroup types inherit from a common superclass and do not define any custom roles, all the roles in these subgroup types will be considered global roles. This has been correct so far.

However, so far, we have excluded any group types without any non-global roles from the role type list. This is useful for configuring mailing lists, but for the README role and group type listing, it's wrong.