### PR TITLE
Add missing css styles for displaying nested groups in nav

### DIFF
--- a/app/javascript/stylesheets/hitobito/modules/_nav_left.scss
+++ b/app/javascript/stylesheets/hitobito/modules/_nav_left.scss
@@ -138,27 +138,31 @@
     padding-left: 3 * $hierarchy-shift-width + $nav-left-padding-full;
   }
 
-  ul ul ul ul ul ul ul a {
+  ul ul ul ul ul ul a {
     padding-left: 4 * $hierarchy-shift-width + $nav-left-padding-full;
   }
 
-  ul ul ul ul ul ul ul ul a {
+  ul ul ul ul ul ul ul a {
     padding-left: 5 * $hierarchy-shift-width + $nav-left-padding-full;
   }
 
-  ul ul ul ul ul ul ul ul ul a {
+  ul ul ul ul ul ul ul ul a {
     padding-left: 6 * $hierarchy-shift-width + $nav-left-padding-full;
   }
 
-  ul ul ul ul ul ul ul ul ul ul a {
+  ul ul ul ul ul ul ul ul ul a {
     padding-left: 7 * $hierarchy-shift-width + $nav-left-padding-full;
   }
 
-  ul ul ul ul ul ul ul ul ul ul ul a {
+  ul ul ul ul ul ul ul ul ul ul a {
     padding-left: 8 * $hierarchy-shift-width + $nav-left-padding-full;
   }
 
-  ul ul ul ul ul ul ul ul ul ul ul ul a {
+  ul ul ul ul ul ul ul ul ul ul ul a {
     padding-left: 9 * $hierarchy-shift-width + $nav-left-padding-full;
+  }
+
+  ul ul ul ul ul ul ul ul ul ul ul ul a {
+    padding-left: 10 * $hierarchy-shift-width + $nav-left-padding-full;
   }
 }


### PR DESCRIPTION
<img width="385" height="255" alt="image" src="https://github.com/user-attachments/assets/35c21701-6765-4904-9edb-645a49ff0b77" />

This fixes the issue of groups (Child 2 and Child 3) to being displayed with the same padding, even tho they are nested in eachother