### PR TITLE
Fix horizontal overflow on login page

### DIFF
--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -399,7 +399,7 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
   def indented(content = nil, &block)
     content = capture(&block) if block
     content_tag(:div, class: "row mb-2") do
-      content_tag(:div, content, class: "offset-md-3 offset-xl-2")
+      content_tag(:div, content, class: "offset-md-3 offset-xl-2 col-md-9 col-xl-10")
     end
   end
 


### PR DESCRIPTION
Before: horizontal scrolling possible in m and xl sizes
<img width="1741" height="864" alt="Screenshot from 2026-01-27 14-51-47" src="https://github.com/user-attachments/assets/c84ca023-04f5-454f-a241-5d1fb926fe99" />

After: no horizontal scroll anymore
<img width="1741" height="864" alt="Screenshot from 2026-01-27 14-53-00" src="https://github.com/user-attachments/assets/5dbf6af4-308c-48f4-b1cf-0ea57c3817a5" />
