### PR TITLE
Fix render_extensions output in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -88,8 +88,8 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  # Annotate rendered view with file names.
-  config.action_view.annotate_rendered_view_with_filenames = true
+  # Do not annotate rendered view with file names. This breaks our render_extensions mechanism.
+  config.action_view.annotate_rendered_view_with_filenames = false
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true


### PR DESCRIPTION
When activated, this setting outputs HTML comments like
```
<!-- BEGIN path/to/partial -->
```
and
```
<!-- END path/to/partial -->
```

These comments are directly output and, if inside a `content_tag do` block, will override the returned output of the block. Therefore, in development, render_extensions with an actual wagon extension file would previously delete the content of any content_tag calls around them.
One such example is the events list with the PBS wagon, but there must be lots more.