### PR TITLE
Parse date value in datetime setter (hitobito/hitobito_sac_cas#2262)

### DIFF
--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -589,6 +589,42 @@ describe Event do
       e.update(dates_attributes: {"0" => {finish_at_date: d2, id: ed.id}})
       expect(e.dates.first.finish_at).to eq(Time.zone.local(2012, 12, 13, 0, 0))
     end
+
+    it "should not have changes when start_at did not change" do
+      date_time = Time.zone.local(2026, 2, 17)
+      date_record = e.dates.create!(start_at: date_time)
+
+      expect(date_record).not_to receive(:start_at_will_change!)
+
+      e.update(
+        dates_attributes: {
+          "0" => {
+            id: date_record.id,
+            start_at_date: date_time.to_s,
+            start_at_hour: date_time.hour,
+            start_at_min: date_time.min
+          }
+        }
+      )
+    end
+
+    it "should set hour and minute to zero when nil is passed" do
+      date_time = Time.zone.local(2026, 2, 17, 6, 7)
+      date_record = e.dates.create!(start_at: date_time)
+
+      e.update(
+        dates_attributes: {
+          "0" => {
+            id: date_record.id,
+            start_at_hour: nil,
+            start_at_min: nil
+          }
+        }
+      )
+
+      expect(date_record.start_at.hour).to be_zero
+      expect(date_record.start_at.min).to be_zero
+    end
   end
 
   context "participation role labels" do


### PR DESCRIPTION
This pull request solves an issue of not being able to track actual changes to event dates date fields (or other models including `DatetimeAttribute`).

The setter was comparing a string to a date which basically led to `start_at_will_change!` and `finish_at_will_change!` always triggering. This added start_at and finish_at to `changes`, when nothing has changed, which then breaks all the methods for active record dirty tracking:
- `will_save_change_to_start_at?`
- `changes_to_save`
- `changed?`
- `saved_change_to_start_at?`
- and many more: https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Dirty.html