### PR TITLE
Fix language dropdown issues

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -374,6 +374,12 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
       find_by(email: Settings.root_email)
     end
 
+    def language_labels
+      Person::LANGUAGES.keys.map do |key|
+        [key, I18n.t("activerecord.attributes.person.languages.#{key}")]
+      end
+    end
+
     private
 
     def company_case_column(if_company, otherwise)

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -555,6 +555,9 @@ de:
           de: Deutsch
           en: Englisch
           fr: Französisch
+          it: Italienisch
+          rm: Rätoromanisch
+          
         primary_group_id: Hauptgruppe
         layer_group_label: Hauptebene
         self_registration_reason: Eintrittsgrund


### PR DESCRIPTION
When a language is not translated, it doesn't show up in the dropdown anymore, since language now is a I18nEnum. We decided to translate the languages in core, to have the translation ready in every wagon.

There also was an issue that Person.language_labels loads all translated languages, but some (those from core like english) are not registered languages in some wagons, they shouldn't be selectable