### PR TITLE
Support using roles scope in subqueries

### DIFF
--- a/app/controllers/person/csv_imports_controller.rb
+++ b/app/controllers/person/csv_imports_controller.rb
@@ -177,7 +177,7 @@ class Person::CsvImportsController < ApplicationController
   end
 
   def redirect_params
-    {filters: {role: {role_type_ids: [role_type.id]}}, name: importer.human_role_name}
+    {filters: {role: {role_type_ids: [role_type.type_id]}}, name: importer.human_role_name}
   end
 
   def role_type

--- a/app/domain/person/filter/role.rb
+++ b/app/domain/person/filter/role.rb
@@ -86,7 +86,7 @@ class Person::Filter::Role < Person::Filter::Base
 
   def initialize_role_types
     classes = role_classes
-    args[:role_type_ids] = classes.map(&:id)
+    args[:role_type_ids] = classes.map(&:type_id)
     args[:role_types] = classes.map(&:sti_name)
   end
 

--- a/app/helpers/filter_navigation/people.rb
+++ b/app/helpers/filter_navigation/people.rb
@@ -177,7 +177,7 @@ module FilterNavigation
     end
 
     def fixed_types_path(name, types, options = {})
-      type_ids = types.collect(&:id).join(Person::Filter::Base::ID_URL_SEPARATOR)
+      type_ids = types.collect(&:type_id).join(Person::Filter::Base::ID_URL_SEPARATOR)
       path(options.merge(name: name,
         filters: {role: {role_type_ids: type_ids}}))
     end

--- a/app/models/concerns/type_id.rb
+++ b/app/models/concerns/type_id.rb
@@ -7,7 +7,7 @@ module TypeId
   extend ActiveSupport::Concern
 
   included do
-    class_attribute :id, instance_reader: false, instance_writer: false
+    class_attribute :type_id, instance_reader: false, instance_writer: false
   end
 
   module ClassMethods
@@ -16,7 +16,7 @@ module TypeId
     def inherited(subclass)
       super
       next_id = @@types_by_id.present? ? @@types_by_id.keys.max + 1 : 1
-      subclass.id = next_id
+      subclass.type_id = next_id
       @@types_by_id[next_id] = subclass
     end
 

--- a/app/views/people_filters/_role.html.haml
+++ b/app/views/people_filters/_role.html.haml
@@ -15,10 +15,10 @@
             %h5.filter-toggle= group
             .controls
               - role_types.each do |role_type|
-                - id = "filters_role_role_type_ids_#{role_type.id}"
+                - id = "filters_role_role_type_ids_#{role_type.type_id}"
                 = label_tag(nil, id, class: 'checkbox inline') do
                   = check_box_tag("filters[role][role_type_ids][]",
-                                  role_type.id,
+                                  role_type.type_id,
                                   filter && filter.to_hash[:role_types].include?(role_type.to_s),
                                   id: id)
                   = role_type.label

--- a/spec/controllers/invoice_runs_controller_spec.rb
+++ b/spec/controllers/invoice_runs_controller_spec.rb
@@ -85,7 +85,7 @@ describe InvoiceRunsController do
             group_id: group.id,
             range: "deep",
             filters: {
-              role: {role_type_ids: role_types.collect(&:id).join("-")}
+              role: {role_type_ids: role_types.collect(&:type_id).join("-")}
             }
           }
         }

--- a/spec/controllers/people_filters_controller_spec.rb
+++ b/spec/controllers/people_filters_controller_spec.rb
@@ -11,7 +11,7 @@ describe PeopleFiltersController do
   let(:user) { people(:top_leader) }
   let(:group) { groups(:top_group) }
   let(:role_types) { [Group::TopGroup::Leader, Group::TopGroup::Member] }
-  let(:role_type_ids) { role_types.collect(&:id) }
+  let(:role_type_ids) { role_types.collect(&:type_id) }
   let(:role_type_ids_string) { role_type_ids.join(Person::Filter::Base::ID_URL_SEPARATOR) }
   let(:role_type_names) { role_types.collect(&:sti_name) }
 

--- a/spec/controllers/person/csv_imports_controller_spec.rb
+++ b/spec/controllers/person/csv_imports_controller_spec.rb
@@ -104,7 +104,7 @@ describe Person::CsvImportsController do
       expect { post :create, params: required_params }.to change(Person, :count).by(1)
       expect(flash[:notice]).to eq ["1 Person (Leader) wurde erfolgreich importiert."]
       expect(flash[:alert]).not_to be_present
-      is_expected.to redirect_to group_people_path(group, filters: {role: {role_type_ids: [role_type.id]}},
+      is_expected.to redirect_to group_people_path(group, filters: {role: {role_type_ids: [role_type.type_id]}},
         name: "Leader")
     end
 
@@ -115,7 +115,7 @@ describe Person::CsvImportsController do
       it "imports first person and displays errors for second person" do
         expect { post :create, params: required_params }.to change(Person, :count).by(0)
         expect(flash[:alert]).to eq ["1 Person (Leader) wurde nicht importiert."]
-        is_expected.to redirect_to group_people_path(group, filters: {role: {role_type_ids: [role_type.id]}},
+        is_expected.to redirect_to group_people_path(group, filters: {role: {role_type_ids: [role_type.type_id]}},
           name: "Leader")
       end
     end
@@ -162,7 +162,7 @@ describe Person::CsvImportsController do
       it "is ignored" do
         expect { post :create, params: required_params }.to change(Person, :count).by(1)
         expect(flash[:alert]).to be_blank
-        is_expected.to redirect_to group_people_path(group, filters: {role: {role_type_ids: [role_type.id]}},
+        is_expected.to redirect_to group_people_path(group, filters: {role: {role_type_ids: [role_type.type_id]}},
           name: "Leader")
       end
     end
@@ -215,7 +215,7 @@ describe Person::CsvImportsController do
         it "creates request" do
           person # create
           post :create, params: required_params.merge(update_behaviour: "override")
-          is_expected.to redirect_to group_people_path(group, filters: {role: {role_type_ids: [role_type.id]}},
+          is_expected.to redirect_to group_people_path(group, filters: {role: {role_type_ids: [role_type.type_id]}},
             name: "Member")
 
           expect(person.reload.roles.count).to eq(1)
@@ -231,7 +231,7 @@ describe Person::CsvImportsController do
           Fabricate(Group::TopGroup::Member.name, group: groups(:top_group), person: user)
 
           post :create, params: required_params.merge(update_behaviour: "override")
-          is_expected.to redirect_to group_people_path(group, filters: {role: {role_type_ids: [role_type.id]}},
+          is_expected.to redirect_to group_people_path(group, filters: {role: {role_type_ids: [role_type.type_id]}},
             name: "Member")
 
           expect(person.reload.roles.count).to eq(2)
@@ -251,7 +251,7 @@ describe Person::CsvImportsController do
 
           post :create, params: required_params
 
-          is_expected.to redirect_to group_people_path(group, filters: {role: {role_type_ids: [role_type.id]}},
+          is_expected.to redirect_to group_people_path(group, filters: {role: {role_type_ids: [role_type.type_id]}},
             name: "Member")
           expect(person.reload.roles.count).to eq(1)
           expect(person.add_requests.count).to eq(1)

--- a/spec/controllers/tag_lists_controller_spec.rb
+++ b/spec/controllers/tag_lists_controller_spec.rb
@@ -69,7 +69,7 @@ describe TagListsController do
 
     it "shows modal for all people" do
       role_type_ids = [leader, bottom_member].map do |p|
-        p.roles.map { |r| r.class.id }
+        p.roles.map { |r| r.class.type_id }
       end.flatten.uniq
 
       get :new, xhr: true,
@@ -117,7 +117,7 @@ describe TagListsController do
 
     it "creates many tags on 'all' and displays flash message" do
       role_type_ids = [leader, bottom_member].map do |p|
-        p.roles.map { |r| r.class.id }
+        p.roles.map { |r| r.class.type_id }
       end.flatten.uniq
 
       post :create, params: {

--- a/spec/domain/person/filter/role_spec.rb
+++ b/spec/domain/person/filter/role_spec.rb
@@ -48,7 +48,7 @@ describe Person::Filter::Role do
     let(:entries) { list_filter.entries }
     let(:range) { nil }
     let(:role_types) { [] }
-    let(:role_type_ids_string) { role_types.collect(&:id).join(Person::Filter::Role::ID_URL_SEPARATOR) }
+    let(:role_type_ids_string) { role_types.collect(&:type_id).join(Person::Filter::Role::ID_URL_SEPARATOR) }
 
     before do
       @tg_member = Fabricate(Group::TopGroup::Member.name.to_sym, group: groups(:top_group)).person
@@ -247,7 +247,7 @@ describe Person::Filter::Role do
     context :filter do
       def filter(attrs)
         include_archived = attrs[:include_archived]
-        role_type_ids = Array(role_type).collect(&:id)
+        role_type_ids = Array(role_type).collect(&:type_id)
         filters = {role: transform(attrs).merge(role_type_ids: role_type_ids, kind: kind,
           include_archived: include_archived)}
         Person::Filter::List.new(attrs.fetch(:group, group), user, range: attrs.fetch(:range, range), filters: filters)

--- a/spec/features/person/people_filter_spec.rb
+++ b/spec/features/person/people_filter_spec.rb
@@ -15,8 +15,8 @@ describe PeopleController, js: true do
 
     sign_in_and_create_filter
 
-    find("#filters_role_role_type_ids_#{Group::BottomLayer::Leader.id}").set(true)
-    find("#filters_role_role_type_ids_#{Group::BottomLayer::Member.id}").set(true)
+    find("#filters_role_role_type_ids_#{Group::BottomLayer::Leader.type_id}").set(true)
+    find("#filters_role_role_type_ids_#{Group::BottomLayer::Member.type_id}").set(true)
     fill_in("people_filter_name", with: "Bottom Layer")
     all("form .btn-toolbar").first.click_button("Suche speichern")
 
@@ -31,10 +31,10 @@ describe PeopleController, js: true do
     # roles accordion is already open
     expect(page).to have_selector(".accordion-body", count: 1)
 
-    expect(page).to have_checked_field("filters_role_role_type_ids_#{Group::BottomLayer::Leader.id}")
-    expect(page).to have_checked_field("filters_role_role_type_ids_#{Group::BottomLayer::Member.id}")
+    expect(page).to have_checked_field("filters_role_role_type_ids_#{Group::BottomLayer::Leader.type_id}")
+    expect(page).to have_checked_field("filters_role_role_type_ids_#{Group::BottomLayer::Member.type_id}")
 
-    find("#filters_role_role_type_ids_#{Group::BottomLayer::Member.id}").set(false)
+    find("#filters_role_role_type_ids_#{Group::BottomLayer::Member.type_id}").set(false)
     all("form .btn-toolbar").first.click_button("Suchen")
 
     expect(page).to have_selector(".table tbody tr", count: 1)

--- a/spec/helpers/filter_navigation/people_spec.rb
+++ b/spec/helpers/filter_navigation/people_spec.rb
@@ -38,9 +38,9 @@ describe "FilterNavigation::People" do
     context "visible false" do
       before do
         group.people_filters.create!(name: "2_Members",
-          filter_chain: {role: {role_types: role_types.map(&:id)}}, visible: false)
+          filter_chain: {role: {role_types: role_types.map(&:type_id)}}, visible: false)
         group.people_filters.create!(name: "1_Leaders",
-          filter_chain: {role: {role_types: role_types.map(&:id)}}, visible: false)
+          filter_chain: {role: {role_types: role_types.map(&:type_id)}}, visible: false)
       end
 
       its("dropdown.items") { should have(3).items }
@@ -68,16 +68,15 @@ describe "FilterNavigation::People" do
           Group::GlobalGroup::Member,
           Group::TopGroup::Leader,
           Group::TopGroup::Secretary,
-          Group::TopGroup::Member]
-                                               .collect(&:id).join("-")}/
+          Group::TopGroup::Member].collect(&:type_id).join("-")}/
       end
 
       context "with custom filters" do
         before do
           group.people_filters.create!(name: "2_Members",
-            filter_chain: {role: {role_types: role_types.map(&:id)}}, visible: true)
+            filter_chain: {role: {role_types: role_types.map(&:type_id)}}, visible: true)
           group.people_filters.create!(name: "1_Leaders",
-            filter_chain: {role: {role_types: role_types.map(&:id)}}, visible: true)
+            filter_chain: {role: {role_types: role_types.map(&:type_id)}}, visible: true)
         end
 
         its("dropdown.active") { should be_falsey }
@@ -105,14 +104,14 @@ describe "FilterNavigation::People" do
     context "with selected filter" do
       before do
         group.people_filters.create!(name: "Leaders",
-          filter_chain: {role: {role_types: role_types.map(&:id)}}, visible: true)
+          filter_chain: {role: {role_types: role_types.map(&:type_id)}}, visible: true)
       end
 
       subject do
         filter = Person::Filter::List.new(group,
           nil,
           name: "Leaders",
-          filters: {role: {role_type_ids: role_types.map(&:id)}})
+          filters: {role: {role_type_ids: role_types.map(&:type_id)}})
         FilterNavigation::People.new(template, group, filter)
       end
 
@@ -146,8 +145,7 @@ describe "FilterNavigation::People" do
         Group::GlobalGroup::Leader,
         Group::GlobalGroup::Member,
         Group::BottomGroup::Leader,
-        Group::BottomGroup::Member]
-                                             .collect(&:id).join("-")}/
+        Group::BottomGroup::Member].collect(&:type_id).join("-")}/
     end
 
     it "contains member item with count" do

--- a/spec/regressions/person/csv_imports_controller_spec.rb
+++ b/spec/regressions/person/csv_imports_controller_spec.rb
@@ -47,7 +47,7 @@ describe Person::CsvImportsController, type: :controller do
           params: {group_id: group.id, data: data, role_type: role_type.sti_name, field_mappings: mapping}
       }.to change(Person, :count).by(1)
       is_expected.to redirect_to group_people_path(group, name: "Leader",
-        filters: {role: {role_type_ids: [role_type.id]}})
+        filters: {role: {role_type_ids: [role_type.type_id]}})
     end
   end
 


### PR DESCRIPTION
The `id` class variable on the `TypeId` Concern, which is used for
in Person filter for filtering by roles prevents that a roles scope is
properly used as a subquery, i.e.

`Person.select(:id).where(id: Role.limit(1).select(:id)).`

generates

```
  SELECT "people"."id"
  FROM "people"
  WHERE "people"."id" IS NULL
```

Changing the name changes the generated SQL to the expected

```
  SELECT "people"."id"
    FROM "people"
    WHERE "people"."id" IN (
      SELECT "roles"."id"
      FROM "roles"
      LIMIT 1
    )
```