### PR TITLE
Only search addresses if addresses actually exist

### DIFF
--- a/app/domain/search_strategies/address_search.rb
+++ b/app/domain/search_strategies/address_search.rb
@@ -6,7 +6,7 @@
 module SearchStrategies
   class AddressSearch < Base
     def search_fulltext
-      return no_adresses unless term_present?
+      return no_adresses unless term_present? && Address.exists?
 
       Address.search(@term).limit(@limit)
     end

--- a/spec/domain/search_strategies/address_search_spec.rb
+++ b/spec/domain/search_strategies/address_search_spec.rb
@@ -51,6 +51,13 @@ describe SearchStrategies::AddressSearch do
         end
       end
     end
+
+    it "should return empty array when no address exists at all" do
+      Address.destroy_all
+      
+      expect(Address).not_to receive(:search)
+      expect(search_class("whatever").search_fulltext).to be_empty
+    end
   end
 
   def search_class(term = nil, page = nil)


### PR DESCRIPTION
fixes: https://glitchtip.puzzle.ch/hitobito/issues/12551

PostgreSql can't build the search column when no address exists, this happens to all wagons when the AddressSync didn't run yet.