### PR TITLE
Link to event inside the known group

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -129,4 +129,10 @@ class EventDecorator < ApplicationDecorator
 
     safe_join(contact_attributes.values_at(*visible_contact_attributes.map(&:to_sym)))
   end
+
+  def organizer_group(group = nil)
+    group ||= event.groups.first
+    return group if groups.include?(group)
+    groups.where(id: group.descendants).first || groups.first
+  end
 end

--- a/app/views/events/_list_table.html.haml
+++ b/app/views/events/_list_table.html.haml
@@ -1,6 +1,6 @@
 = crud_table do |t|
   - t.col(t.sort_header(:name)) do |e|
-    %strong= link_to e.name, group_event_path(e.groups.first, e)
+    %strong= link_to e.name, group_event_path(e.organizer_group(@group), e)
   - t.sortable_attr(:dates_full)
   - t.attr(:description_short, t.attr_header(:description))
   - t.attr(:booking_info)
@@ -9,5 +9,5 @@
 
   = render_extensions(:list_columns, locals: { t: t })
 
-  - t.col(nil, class: 'center') { |e| button_action_event_apply(e, e.groups.first) }
+  - t.col(nil, class: 'center') { |e| button_action_event_apply(e, e.organizer_group(@group)) }
 


### PR DESCRIPTION
In 2d6d30ec and f0ffaa9f, we previously switched to displaying the event in the context of the first organizer group. Now that with #3889 all groups are equally organizer, we can link to display the event in the context of the current group, or a fitting subgroup of the current group.