### PR TITLE
Fix session timeout ignoring "remember me" checkbox

### DIFF
--- a/app/models/person/devise_overrides.rb
+++ b/app/models/person/devise_overrides.rb
@@ -19,6 +19,10 @@ module Person::DeviseOverrides
     end
   end
 
+  def timeout_in
+    remember_created_at? ? 2.weeks : Devise.timeout_in
+  end
+
   def send_unlock_instructions
     super if email?
   end


### PR DESCRIPTION
The :timeoutable Devise module was expiring sessions after 30 minutes even when users had checked "Stay logged in". Override timeout_in on Person to return 2 weeks when a remember cookie is present, falling back to the configured Devise timeout for regular sessions.