### PR TITLE
SocialMedia Settings Update/Cleanup

### DIFF
--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -159,8 +159,8 @@ de:
       placeholder_type: Bezeichnung (Privat, Arbeit...)
 
     social_account_fields:
-      placeholder_value: Website, Skypename, Profillink...
-      placeholder_type: Art (Skype, Facebook...)
+      placeholder_value: Website, SocialMedia, Profillink...
+      placeholder_type: Art (Instagram, Facebook...)
 
     additional_email_fields:
       placeholder_value: E-Mail

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -159,7 +159,7 @@ de:
       placeholder_type: Bezeichnung (Privat, Arbeit...)
 
     social_account_fields:
-      placeholder_value: Website, SocialMedia, Profillink...
+      placeholder_value: Website, Social Media, Profillink...
       placeholder_type: Art (Instagram, Facebook...)
 
     additional_email_fields:

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -157,7 +157,7 @@ en:
 
     social_account_fields:
       placeholder_value: Website, Skype-name, other profiles...
-      placeholder_type: Type (Skype, Facebook, ...)
+      placeholder_type: Type (Instagram, Facebook, ...)
 
     additional_email_fields:
       placeholder_value: E-Mail

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -158,7 +158,7 @@ fr:
 
     social_account_fields:
       placeholder_value: Site internet, identifiant Skype, lien vers un profil...
-      placeholder_type: Type (Skype, Facebook...)
+      placeholder_type: Type (Instagram, Facebook...)
 
     additional_email_fields:
       placeholder_value: Courriel

--- a/config/locales/views.it.yml
+++ b/config/locales/views.it.yml
@@ -158,7 +158,7 @@ it:
 
     social_account_fields:
       placeholder_value: Sito internet, nome skype, profilo...
-      placeholder_type: Tipo (Skype, Facebook...)
+      placeholder_type: Tipo (Instagram, Facebook...)
 
     additional_email_fields:
       placeholder_value: Email

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -91,7 +91,6 @@ social_account:
   custom_label:
     enabled: true
   predefined_labels:
-    - Facebook
     - WhatsApp
     - YouTube
     - Facebook

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -92,9 +92,16 @@ social_account:
     enabled: true
   predefined_labels:
     - Facebook
-    - MSN
-    - Skype
-    - Twitter
+    - WhatsApp
+    - YouTube
+    - Facebook
+    - Instagram
+    - Snapchat
+    - LinkedIn
+    - Pinterest
+    - Reddit
+    - X (Twitter)
+    - TikTok
     - Webseite
     - Andere
 

--- a/db/migrate/20260314000000_rename_obsolete_social_account_labels.rb
+++ b/db/migrate/20260314000000_rename_obsolete_social_account_labels.rb
@@ -1,0 +1,25 @@
+#  Copyright (c) 2026, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class RenameObsoleteSocialAccountLabels < ActiveRecord::Migration[8.0]
+  RENAMED = {
+    "Twitter" => "X (Twitter)"
+  }.freeze
+
+  REMOVED = ["MSN", "Skype"].freeze
+
+  def up
+    RENAMED.each do |old_label, new_label|
+      execute "UPDATE social_accounts SET label = #{quote(new_label)} WHERE label = #{quote(old_label)}"
+    end
+    REMOVED.each do |old_label|
+      execute "UPDATE social_accounts SET label = 'Andere', name = #{quote(old_label)} || ':' || name WHERE label = #{quote(old_label)}"
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION

Ich habe viel gelernt. Gut möglich, dass es den Qual.kriterien nicht genügt. 


Core (app/hitobito):


Update social account predefined labels and migrate obsolete entries

Die predefined_labels für social_account in config/settings.yml wurden
aktualisiert. Veraltete Plattformen wurden entfernt und neue hinzugefügt.

Neue Core-Liste:
- Entfernt: MSN, Skype, Twitter
- Hinzugefügt: WhatsApp, YouTube, Snapchat, LinkedIn, Pinterest, Reddit,
  X (Twitter), TikTok
- Unverändert: Facebook, Webseite, Andere

Datenmigration (20260314000000):
- Twitter → "X (Twitter)" (gleiche Plattform, neuer Name)
- MSN/Skype → "Andere", ursprünglicher Name als Präfix im Wert erhalten
  (z.B. "MSN:randolph", "Skype:0292929")

Hinweise für Wagon-Maintainer: siehe Commit-Beschreibung auf GitHub.
Wagons mit MSN/Skype/Twitter in settings.yml müssen diese entfernen.
Pinterest/X (Twitter) können mit Knockout-Prefix (--) ausgeschlossen werden.
jubla-Wagon (app/hitobito_jubla):


Update social account predefined labels for jubla wagon

Angepasst an neue Core-Liste:
- MSN, Skype, Twitter, Facebook, Webseite, Andere entfernt
  (kommen neu direkt aus dem Core)
- --Pinterest: wird aus Core-Liste ausgeschlossen
- --X (Twitter): wird aus Core-Liste ausgeschlossen
- E-Mail: jubla-spezifische Ergänzung bleibt