### PR TITLE
change text of application market confirmation dialog

### DIFF
--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -423,8 +423,8 @@ de:
         confirm_and_send_no_mail: Bestätigen ohne E-Mail
       participant:
         modal_title: Wollen Sie diese Zuteilung entfernen?
-        confirm_and_send_mail: Entfernen und E-Mail senden
-        confirm_and_send_no_mail: Entfernen ohne E-Mail
+        confirm_and_send_mail: Bestätigen und E-Mail senden
+        confirm_and_send_no_mail: Bestätigen ohne E-Mail
       already_assigned: "Diese Person ist bereits anderweitig zugeteilt oder bei diesem Anlass angemeldet."
       maximum_participations_reached: Die maximal erlaubte Teilnehmerzahl ist erreicht. Um weitere Anmeldungen zu bestätigen, muss die maximale Teilnehmerzahl erhöht werden.
       participation:

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -415,8 +415,8 @@ en:
         confirm_and_send_no_mail: Confirm without email
       participant:
         modal_title: Do you wish to remove this registration?
-        confirm_and_send_mail: Remove and send an email
-        confirm_and_send_no_mail: Remove without email
+        confirm_and_send_mail: Confirm and send an email
+        confirm_and_send_no_mail: Confirm without email
       already_assigned: "This person was already assigned or registered for a different event."
       maximum_participations_reached: The maximum number of participants has been reached. In order to accept further registrations, the maximum number of participants must be increased.
       participation:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -421,8 +421,8 @@ fr:
         confirm_and_send_no_mail: Confirmer sans e-mail
       participant:
         modal_title: Souhaitez-vous supprimer cette inscription?
-        confirm_and_send_mail: Supprimer et envoyer un e-mail
-        confirm_and_send_no_mail: Supprimer sans e-mail
+        confirm_and_send_mail: Confirmer et envoyer un e-mail
+        confirm_and_send_no_mail: Confirmer sans e-mail
       already_assigned: "Cette personne est déjà attribuée à un autre endroit."
       maximum_participations_reached: Le nombre maximal de participants autorisé est atteint. Pour confirmer d'autres inscriptions, le nombre maximal de participants doit être augmenté.
       participation:

--- a/config/locales/views.it.yml
+++ b/config/locales/views.it.yml
@@ -421,8 +421,8 @@ it:
         confirm_and_send_no_mail: Conferma senza e-mail
       participant:
         modal_title: Vuoi cancellare questa registrazione?
-        confirm_and_send_mail: Cancellare e inviare l'e-mail
-        confirm_and_send_no_mail: Cancellare senza e-mail
+        confirm_and_send_mail: Confermare e inviare l'e-mail
+        confirm_and_send_no_mail: Conferma senza e-mail
       already_assigned: "Questa persona è già assegnata da un'altra parte."
       maximum_participations_reached: È stato raggiunto il numero massimo di partecipanti consentito. Per confermare ulteriori iscrizioni, è necessario aumentare il numero massimo di partecipanti.
       participation:


### PR DESCRIPTION
The dialog title for confirmation and removal of an application in the market was the same.
Now the intention is clear.