### PR TITLE
Fix invoice state not updating to payed when payment fails address validation

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -90,7 +90,7 @@ class Payment < ActiveRecord::Base
     end
 
     if new_state
-      invoice.update(state: new_state)
+      invoice.update_column(:state, new_state)
     end
   end
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -58,6 +58,26 @@ describe Payment do
     expect(invoice.amount_open).to eq(-1.0)
   end
 
+  it "marks reminded invoice with total 0 as payed even when invoice has missing structured address fields" do
+    # Simulates an old invoice (pre-structured-addresses) in reminded state with total 0.
+    # Such invoices fail address validations on invoice.update(), which previously caused the
+    # state change to be silently dropped.
+    invoice.update_columns(
+      state: "reminded",
+      total: 0,
+      recipient_name: nil,
+      recipient_street: nil,
+      recipient_zip_code: nil,
+      recipient_town: nil,
+      recipient_country: nil
+    )
+    invoice.reload
+
+    expect do
+      invoice.payments.create!(amount: 0)
+    end.to change { invoice.reload.state }.to("payed")
+  end
+
   it "allows multiple payments for same invoice without reference" do
     invoice.payments.create!(amount: invoice.total - 1)
     expect(invoice.payments.build(amount: 1)).to be_valid


### PR DESCRIPTION
Payment#update_invoice used invoice.update() which runs all validations. Invoices created before structured address fields were introduced (Nov 2025) have NULL recipient_name/zip_code/town/country, causing the update to silently return false and leaving the invoice stuck in "reminded" state even after a settling payment (e.g. CHF 0) was recorded.

Switch to update_column(:state, ...) which bypasses validations and ensures the state transition always succeeds regardless of the invoice's address data completeness.

This fixes https://github.com/cevi/hitobito_cevi/issues/249