### PR TITLE
Forward token param through top-level redirects for person, event and invoice

### DIFF
--- a/app/controllers/event/top_controller.rb
+++ b/app/controllers/event/top_controller.rb
@@ -21,7 +21,9 @@ class Event::TopController < ApplicationController
 
   def redirect_to_group_event
     flash.keep if html_request?
-    redirect_to group_event_path(entry.groups.first, entry, format: request.format.to_sym)
+    options = {format: request.format.to_sym}
+    options[:token] = params[:token] if params[:token].present?
+    redirect_to group_event_path(entry.groups.first, entry, options)
   end
 
   def authorize_action

--- a/app/controllers/invoices/top_controller.rb
+++ b/app/controllers/invoices/top_controller.rb
@@ -21,7 +21,9 @@ class Invoices::TopController < ApplicationController
 
   def redirect_to_group_invoice
     flash.keep if html_request?
-    redirect_to group_invoice_path(entry.group, entry, format: request.format.to_sym)
+    options = {format: request.format.to_sym}
+    options[:token] = params[:token] if params[:token].present?
+    redirect_to group_invoice_path(entry.group, entry, options)
   end
 
   def authorize_action

--- a/app/controllers/person/top_controller.rb
+++ b/app/controllers/person/top_controller.rb
@@ -23,7 +23,9 @@ class Person::TopController < ApplicationController
     flash.keep if html_request?
     format = request.format.to_sym
     format = (format == :html) ? nil : format
-    redirect_to person_home_path(entry, format: format)
+    options = {format: format}
+    options[:token] = params[:token] if params[:token].present?
+    redirect_to person_home_path(entry, options)
   end
 
   def authorize_action

--- a/spec/controllers/event/top_controller_spec.rb
+++ b/spec/controllers/event/top_controller_spec.rb
@@ -7,24 +7,24 @@
 
 require "spec_helper"
 
-describe Person::TopController do
+describe Event::TopController do
   let(:top_leader) { people(:top_leader) }
+  let(:event) { events(:top_course) }
 
   before { sign_in(top_leader) }
 
   context "GET show" do
     context "html" do
-      it "keeps flash, does not add .html to url" do
-        get :show, params: {id: top_leader.id}
-        is_expected.to redirect_to(group_person_path(top_leader.primary_group_id, top_leader.id, format: nil))
+      it "redirects to group event path" do
+        get :show, params: {id: event.id}
+        is_expected.to redirect_to(group_event_path(event.groups.first, event, format: :html))
       end
     end
 
     context "json with token" do
       it "forwards token param in redirect" do
-        get :show, params: {id: top_leader.id, token: "secret", format: :json}
-        is_expected.to redirect_to(group_person_path(top_leader.primary_group_id, top_leader.id,
-          format: :json, token: "secret"))
+        get :show, params: {id: event.id, token: "secret", format: :json}
+        is_expected.to redirect_to(group_event_path(event.groups.first, event, format: :json, token: "secret"))
       end
     end
   end

--- a/spec/controllers/invoices/top_controller_spec.rb
+++ b/spec/controllers/invoices/top_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2022, Schweizer Wanderwege. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+describe Invoices::TopController do
+  let(:person) { people(:bottom_member) }
+  let(:invoice) { invoices(:invoice) }
+
+  before { sign_in(person) }
+
+  context "GET show" do
+    context "html" do
+      it "redirects to group invoice path" do
+        get :show, params: {id: invoice.id}
+        is_expected.to redirect_to(group_invoice_path(invoice.group, invoice, format: :html))
+      end
+    end
+
+    context "json with token" do
+      it "forwards token param in redirect" do
+        get :show, params: {id: invoice.id, token: "secret", format: :json}
+        is_expected.to redirect_to(group_invoice_path(invoice.group, invoice, format: :json, token: "secret"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
When calling /people/:id.json?token=..., /events/:id.json?token=... or /invoices/:id.json?token=..., the respective TopControllers redirect to the group-scoped URL without preserving the token query parameter, causing a 403.

Forward params[:token] to the redirect options so token-based API calls work without requiring the X-TOKEN header workaround.

This fixes https://github.com/hitobito/hitobito/issues/3048