### PR TITLE
Implement attribute-level permissions

### DIFF
--- a/app/abilities/ability_dsl/attribute_config.rb
+++ b/app/abilities/ability_dsl/attribute_config.rb
@@ -1,0 +1,31 @@
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module AbilityDsl
+  # Configuration for attribute-level permissions.
+  # Records which attributes are permitted or excluded for a given
+  # permission, action and constraint.
+  #
+  # +kind+ is either :permit (allowlist) or :except (denylist).
+  #
+  # For +:permit+, a +can+ rule scoped to the listed attributes is generated.
+  # For +:except+, a +cannot+ rule scoped to the listed attributes is generated
+  # (paired with a broad +can+ rule registered separately).
+  class AttributeConfig
+    attr_reader :permission, :subject_class, :action, :ability_class,
+      :constraint, :attrs, :kind
+
+    def initialize(permission, subject_class, action, ability_class, constraint, attrs,
+      kind = :permit)
+      @permission = permission
+      @subject_class = subject_class
+      @action = action
+      @ability_class = ability_class
+      @constraint = constraint
+      @attrs = Array(attrs)
+      @kind = kind
+    end
+  end
+end

--- a/app/helpers/standard_form_builder.rb
+++ b/app/helpers/standard_form_builder.rb
@@ -40,6 +40,8 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
   # The input field is chosen based on the ActiveRecord column type.
   # Use additional html_options for the input element.
   def input_field(attr, html_options = {}) # rubocop:disable Metrics/*
+    return readonly_value(attr, html_options) if cannot?(:update, @object, attr)
+
     # Checks if the attr is a globalized attr (translates: ...) and automatically generates
     # a globalized input field for it, allowing the user to fill in the field in
     # all available languages.
@@ -431,9 +433,10 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
   # To add an additional help text, use the help option.
   # E.g. labeled_boolean_field(:checked, :help => 'Some Help')
   def method_missing(name, *args)
-    field_method = labeled_field_method?(name)
-    if field_method
+    if (field_method = labeled_field_method?(name))
       build_labeled_field(field_method, *args)
+    elsif (field_method = permitted_field_method?(name))
+      build_permitted_field(field_method, *args)
     else
       super
     end
@@ -441,7 +444,9 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
 
   # Overriden to fullfill contract with method_missing 'labeled_' methods.
   def respond_to_missing?(name, include_all = false)
-    labeled_field_method?(name).present? || super
+    labeled_field_method?(name).present? ||
+      permitted_field_method?(name).present? ||
+      super
   end
 
   # Generates a help inline for fields
@@ -490,6 +495,8 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   private
+
+  def cannot?(*args) = @template.current_ability&.cannot?(*args)
 
   # Returns true if attr is a non-polymorphic association.
   # If one or more macros are given, the association must be of this kind.
@@ -572,6 +579,22 @@ class StandardFormBuilder < ActionView::Helpers::FormBuilder
       required: options[:required],
       label_class: label_class,
       class: content_class)
+  end
+
+  def permitted_field_method?(name)
+    suffix = "_if_permitted"
+    if name.to_s.end_with?(suffix)
+      field_method = name.to_s[0...-suffix.size]
+      field_method if respond_to?(field_method)
+    end
+  end
+
+  def build_permitted_field(field_method, *args)
+    if @template.can?(:update, @object, args.first)
+      send(field_method, *args)
+    else
+      readonly_value(*args)
+    end
   end
 
   def with_labeled_field_help(help, help_inline)

--- a/spec/abilities/ability_dsl/attribute_level_permissions_spec.rb
+++ b/spec/abilities/ability_dsl/attribute_level_permissions_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
+require "spec_helper"
+
+describe "Attribute-level permissions" do
+  before do
+    stub_const("TestAttributeAbility", Class.new(AbilityDsl::Base) do
+      include AbilityDsl::Constraints::Person
+
+      on(Person) do
+        permission(:any).may(:update).herself
+        permission(:any).may(:update).except_attrs(:first_name).herself
+        permission(:layer_and_below_full).may(:update).in_same_layer_or_below
+      end
+
+      def person = subject
+    end)
+
+    stub_const("TestAbility", Class.new(Ability) do
+      self.store = AbilityDsl::Store.new
+    end)
+    TestAbility.store.register(TestAttributeAbility)
+  end
+
+  let(:user) { people(:bottom_member) }
+
+  subject(:ability) { TestAbility.new(user) }
+
+  describe "except_attrs DSL" do
+    context "when updating herself" do
+      let(:user) { people(:bottom_member) }
+
+      it "cannot update first_name" do
+        expect(ability.can?(:update, user, :first_name)).to be false
+      end
+
+      it "can update last_name" do
+        expect(ability.can?(:update, user, :last_name)).to be true
+      end
+
+      it "can still update overall" do
+        expect(ability.can?(:update, user)).to be true
+      end
+
+      it "excludes first_name from permitted_attributes" do
+        attrs = ability.permitted_attributes(:update, user)
+        expect(attrs).not_to include(:first_name)
+        expect(attrs).to include(:last_name)
+      end
+    end
+
+    context "when updating another person" do
+      let(:user) do
+        Fabricate(Group::BottomLayer::Leader.sti_name, group: roles(:bottom_member).group).person
+      end
+      let(:other) { people(:bottom_member) }
+
+      it "can update first_name (no attribute restriction for this path)" do
+        # first make sure the user has permission to update other in general
+        expect(ability.can?(:update, other)).to be true
+
+        # then check that the attribute restriction does not apply when updating another person
+        expect(ability.can?(:update, other, :first_name)).to be true
+      end
+
+      it "includes first_name in permitted_attributes" do
+        attrs = ability.permitted_attributes(:update, other)
+        expect(attrs).to include(:first_name)
+      end
+    end
+  end
+end

--- a/spec/abilities/ability_dsl/recorder_spec.rb
+++ b/spec/abilities/ability_dsl/recorder_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
+require "spec_helper"
+
+describe AbilityDsl::Recorder do
+  let(:store) { instance_double(AbilityDsl::Store) }
+  let(:ability_class) do
+    Class.new(AbilityDsl::Base) do
+      def self.constraint_methods
+        [:herself, :in_same_group, :everybody]
+      end
+    end
+  end
+  let(:subject_class) { Person }
+
+  before do
+    allow(store).to receive(:add)
+    allow(store).to receive(:add_attribute_config)
+  end
+
+  describe AbilityDsl::Recorder::Permission do
+    subject(:permission) { described_class.new(store, ability_class, subject_class, :any) }
+
+    describe "without attribute restrictions" do
+      it "only calls store.add when no attr_config is set" do
+        expect(store).to receive(:add).once
+        expect(store).not_to receive(:add_attribute_config)
+
+        permission.may(:update).tap do |p|
+          p.send(:constraint, :herself)
+        end
+      end
+    end
+
+    describe "#permitted_attrs" do
+      it "does NOT call store.add for regular config" do
+        expect(store).not_to receive(:add)
+
+        permission.may(:update).permitted_attrs(:first_name).herself
+      end
+
+      it "calls store.add_attribute_config with correct parameters" do
+        expected_config = have_attributes(
+          permission: :any,
+          subject_class: Person,
+          action: :update,
+          ability_class: ability_class,
+          constraint: :herself,
+          attrs: [:first_name],
+          kind: :permit
+        )
+
+        expect(store).to receive(:add_attribute_config).with(expected_config)
+
+        permission.may(:update).permitted_attrs(:first_name).herself
+      end
+
+      it "creates attribute config for each action" do
+        expect(store).to receive(:add_attribute_config).twice
+
+        permission.may(:update, :show).permitted_attrs(:first_name).herself
+      end
+
+      it "works with multiple attributes" do
+        expected_config = have_attributes(
+          attrs: [:first_name, :last_name, :email],
+          kind: :permit
+        )
+
+        expect(store).to receive(:add_attribute_config).with(expected_config)
+
+        permission.may(:update).permitted_attrs(:first_name, :last_name, :email).herself
+      end
+    end
+
+    describe "#except_attrs" do
+      it "calls store.add" do
+        expected_config = have_attributes(
+          permission: :any,
+          subject_class: Person,
+          action: :update,
+          ability_class: ability_class,
+          constraint: :herself
+        )
+
+        expect(store).to receive(:add).with(expected_config)
+
+        permission.may(:update).except_attrs(:first_name).herself
+      end
+
+      it "calls store.add_attribute_config with correct parameters" do
+        expected_config = have_attributes(
+          permission: :any,
+          subject_class: Person,
+          action: :update,
+          ability_class: ability_class,
+          constraint: :herself,
+          attrs: [:first_name],
+          kind: :except
+        )
+
+        expect(store).to receive(:add_attribute_config).with(expected_config)
+
+        permission.may(:update).except_attrs(:first_name).herself
+      end
+
+      it "creates both configs for each action" do
+        # One add call and one add_attribute_config call per action
+        expect(store).to receive(:add).twice
+        expect(store).to receive(:add_attribute_config).twice
+
+        permission.may(:update, :show).except_attrs(:first_name).herself
+      end
+
+      it "works with multiple attributes" do
+        expected_config = have_attributes(
+          attrs: [:first_name, :last_name, :email],
+          kind: :except
+        )
+
+        expect(store).to receive(:add_attribute_config).with(expected_config)
+
+        permission.may(:update).except_attrs(:first_name, :last_name, :email).herself
+      end
+    end
+  end
+end

--- a/spec/abilities/ability_dsl/store_spec.rb
+++ b/spec/abilities/ability_dsl/store_spec.rb
@@ -6,7 +6,7 @@
 require "spec_helper"
 
 describe AbilityDsl::Store do
-  subject { AbilityDsl::Store.new }
+  subject(:store) { AbilityDsl::Store.new }
 
   before { subject.load }
 
@@ -49,6 +49,43 @@ describe AbilityDsl::Store do
       subject.add(c1)
       subject.add(c2)
       expect(subject.general_constraints(:subj, :action)).to match_array([c1])
+    end
+  end
+
+  context "#attribute_config_for" do
+    it "finds attribute_config_for matching key" do
+      config = AbilityDsl::AttributeConfig.new(
+        :any, Person, :update, PersonAbility, :herself, [:first_name], :except
+      )
+      store.add_attribute_config(config)
+
+      found = store.attribute_config(:any, Person, :update)
+      expect(found).to eq config
+    end
+
+    it "returns nil for non-matching key" do
+      config = AbilityDsl::AttributeConfig.new(
+        :any, Person, :update, PersonAbility, :herself, [:first_name], :except
+      )
+      store.add_attribute_config(config)
+
+      expect(store.attribute_config(:group_full, Person, :update)).to be_nil
+    end
+
+    it "overwrites attribute configs with same key (wagon override)" do
+      config1 = AbilityDsl::AttributeConfig.new(
+        :any, Person, :update, PersonAbility, :herself, [:first_name], :except
+      )
+      config2 = AbilityDsl::AttributeConfig.new(
+        :any, Person, :update, PersonAbility, :herself, [:first_name, :last_name], :except
+      )
+
+      store.add_attribute_config(config1)
+      store.add_attribute_config(config2)
+
+      configs = store.instance_variable_get(:@attribute_configs).values
+      expect(configs.size).to eq 1
+      expect(configs.first.attrs).to eq [:first_name, :last_name]
     end
   end
 end


### PR DESCRIPTION
Implement Attribute-level permissions. This allows fine-granular permissions, e.g.:

        on(Person) do
          permission(:any).may(:update).except_attrs(:first_name, :last_name).herself
        end