### PR TITLE
Add description field to OAuth applications

### DIFF
--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -8,7 +8,7 @@
 module Oauth
   class ApplicationsController < CrudController
     self.permitted_attrs = [
-      :name, :redirect_uri, :confidential,
+      :name, :description, :redirect_uri, :confidential,
       :logo, :remove_logo, :skip_consent_screen,
       :additional_audiences,
       scopes: [], cors_origins_attributes: [:id, :origin, :_destroy]

--- a/app/views/oauth/applications/_attrs.html.haml
+++ b/app/views/oauth/applications/_attrs.html.haml
@@ -1,4 +1,4 @@
-= render_attrs(entry, :name, :uid, :secret, :redirect_uri, :additional_audiences, :scopes, :cors_origins, :skip_consent_screen)
+= render_attrs(entry, :name, :description, :uid, :secret, :redirect_uri, :additional_audiences, :scopes, :cors_origins, :skip_consent_screen)
 
 %dl.dl-horizontal.border-top.pt-2
   .labeled-grid

--- a/app/views/oauth/applications/_form.html.haml
+++ b/app/views/oauth/applications/_form.html.haml
@@ -1,6 +1,8 @@
 = entry_form do |f|
   = f.labeled_input_field :name
 
+  = f.labeled_text_area :description, rows: 5
+
   = f.labeled_text_area :redirect_uri, rows: 5,
     help: raw(t('.help_native_redirect_uris', native_redirect_uri: Doorkeeper.configuration.native_redirect_uri)),
     class: 'col-6 form-control form-control-sm'

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -892,6 +892,7 @@ de:
         uid: Client ID
         secret: Client secret
         redirect_uri: Redirect URIs
+        description: Beschreibung
         additional_audiences: Weitere Audiences
         skip_consent_screen: Einwilligung überspringen
 

--- a/config/locales/models.en.yml
+++ b/config/locales/models.en.yml
@@ -890,6 +890,7 @@ en:
         uid: Client ID
         secret: Client secret
         redirect_uri: Redirect URIs
+        description: Description
         additional_audiences: Further audiences
         skip_consent_screen: Skip consent
 

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -961,6 +961,7 @@ fr:
         uid: Client ID
         secret: Client secret
         redirect_uri: Rediriger les URIs
+        description: Description
         additional_audiences: Autres audiences
         skip_consent_screen: Sauter le consentement
 

--- a/config/locales/models.it.yml
+++ b/config/locales/models.it.yml
@@ -960,6 +960,7 @@ it:
         uid: Client ID
         secret: Client secret
         redirect_uri: Redirect URIs
+        description: Descrizione
         additional_audiences: Altri destinatari
         skip_consent_screen: Salta il consenso
 

--- a/db/migrate/20260314000000_add_description_to_oauth_applications.rb
+++ b/db/migrate/20260314000000_add_description_to_oauth_applications.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class AddDescriptionToOauthApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :oauth_applications, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_06_134500) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_14_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -906,6 +906,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_06_134500) do
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "skip_consent_screen", default: false
     t.string "additional_audiences"
+    t.text "description"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 

--- a/spec/controllers/oauth/applications_controller_spec.rb
+++ b/spec/controllers/oauth/applications_controller_spec.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2019, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -15,5 +15,42 @@ describe Oauth::ApplicationsController do
       params: {oauth_application: {name: "MyApp", redirect_uri: "urn:ietf:wg:oauth:2.0:oob", scopes: %w[name email]}}
     application = Oauth::Application.find_by(name: "MyApp")
     expect(application.scopes).to eq %w[name email]
+  end
+
+  describe "description field" do
+    let(:description_text) { "Wird verwendet für den internen Mitgliederbereich." }
+
+    it "POST#create saves description" do
+      post :create,
+        params: {oauth_application: {
+          name: "MyApp",
+          redirect_uri: "urn:ietf:wg:oauth:2.0:oob",
+          description: description_text
+        }}
+      application = Oauth::Application.find_by(name: "MyApp")
+      expect(application.description).to eq description_text
+    end
+
+    context "with existing application" do
+      let!(:application) do
+        Oauth::Application.create!(
+          name: "ExistingApp",
+          redirect_uri: "urn:ietf:wg:oauth:2.0:oob"
+        )
+      end
+
+      it "PATCH#update saves description" do
+        patch :update,
+          params: {id: application.id, oauth_application: {description: description_text}}
+        expect(application.reload.description).to eq description_text
+      end
+
+      it "GET#show assigns entry with description" do
+        application.update!(description: description_text)
+        get :show, params: {id: application.id}
+        expect(response).to be_successful
+        expect(assigns(:application).description).to eq description_text
+      end
+    end
   end
 end


### PR DESCRIPTION
- Adds a `description` text field to the `Oauth::Application` model
- Field appears in the create/edit form (below "Name")
- Field is displayed in the application detail view (show page)
- Translations included for all four supported locales (de, en, fr, it)

I tested it manually in my local instance.

This fixes https://github.com/cevi/hitobito_cevi/issues/189