### PR TITLE
Do not run invoice export job when no invoices found

### DIFF
--- a/app/jobs/export/invoices_job.rb
+++ b/app/jobs/export/invoices_job.rb
@@ -24,6 +24,8 @@ class Export::InvoicesJob < Export::ExportBaseJob
   end
 
   def data
+    return if entries.blank?
+
     case @format
     when :pdf
       Export::Pdf::Invoice.render_multiple(entries, @options.merge({

--- a/spec/jobs/export/invoices_job_spec.rb
+++ b/spec/jobs/export/invoices_job_spec.rb
@@ -42,4 +42,14 @@ describe Export::InvoicesJob do
       subject.perform
     end
   end
+
+  context "no invoices" do
+    let(:format) { :pdf }
+    let(:invoice_ids) { [] }
+
+    it "does nothing" do
+      expect(Export::Pdf::Invoice).not_to receive(:render_multiple).with(invoices_in_order, anything)
+      subject.perform
+    end
+  end
 end


### PR DESCRIPTION
https://glitchtip.puzzle.ch/hitobito/issues/10005

I don't exactly know how the invoice_run got created, but it should definitely not do something when there's no invoice found...