### PR TITLE
 Implement event question template (hitobito/hitobito_sac_cas#2322)

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -27,15 +27,15 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
         :_destroy
       ],
       application_questions_attributes: [
-        :id, :question, :choices, :multiple_choices, :disclosure, :type,
-        :derived_from_question_id, :_destroy,
+        :id, :question, :choices, :multiple_choices, :type,
+        :required, :derived, :_destroy,
         {
           choices_attributes: [:choice, :_destroy]
         }
       ],
       admin_questions_attributes: [
-        :id, :question, :choices, :multiple_choices, :disclosure, :type,
-        :derived_from_question_id, :_destroy,
+        :id, :question, :choices, :multiple_choices, :type,
+        :required, :derived, :_destroy,
         {
           choices_attributes: [:choice, :_destroy]
         }
@@ -99,10 +99,6 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
     respond_with(entry)
   end
 
-  def edit
-    entry.init_questions(disclosure: :hidden)
-  end
-
   def update
     # This ensures that question choices stay deleted when the form is invalid after
     # deleting all choices
@@ -137,6 +133,20 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
     p.delete(:type)
     p.delete(:contact)
     p.permit(globalized_permitted_attrs)
+  end
+
+  # add template_id to permitted question_attributes during create
+  def globalized_permitted_attrs
+    attrs = super
+    return attrs unless action_name == "create"
+
+    question_keys = %i[application_questions_attributes admin_questions_attributes]
+
+    attrs.map do |attr|
+      next attr unless attr.is_a?(Hash)
+
+      attr.merge(attr.slice(*question_keys).transform_values { _1 + [:template_id] })
+    end
   end
 
   def return_path
@@ -208,10 +218,6 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
     participation.person = person
 
     entry.application_possible? && can?(:new, participation)
-  end
-
-  def init_questions
-    entry.init_questions
   end
 
   def render_tabular_in_background(format, name = :events_export)

--- a/app/domain/table_displays/event/participations/question_column.rb
+++ b/app/domain/table_displays/event/participations/question_column.rb
@@ -16,7 +16,7 @@ module TableDisplays::Event::Participations
 
       def available(list)
         list.map(&:event).uniq.flat_map do |event|
-          event.questions.where.not(disclosure: :hidden).pluck(:id).map { |id|
+          event.questions.pluck(:id).map { |id|
             "event_question_#{id}"
           }
         end.uniq

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -437,20 +437,14 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
     places_available? || waiting_list_available?
   end
 
-  def init_questions(disclosure: nil) # rubocop:todo Metrics/AbcSize
-    application_questions << Question.global
-      .where(event_type: [self.class.sti_name, nil])
-      .where.not(id: application_questions.map(&:derived_from_question_id))
-      .application
-      .list
-      .map { |question| question.derive(disclosure: disclosure) }
+  def init_questions
+    application_questions << Event::QuestionTemplate
+      .applicable_to(groups, event_type: self.class.sti_name)
+      .map(&:derive_question)
 
-    admin_questions << Question.global
-      .where(event_type: [self.class.sti_name, nil])
-      .where.not(id: admin_questions.map(&:derived_from_question_id))
-      .admin
-      .list
-      .map { |question| question.derive(disclosure: disclosure) }
+    admin_questions << Event::QuestionTemplate
+      .applicable_to(groups, event_type: self.class.sti_name, admin: true)
+      .map(&:derive_question)
   end
 
   def course?

--- a/app/models/event/participation.rb
+++ b/app/models/event/participation.rb
@@ -155,7 +155,6 @@ class Event::Participation < ActiveRecord::Base
   def init_answers
     answers.tap do |list|
       event.questions.list.each do |question|
-        next if question.hidden?
         next if list.find { |answer| answer.question_id == question.id }
 
         list << question.answers.new(question: question) # without this, only the id is set

--- a/app/models/event/question.rb
+++ b/app/models/event/question.rb
@@ -9,29 +9,31 @@
 #
 # Table name: event_questions
 #
-#  id                       :integer          not null, primary key
-#  admin                    :boolean          default(FALSE), not null
-#  choices                  :string
-#  disclosure               :string
-#  event_type               :string
-#  multiple_choices         :boolean          default(FALSE), not null
-#  question                 :text
-#  sensitive                :boolean          default(TRUE), not null
-#  type                     :string           not null
-#  derived_from_question_id :integer
-#  event_id                 :integer
-#  event_question_id        :integer          not null
+#  id                :integer          not null, primary key
+#  admin             :boolean          default(FALSE), not null
+#  choices           :string
+#  derived           :boolean          default(FALSE)
+#  multiple_choices  :boolean          default(FALSE), not null
+#  question          :text
+#  required          :boolean          default(FALSE), not null
+#  sensitive         :boolean          default(TRUE), not null
+#  type              :string           not null
+#  created_at        :datetime
+#  updated_at        :datetime
+#  event_id          :integer
+#  event_question_id :integer          not null
 #
 # Indexes
 #
-#  index_event_questions_on_derived_from_question_id  (derived_from_question_id)
-#  index_event_questions_on_event_id                  (event_id)
+#  index_event_questions_on_event_id  (event_id)
 #
 class Event::Question < ActiveRecord::Base
   has_paper_trail meta: {main_id: ->(q) { q.event_id },
                          main_type: Event.sti_name}
 
   include Globalized
+
+  attr_accessor :template_id
 
   # To prevent issues of having paper trail versions when we don't want/need them, we add all
   # translated attributes to the skip list and create own paper trail versions on the
@@ -66,16 +68,8 @@ class Event::Question < ActiveRecord::Base
   self.list_alphabetically = Settings.event.questions.list_alphabetically
 
   belongs_to :event
-  belongs_to :derived_from_question, class_name: "Event::Question", inverse_of: :derived_questions
 
   has_many :answers, dependent: :destroy
-  # rubocop:todo Layout/LineLength
-  has_many :derived_questions, class_name: "Event::Question", foreign_key: :derived_from_question_id,
-    # rubocop:enable Layout/LineLength
-    dependent: :nullify, inverse_of: :derived_from_question
-
-  DISCLOSURE_VALUES = %w[optional required hidden].freeze
-  i18n_enum :disclosure, DISCLOSURE_VALUES, queries: true
 
   attribute :type, default: -> { Event::Question::Default.sti_name }
   attr_accessor :skip_add_answer_to_participations
@@ -86,11 +80,8 @@ class Event::Question < ActiveRecord::Base
   # so we can have different error messages
   validates :question, presence: {message: :admin_blank}, if: :admin?
   validates :question, presence: {message: :application_blank}, unless: :admin?
-  validates :disclosure, presence: true, unless: :global?
-  validates :derived_from_question_id, uniqueness: {scope: :event_id}, allow_blank: true,
-    if: :event_id
 
-  before_validation :assign_derived_attributes, on: :create, if: :derived?
+  before_create :copy_translations_for_derived_question, if: :derived?
   after_create :add_answer_to_participations
 
   scope :global, -> { where(event_id: nil) }
@@ -101,25 +92,8 @@ class Event::Question < ActiveRecord::Base
     [
       # needed for the required attribute mark in forms
       # as the relevant validation is conditional
-      :question, :disclosure
+      :question
     ]
-  end
-
-  def derive(disclosure: nil)
-    return unless global? # prevent deriving questions that are attached to an event
-
-    Event::Question.build(attributes.excluding("id")).tap do |derived_question|
-      derived_question.derived_from_question = self
-      derived_question.disclosure = disclosure if disclosure.present?
-    end
-  end
-
-  # most attributes of global questions must not be overriden by derived questions
-  def assign_derived_attributes
-    return if derived_from_question.blank?
-
-    keep_attributes = %w[id event_id disclosure derived_from_question_id]
-    assign_attributes(derived_from_question.attributes.except(*keep_attributes))
   end
 
   def label
@@ -136,44 +110,10 @@ class Event::Question < ActiveRecord::Base
     event.blank?
   end
 
-  def derived?
-    derived_from_question_id.present?
-  end
-
   def validate_answer(_answer)
   end
 
   def before_validate_answer(_answer)
-  end
-
-  # Seed global questions and make sure the same question does not get seeded twice.
-  # In case a global question needs to be changed, make sure to create a migration
-  # accordingly and change the seed at the same time.
-  # Useful options for global questions are:
-  # rubocop:todo Layout/LineLength
-  # - `translation_attributes`: seed all translations at creation. `[{ locale: :de, question: "...", choices: "..." }]`
-  # rubocop:enable Layout/LineLength
-  # - `type`: STI-name of question type
-  # rubocop:todo Layout/LineLength
-  # - `event_type`: STI-name of Event, on which the global question should be applied. `nil` will apply to all events.
-  # rubocop:enable Layout/LineLength
-  # rubocop:todo Layout/LineLength
-  # - `disclosure`: specifies if question is required, optional or hidden. `nil` will force choice at event creation.
-  # rubocop:enable Layout/LineLength
-  def self.seed_global(attributes)
-    questions = [attributes[:question],
-      attributes[:translation_attributes]&.pluck(:question)].flatten.compact_blank
-    return if includes(:translations).where(event_id: nil, question: questions).exists?
-
-    Event::Question.transaction do
-      new(attributes.except(:translation_attributes)).tap do |question|
-        attributes[:translation_attributes]&.each do |translation_attributes|
-          question.attributes = translation_attributes.slice(:locale,
-            *Event::Question.translated_attribute_names)
-        end
-        question.save!
-      end
-    end
   end
 
   def deserialized_choices
@@ -228,13 +168,24 @@ class Event::Question < ActiveRecord::Base
     return if event.blank? || skip_add_answer_to_participations
 
     event.participations.find_each do |participation|
-      existing_answer = participation.answers.find { _1.question_id == derived_from_question_id }
+      existing_answer = participation.answers.find { _1.question.id == id }
 
       if existing_answer
         existing_answer.update(question: self)
       else
         participation.answers << answers.new
       end
+    end
+  end
+
+  def copy_translations_for_derived_question
+    template_question = Event::QuestionTemplate.find(template_id).question
+    [:question, :choices].each do |attribute|
+      template_translations = template_question.globalize_locales
+        .map { [_1.to_s, nil] }
+        .to_h
+        .merge(template_question.send(:"#{attribute}_translations"))
+      send(:"#{attribute}_translations=", template_translations)
     end
   end
 

--- a/app/models/event/question/default.rb
+++ b/app/models/event/question/default.rb
@@ -4,6 +4,7 @@
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
+
 class Event::Question::Default < Event::Question
   def choice_items
     deserialized_choices.map(&:choice)

--- a/app/models/event/question_template.rb
+++ b/app/models/event/question_template.rb
@@ -1,0 +1,61 @@
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+# == Schema Information
+#
+# Table name: event_question_templates
+#
+#  id          :bigint           not null, primary key
+#  default     :boolean          default(FALSE), not null
+#  event_type  :string
+#  inherit     :boolean          default(FALSE), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  group_id    :bigint           not null
+#  question_id :bigint           not null
+#
+# Indexes
+#
+#  index_event_question_templates_on_group_id     (group_id)
+#  index_event_question_templates_on_question_id  (question_id)
+#
+class Event::QuestionTemplate < ActiveRecord::Base
+  belongs_to :question, dependent: :destroy
+  belongs_to :group
+
+  scope :in_hierarchy, ->(groups) {
+    layer_ids = groups.map(&:layer_group_id).uniq
+    hierarchy_ids = groups.flat_map { |g| g.hierarchy.pluck(:layer_group_id) }.uniq
+
+    where("group_id IN (?) OR (group_id IN (?) AND inherit IS TRUE)", layer_ids, hierarchy_ids)
+  }
+
+  def self.applicable_to(groups, event_type: nil, admin: false)
+    return none if groups.blank?
+
+    joins(:question)
+      .where(default: true, event_type: [event_type, nil])
+      .in_hierarchy(groups)
+      .merge(Event::Question.where(admin: admin).list)
+      .select(attribute_names)
+  end
+
+  def derive_question
+    attrs = question.attributes.excluding("id", "created_at", "updated_at")
+    Event::Question.build(attrs).tap do |derived_question|
+      derived_question.derived = true
+      derived_question.template_id = id
+
+      # copy translations from template question
+      [:question, :choices].each do |attribute|
+        template_translations = question.send(:"#{attribute}_translations")
+        derived_question.send(:"#{attribute}_translations=", question.globalize_locales
+                                                                     .map { [_1.to_s, nil] }
+                                                                     .to_h
+                                                                     .merge(template_translations))
+      end
+    end
+  end
+end

--- a/app/views/event/questions/_fields.html.haml
+++ b/app/views/event/questions/_fields.html.haml
@@ -4,7 +4,8 @@
 -# https://github.com/hitobito/hitobito.
 
 = f.hidden_field(:type)
-= f.hidden_field(:derived_from_question_id)
+= f.hidden_field(:derived)
+= f.hidden_field(:template_id)
 
 - # lookup if a partial for the question type and render it if it exists.
 - # `lookup_context.find_all` needs the partial including the leading underscore,
@@ -13,9 +14,7 @@
 - if lookup_context.find_all(File.join(partial_path, '_fields')).any?
   = render partial: File.join(partial_path, 'fields'), locals: { f: f }
 
-= f.labeled(:disclosure) do
-  - Event::Question::DISCLOSURE_VALUES.each do |key|
-    = f.inline_radio_button(:disclosure, key, f.object.disclosure_label(key))
+= f.labeled_input_field(:required, caption: t('event.questions.required_caption'))
 
 - if Settings.event.participations.manual_sensitive_option
   - delete_answers_after_months = Settings.event.participations.delete_answers_after_months

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -863,26 +863,20 @@ de:
         question: Frage
         choices: Mögliche Antworten
         multiple_choices: Mehrfachauswahl
-        disclosure: Antwortangabe
+        required: Obligatorisch
         sensitive: Sensibel
-        disclosures:
-          required: Obligatorisch
-          optional: Optional
-          hidden: Nicht angezeigt
 
       admin_questions:
         question: Frage
         choices: Mögliche Antworten
         multiple_choices: Mehrfachauswahl
         required: Antwort obligatorisch
-        disclosure: Antwortangabe
 
       application_questions:
         question: Frage
         choices: Mögliche Antworten
         multiple_choices: Mehrfachauswahl
         required: Antwort obligatorisch
-        disclosure: Antwortangabe
 
       event/role:
         label: Bezeichnung

--- a/config/locales/models.en.yml
+++ b/config/locales/models.en.yml
@@ -873,14 +873,12 @@ en:
         choices: Possible answers
         multiple_choices: Multiple choice
         required: Reply mandatory
-        disclosure: Antwortangabe
 
       application_questions:
         question: Question
         choices: Possible answers
         multiple_choices: Multiple choice
         required: Reply mandatory
-        disclosure: Antwortangabe
 
       event/role:
         label: Description

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -946,14 +946,12 @@ fr:
         choices: Réponses possibles
         multiple_choices: Sélection multiple
         required: Réponse obligatoire
-        disclosure: Paramétrage
 
       application_questions:
         question: Question
         choices: Réponses possibles
         multiple_choices: Sélection multiple
         required: Réponse obligatoire
-        disclosure: Paramétrage
 
       event/role:
         label: Désignation

--- a/config/locales/models.it.yml
+++ b/config/locales/models.it.yml
@@ -945,14 +945,12 @@ it:
         choices: Possibili risposte
         multiple_choices: Scelta multipla
         required: Risposta obbligatoria
-        disclosure: Impostazione
 
       application_questions:
         question: Domanda
         choices: Possibili risposte
         multiple_choices: Scelta multipla
         required: Risposta obbligatoria
-        disclosure: Impostazione
 
       event/role:
         label: Descrizione

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -603,6 +603,7 @@ de:
     questions:
       add_choice: "Antwortmöglichkeit hinzufügen"
       sensitive_caption: Antworten werden %{cutoff} Monate nach Ende des Anlasses gelöscht.
+      required_caption: Diese Frage muss beim Anmelden beantworten werden.
 
   assignments:
     attachment: "Anhang anzeigen"

--- a/db/migrate/20260317085059_add_question_template_table.rb
+++ b/db/migrate/20260317085059_add_question_template_table.rb
@@ -1,0 +1,78 @@
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class AddQuestionTemplateTable < ActiveRecord::Migration[8.0]
+  def up
+    create_table :event_question_templates do |t|
+      t.belongs_to :group, null: false
+      t.belongs_to :question, null: false
+      t.string :event_type
+      t.boolean :default, null: false, default: false
+      t.boolean :inherit, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_column :event_questions, :required, :boolean, null: false, default: false
+    add_column :event_questions, :derived, :boolean, default: false
+    add_timestamps :event_questions, null: true
+
+    execute <<-SQL
+      UPDATE "event_questions" SET "required" = TRUE WHERE "disclosure" = 'required'
+    SQL
+
+    execute <<-SQL
+      DELETE FROM "event_questions" WHERE "disclosure" = 'hidden' AND "event_id" IS NOT NULL;
+    SQL
+
+    execute <<-SQL
+      INSERT INTO "event_question_templates" (
+        "group_id",
+        "question_id",
+        "event_type",
+        "default",
+        "inherit",
+        "created_at",
+        "updated_at"
+      )
+      SELECT
+        (SELECT id FROM (SELECT "id" FROM "groups" WHERE "parent_id" IS NULL LIMIT 1)),
+        "id",
+        "event_type",
+        CASE
+          WHEN "disclosure" = 'hidden' THEN FALSE
+          ELSE TRUE
+        END,
+        TRUE,
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      FROM "event_questions"
+      WHERE "event_id" IS NULL;
+    SQL
+
+    execute <<-SQL
+      UPDATE "event_questions"
+      SET "derived" = TRUE
+      WHERE "derived_from_question_id" IS NOT NULL;
+    SQL
+
+    remove_column :event_questions, :disclosure, :string
+    remove_column :event_questions, :derived_from_question_id, :integer
+    remove_column :event_questions, :event_type, :string
+  end
+
+  def down
+    add_column :event_questions, :derived_from_question_id, :integer
+    add_column :event_questions, :event_type, :string
+    add_column :event_questions, :disclosure, :string
+
+    remove_column :event_questions, :derived
+    remove_column :event_questions, :required
+    remove_column :event_questions, :created_at
+    remove_column :event_questions, :updated_at
+
+    drop_table :event_question_templates
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -362,6 +362,18 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_30_065720) do
     t.index ["event_id"], name: "index_event_participations_filters_on_event_id"
   end
 
+  create_table "event_question_templates", force: :cascade do |t|
+    t.bigint "group_id", null: false
+    t.bigint "question_id", null: false
+    t.string "event_type"
+    t.boolean "default", default: false, null: false
+    t.boolean "inherit", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_event_question_templates_on_group_id"
+    t.index ["question_id"], name: "index_event_question_templates_on_question_id"
+  end
+
   create_table "event_question_translations", force: :cascade do |t|
     t.integer "event_question_id", null: false
     t.string "locale", null: false
@@ -377,12 +389,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_30_065720) do
     t.integer "event_id"
     t.boolean "multiple_choices", default: false, null: false
     t.boolean "admin", default: false, null: false
-    t.string "disclosure"
     t.string "type", null: false
-    t.integer "derived_from_question_id"
-    t.string "event_type"
     t.boolean "sensitive", default: true, null: false
-    t.index ["derived_from_question_id"], name: "index_event_questions_on_derived_from_question_id"
+    t.boolean "required", default: false, null: false
+    t.boolean "derived", default: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["event_id"], name: "index_event_questions_on_event_id"
   end
 

--- a/db/seeds/development/event_question_templates.rb
+++ b/db/seeds/development/event_question_templates.rb
@@ -1,0 +1,34 @@
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito_jubla and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+def available_locales(attrs)
+  attrs.select do
+    Settings.application.languages.keys.map(&:to_s).include?(_1.to_s.split("_").last)
+  end
+end
+
+Event::QuestionTemplate.seed_once(group_id: 1,
+                                  event_type: nil,
+                                  default: true,
+                                  inherit: true,
+                                  question: Event::Question.seed_once(
+                                    available_locales({
+                                      question_de: "Hast du ein GA?",
+                                      question_fr: "Tu as un GA?",
+                                      question_it: "Hai un GA?"
+                                    })
+                                  ).first)
+
+Event::QuestionTemplate.seed_once(group_id: 1,
+                                  event_type: nil,
+                                  default: true,
+                                  inherit: true,
+                                  question: Event::Question.seed_once(
+                                    available_locales({
+                                      question_de: "Sind Kurse besser als Anlässe?",
+                                      question_fr: "Les parcours sont-ils meilleurs que les événements?",
+                                      question_it: "I corsi sono migliori degli eventi?"
+                                    })
+                                  ).first)

--- a/db/seeds/support/event_seeder.rb
+++ b/db/seeds/support/event_seeder.rb
@@ -45,8 +45,8 @@ class EventSeeder
     event.save(validate: false)
 
     seed_dates(event, date + 90.days)
-    seed_questions(event)
     seed_leaders(event)
+    seed_questions(event)
     3.times do
       event.participant_types.each do |type|
         seed_event_role(event, type)
@@ -101,9 +101,6 @@ class EventSeeder
 
   def seed_questions(event)
     event.init_questions
-    event.application_questions.map do |question|
-      question.update(disclosure: :optional)
-    end
   end
 
   def seed_leaders(event)

--- a/spec/controllers/event/participations_controller_spec.rb
+++ b/spec/controllers/event/participations_controller_spec.rb
@@ -643,7 +643,7 @@ describe Event::ParticipationsController do
 
       it "fails if required answers are missing" do
         expect_any_instance_of(described_class).not_to receive(:set_success_notice)
-        course.questions.first.update!(disclosure: :required)
+        course.questions.first.update!(required: true)
 
         post :create,
           params: {
@@ -662,7 +662,7 @@ describe Event::ParticipationsController do
       end
 
       it "preserves given answers on create when required answer is missing" do
-        course.questions.first.update!(disclosure: :required)
+        course.questions.first.update!(required: true)
         second_question = course.questions.second
 
         post :create,
@@ -835,8 +835,8 @@ describe Event::ParticipationsController do
   context "PUT update" do
     let(:event) { events(:top_event) }
     let(:user) { people(:top_leader) }
-    let(:q1) { Fabricate(:event_question, event: event, disclosure: :required) }
-    let(:q2) { Fabricate(:event_question, event: event, disclosure: :optional) }
+    let(:q1) { Fabricate(:event_question, event: event, required: true) }
+    let(:q2) { Fabricate(:event_question, event: event, required: false) }
     let!(:existing) do
       p = Fabricate(:event_participation, event: event, participant: user)
       p.answers.find_by(question_id: q1.id).update!(answer: "Ja")
@@ -988,7 +988,7 @@ describe Event::ParticipationsController do
     end
 
     def make_request(person, answer, other_person_id = nil)
-      question = course.questions.create!(question: "dummy", disclosure: :required)
+      question = course.questions.create!(question: "dummy", required: true)
       sign_in(person)
 
       attrs = {answers_attributes: {
@@ -1042,7 +1042,7 @@ describe Event::ParticipationsController do
       event.questions.create!(
         question: "Terms and Conditions? Do you speak it?",
         choices: "yep",
-        disclosure: :required
+        required: true
       )
     end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -19,7 +19,7 @@ describe EventsController do
       let(:date) do
         {label: "foo", start_at_date: Time.zone.today, finish_at_date: Time.zone.today}
       end
-      let(:question) { {question: "foo?", choices: "1,2,3,4", disclosure: :optional} }
+      let(:question) { {question: "foo?", choices: "1,2,3,4", required: false} }
 
       it "creates new event course with dates" do
         sign_in(people(:top_leader))
@@ -255,6 +255,7 @@ describe EventsController do
       it "duplicates other course" do
         sign_in(people(:top_leader))
         source = events(:top_course)
+        source.init_questions
 
         get :new, params: {group_id: source.groups.first.id, source_id: source.id}
 
@@ -287,7 +288,7 @@ describe EventsController do
       let(:date) do
         {label: "foo", start_at_date: Time.zone.today, finish_at_date: Time.zone.today}
       end
-      let(:question) { {question: "foo?", choices: "1,2,3,4", disclosure: :optional} }
+      let(:question) { {question: "foo?", choices: "1,2,3,4", required: false} }
 
       it "creates new event course with dates" do
         sign_in(people(:top_leader))
@@ -329,80 +330,6 @@ describe EventsController do
             group_id: group.id
           }
         end.to raise_error(CanCan::AccessDenied)
-      end
-
-      describe "global questions" do
-        let(:ga) { event_questions(:ga) }
-        let(:global_question_attributes) {
-          {
-            derived_from_question_id: ga.id,
-            question: ga.question,
-            choices: ga.choices,
-            disclosure: ga.disclosure
-          }
-        }
-        let(:event) { assigns(:event) }
-        let(:question) { assigns(:event).questions.first }
-        let(:params) {
-          {
-            group_id: group.id,
-            event: {
-              group_ids: [group.id, group2.id],
-              name: "foo",
-              kind_id: event_kinds(:slk).id,
-              dates_attributes: [date],
-              type: "Event::Course"
-            }
-          }
-        }
-
-        before { sign_in(people(:top_leader)) }
-
-        it "populates application question with available translations" do
-          post :create, params: params.deep_merge(event: {
-            application_questions_attributes: [global_question_attributes]
-          })
-          expect(response).to redirect_to(group_event_path(group, event))
-          expect(question.question_translations).to eq(
-            {
-              "de" => "Ich habe folgendes ÖV Abo",
-              "en" => nil,
-              "fr" => "J'ai l'abonnement de transports publics suivant",
-              "it" => nil
-            }
-          )
-          expect(question.choices_translations).to eq(
-            {
-              "de" => "GA, Halbtax / unter 16, keine Vergünstigung",
-              "en" => nil,
-              "fr" => "AG, demi-tarif / moins de 16 ans, pas de réduction",
-              "it" => nil
-            }
-          )
-        end
-
-        it "populates admin question with available translations" do
-          post :create, params: params.deep_merge(event: {
-            admin_questions_attributes: [global_question_attributes]
-          })
-          expect(response).to redirect_to(group_event_path(group, event))
-          expect(question.question_translations).to eq(
-            {
-              "de" => "Ich habe folgendes ÖV Abo",
-              "en" => nil,
-              "fr" => "J'ai l'abonnement de transports publics suivant",
-              "it" => nil
-            }
-          )
-          expect(question.choices_translations).to eq(
-            {
-              "de" => "GA, Halbtax / unter 16, keine Vergünstigung",
-              "en" => nil,
-              "fr" => "AG, demi-tarif / moins de 16 ans, pas de réduction",
-              "it" => nil
-            }
-          )
-        end
       end
     end
 
@@ -454,9 +381,9 @@ describe EventsController do
       end
 
       it "creates, updates and destroys questions" do
-        q1 = event.questions.create!(question: "Who?", disclosure: :optional)
-        q2 = event.questions.create!(question: "What?", disclosure: :optional)
-        q3 = event.questions.create!(question: "Payed?", disclosure: :optional, admin: true)
+        q1 = event.questions.create!(question: "Who?", required: false)
+        q2 = event.questions.create!(question: "What?", required: false)
+        q3 = event.questions.create!(question: "Payed?", required: false, admin: true)
 
         expect do
           put :update, params: {
@@ -468,9 +395,9 @@ describe EventsController do
                 name: "1"
               },
               application_questions_attributes: {
-                q1.id.to_s => {id: q1.id, question: "Whoo?", disclosure: :optional, choices_attributes: {}},
+                q1.id.to_s => {id: q1.id, question: "Whoo?", required: false, choices_attributes: {}},
                 q2.id.to_s => {id: q2.id, _destroy: true, choices_attributes: {}},
-                "999" => {question: "How much?", disclosure: :optional, choices_attributes: {
+                "999" => {question: "How much?", required: false, choices_attributes: {
                   "1" => {choice: "1", choice_en: "", choice_fr: "", choice_it: ""},
                   "2" => {choice: "2", choice_en: "", choice_fr: "", choice_it: ""},
                   "3" => {choice: "3", choice_en: "", choice_fr: "", choice_it: ""}
@@ -478,7 +405,7 @@ describe EventsController do
               },
               admin_questions_attributes: {
                 q3.id.to_s => {id: q3.id, _destroy: true, choices_attributes: {}},
-                "999" => {question: "Powned?", disclosure: :optional, choices_attributes: {
+                "999" => {question: "Powned?", required: false, choices_attributes: {
                   "1" => {choice: "ja", choice_en: "", choice_fr: "", choice_it: ""},
                   "2" => {choice: "nein", choice_en: "", choice_fr: "", choice_it: ""}
                 }}
@@ -503,8 +430,8 @@ describe EventsController do
       end
 
       it "question choices stay deleted when form is invalid after deleting all choices" do
-        q1 = event.questions.create!(question: "Who?", disclosure: :optional, choices: "all,some")
-        q2 = event.questions.create!(question: "Payed?", disclosure: :optional, admin: true, choices: "yes,no")
+        q1 = event.questions.create!(question: "Who?", required: false, choices: "all,some")
+        q2 = event.questions.create!(question: "Payed?", required: false, admin: true, choices: "yes,no")
 
         put :update, params: {
           group_id: group.id,
@@ -512,13 +439,13 @@ describe EventsController do
           event: {
             name: "",
             application_questions_attributes: {
-              q1.id.to_s => {id: q1.id, question: "Who?", disclosure: :optional, choices_attributes: {
+              q1.id.to_s => {id: q1.id, question: "Who?", required: false, choices_attributes: {
                 "1" => {choice: "all", choice_en: "", choice_fr: "", choice_it: "", _destroy: true},
                 "2" => {choice: "some", choice_en: "", choice_fr: "", choice_it: "", _destroy: true}
               }}
             },
             admin_questions_attributes: {
-              q2.id.to_s => {id: q2.id, question: "Payed?", disclosure: :optional, choices_attributes: {
+              q2.id.to_s => {id: q2.id, question: "Payed?", required: false, choices_attributes: {
                 "1" => {choice: "yes", choice_en: "", choice_fr: "", choice_it: "", _destroy: true},
                 "2" => {choice: "no", choice_en: "", choice_fr: "", choice_it: "", _destroy: true}
               }}
@@ -537,10 +464,10 @@ describe EventsController do
           event: {
             name: "",
             application_questions_attributes: {
-              q1.id.to_s => {id: q1.id, question: "Who?", disclosure: :optional}
+              q1.id.to_s => {id: q1.id, question: "Who?", required: false}
             },
             admin_questions_attributes: {
-              q2.id.to_s => {id: q2.id, question: "Payed?", disclosure: :optional}
+              q2.id.to_s => {id: q2.id, question: "Payed?", required: false}
             }
           }
         }

--- a/spec/decorators/paper_trail/version_changeset_presenter_spec.rb
+++ b/spec/decorators/paper_trail/version_changeset_presenter_spec.rb
@@ -66,11 +66,30 @@ describe PaperTrail::VersionChangesetPresenter, :draper_with_helpers, versioning
     expect(string).to eq("Sprache wurde von <i>Deutsch</i> auf <i>Französisch</i> geändert.")
   end
 
+  # We currently have to add a custom i18n key for this spec because there is no example for this case anymore.
+  # disclosure on event_questions was a good example before but was removed.
+  #
+  # For having this test case we add the enum values back, if the core ever gets another model with the
+  # enum translations on the base model and the model having sti subtypes, this can be replaced.
   it "translates i18n_enum values from base type if subtype does not have own translation" do
-    version.update!(item: event_questions(:top_ov), item_subtype: "Event::Question::Default")
-    string = presenter.attribute_change(:disclosure, "hidden", "optional")
+    I18n.backend.store_translations(:de, {
+      activerecord: {
+        attributes: {
+          "event/question": {
+            custom_enum_attribute: "Nicht existierendes Attribut",
+            custom_enum_attributes: {
+              hidden: "Nicht angezeigt",
+              optional: "Optional"
+            }
+          }
+        }
+      }
+    })
 
-    expect(string).to eq("Antwortangabe wurde von <i>Nicht angezeigt</i> auf <i>Optional</i> geändert.")
+    version.update!(item: event_questions(:top_ov), item_subtype: "Event::Question::Default")
+    string = presenter.attribute_change(:custom_enum_attribute, :hidden, :optional)
+
+    expect(string).to eq("Nicht existierendes Attribut wurde von <i>Nicht angezeigt</i> auf <i>Optional</i> geändert.")
   end
 
   it "translates attribute label of translated attributes" do

--- a/spec/domain/event/participant_assigner_spec.rb
+++ b/spec/domain/event/participant_assigner_spec.rb
@@ -83,7 +83,7 @@ describe Event::ParticipantAssigner do
           quest = course.questions.first
           other = Fabricate(:course, groups: [groups(:top_layer)])
           other.questions << Event::Question::NonDefaultQuestion.create!(event: other,
-            disclosure: :optional,
+            required: false,
             question: participation.answers.first.question.question)
           other.questions << Fabricate(:event_question, event: other, question: quest.question, choices: quest.choices,
             multiple_choices: quest.multiple_choices)

--- a/spec/domain/export/csv/people/participations_full_spec.rb
+++ b/spec/domain/export/csv/people/participations_full_spec.rb
@@ -36,7 +36,7 @@ describe Export::Tabular::People::ParticipationsFull do
     end
 
     it "has keys and values of admin questions" do
-      irgendwas = events(:top_course).questions.create!(question: "Irgendwas", disclosure: :optional, admin: true)
+      irgendwas = events(:top_course).questions.create!(question: "Irgendwas", required: false, admin: true)
       participation.init_answers
       expect(subject[:"question_#{irgendwas.id}"]).to eq "Irgendwas"
       expect(subject.keys.count { |key| key =~ /question/ }).to eq(4)

--- a/spec/domain/export/pdf/participation/specifics_spec.rb
+++ b/spec/domain/export/pdf/participation/specifics_spec.rb
@@ -31,8 +31,8 @@ describe Export::Pdf::Participation::Specifics do
     )
   end
   let(:participation) { Event::Participation.create(event: event, person: person) }
-  let!(:question1) { Event::Question.create!(question: "B", disclosure: :optional, event: event) }
-  let!(:question2) { Event::Question.create!(question: "A", disclosure: :optional, event: event) }
+  let!(:question1) { Event::Question.create!(question: "B", required: false, event: event) }
+  let!(:question2) { Event::Question.create!(question: "A", required: false, event: event) }
   let!(:answer1) {
     Event::Answer.find_or_create_by(question: question1, participation: participation).update(answer: "answer b")
   }

--- a/spec/fabricators/event/question_fabricator.rb
+++ b/spec/fabricators/event/question_fabricator.rb
@@ -2,8 +2,9 @@
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
+
 Fabricator(:event_question, class_name: "Event::Question") do
   event
   question { Faker::Lorem.words.join(" ") + "?" }
-  disclosure { :optional }
+  required { false }
 end

--- a/spec/features/event/events_controller_spec.rb
+++ b/spec/features/event/events_controller_spec.rb
@@ -8,14 +8,19 @@
 require "spec_helper"
 
 describe EventsController, js: true do
-  let(:event) do
+  let!(:event) do
     event = Fabricate(:course, kind: event_kinds(:slk), groups: [groups(:top_group)])
     event.dates.create!(start_at: 10.days.ago, finish_at: 5.days.ago)
+    event.init_questions
     event
   end
 
   def click_save
     all("form .btn-group").first.click_button "Speichern"
+  end
+
+  before do
+    sign_in
   end
 
   context "contacts" do
@@ -40,7 +45,6 @@ describe EventsController, js: true do
     end
 
     it "may set and remove contact from event" do
-      sign_in
       visit edit_path
 
       hidden_contact_fields_visible(false)
@@ -70,7 +74,6 @@ describe EventsController, js: true do
     end
 
     it "shows no results message for contact and does not interact with message click" do
-      sign_in
       visit edit_path
 
       hidden_contact_fields_visible(false)
@@ -86,7 +89,6 @@ describe EventsController, js: true do
     it "toggles participation notifications" do
       event.update(contact: people(:top_leader))
 
-      sign_in
       visit edit_path
 
       expect(notification_checkbox).not_to be_checked
@@ -109,7 +111,6 @@ describe EventsController, js: true do
     let(:edit_path) { edit_group_event_path(event.group_ids.first, event.id) }
 
     it "may change master organizer groups of course" do
-      sign_in
       visit edit_path
 
       # change organizer group
@@ -130,7 +131,6 @@ describe EventsController, js: true do
     let(:prefill_description) { "Test description" }
 
     before do
-      sign_in
       visit form_path
     end
 
@@ -147,14 +147,26 @@ describe EventsController, js: true do
   end
 
   context "event_questions" do
-    it "orders event questions by id on edit page" do
-      Event::Question.where(event_id: nil).second.update!(question: "A question?")
+    it "orders event questions by id on new page" do
+      event_questions(:vegi).update!(question: "A question?")
 
-      sign_in
+      visit new_group_event_path(group_id: event.groups.first.id)
+      click_on "Anmeldeangaben"
+      expect(find("#event_application_questions_attributes_0_question+p").text).to eq "Ich habe folgendes ÖV Abo"
+      expect(find("#event_application_questions_attributes_1_question+p").text).to eq "Ich habe bereits den Schub " \
+        "(das Werkbuch für Leiterinnen und Leiter der Jubla)"
+      expect(find("#event_application_questions_attributes_2_question+p").text).to eq "A question?"
+    end
+
+    it "orders event questions by id on edit page" do
+      event.questions.third.update!(question: "A question?")
+
       visit edit_group_event_path(event.groups.first, event)
       click_on "Anmeldeangaben"
       expect(find("#event_application_questions_attributes_0_question+p").text).to eq "Ich habe folgendes ÖV Abo"
-      expect(find("#event_application_questions_attributes_1_question+p").text).to eq "A question?"
+      expect(find("#event_application_questions_attributes_1_question+p").text).to eq "Ich habe bereits den Schub " \
+        "(das Werkbuch für Leiterinnen und Leiter der Jubla)"
+      expect(find("#event_application_questions_attributes_2_question+p").text).to eq "A question?"
     end
   end
 end

--- a/spec/features/event/question_spec.rb
+++ b/spec/features/event/question_spec.rb
@@ -13,12 +13,28 @@ describe EventsController, js: true do
       event.dates.create!(start_at: 10.days.ago, finish_at: 5.days.ago)
     end
   end
-  let(:global_questions) do
+  let(:question_templates) do
     {
-      vegetarian: Event::Question::Default.create!(question: "Vegetarian?", choices: "yes", event_type: "Event"),
-      camp_only: Event::Question::Default.create!(question: "Course?", event_type: "Event::Camp"),
-      required: Event::Question::Default.create!(question: "Required?", disclosure: :required),
-      hidden: Event::Question::Default.create!(question: "Hidden?", disclosure: :hidden)
+      vegetarian: Event::QuestionTemplate.create!(
+        group: groups(:top_layer),
+        default: true,
+        event_type: "Event",
+        question: Event::Question::Default.create!(question: "Vegetarian?",
+          choices: "yes",
+          question_fr: "Vegetartian? but in french",
+          question_it: "Vegetartian? but in italian")
+      ),
+      camp_only: Event::QuestionTemplate.create!(
+        group: groups(:top_layer),
+        default: true,
+        event_type: "Event::Camp",
+        question: Event::Question::Default.create!(question: "Course?")
+      ),
+      required: Event::QuestionTemplate.create!(
+        group: groups(:top_layer),
+        default: true,
+        question: Event::Question::Default.create!(question: "Required?", required: true)
+      )
     }
   end
 
@@ -38,14 +54,14 @@ describe EventsController, js: true do
     page.all(".fields").find { |question_element| question_element.text.start_with?(question.question) }
   end
 
-  def add_question_with_choices(question_text:, disclosure:, multiple_choices:, choices:)
+  def add_question_with_choices(question_text:, required:, multiple_choices:, choices:)
     within("#application_questions") do
       click_link I18n.t("global.associations.add")
     end
 
     within(all(".fields[data-new-record='true']").last) do
       fill_in "Frage", with: question_text
-      choose Event::Question.disclosure_labels[disclosure]
+      check "Obligatorisch" if required
 
       multiple_choices ? check("Mehrfachauswahl") : uncheck("Mehrfachauswahl")
 
@@ -84,9 +100,7 @@ describe EventsController, js: true do
   end
 
   def verify_question_options(question_data)
-    disclosure = question_data[:disclosure]
-    disclosure_label = Event::Question.disclosure_labels[disclosure]
-    expect(page).to have_checked_field(disclosure_label)
+    expect(page).to have_field("Obligatorisch", checked: question_data[:required])
     if question_data[:multiple_choices]
       expect(page).to have_checked_field("Mehrfachauswahl")
     else
@@ -105,25 +119,19 @@ describe EventsController, js: true do
       [
         {
           question_text: "Question 1 - Optional Single",
-          disclosure: :optional,
+          required: false,
           multiple_choices: false,
           choices: ["Q1 Choice 1", "Q1 Choice 2"]
         },
         {
           question_text: "Question 2 - Required Multiple",
-          disclosure: :required,
+          required: true,
           multiple_choices: true,
           choices: ["Q2 Choice 1", "Q2 Choice 2", "Q2 Choice 3"]
         },
         {
-          question_text: "Question 3 - Hidden Single",
-          disclosure: :hidden,
-          multiple_choices: false,
-          choices: ["Q3 Choice 1", "Q3 Choice 2"]
-        },
-        {
-          question_text: "Question 4 - Optional Free Text",
-          disclosure: :optional,
+          question_text: "Question 3 - Optional Free Text",
+          required: true,
           multiple_choices: false,
           choices: []
         }
@@ -183,7 +191,7 @@ describe EventsController, js: true do
         choices_en: "Choice 1,Choice 2,Choice 3",
         choices_fr: "Réponse 1,Réponse 2,Réponse 3",
         choices_it: "Risposta 1,Risposta 2,Risposta 3",
-        disclosure: :required
+        required: true
       )
 
       visit edit_group_event_path(event.group_ids.first, event.id)
@@ -204,7 +212,7 @@ describe EventsController, js: true do
         question: "Testquestion",
         choices: "Antwort 1, Antwort 2",
         choices_en: "Choice 1, Choice 2",
-        disclosure: :required
+        required: true
       )
 
       visit edit_group_event_path(event.group_ids.first, event.id)
@@ -227,6 +235,7 @@ describe EventsController, js: true do
       click_link("Antwortmöglichkeit hinzufügen")
       expect(page).to have_content("Antwortmöglichkeit", count: 5)
       expect(page).to have_field("Sensibel")
+      expect(page).to have_field("Obligatorisch")
 
       all(".fa-language").last.click
       input_id = all(".fields").last.first("input")[:id]
@@ -256,16 +265,17 @@ describe EventsController, js: true do
     end
 
     before do
-      Event::Question.delete_all
-      global_questions
+      Event::QuestionTemplate.delete_all
+      question_templates
+      event.init_questions
+      event.save!
       sign_in
     end
 
     it "includes global questions with matching event type" do
       visit edit_group_event_path(event.group_ids.first, event.id)
-      is_expected.to have_text(global_questions[:vegetarian].question)
-      is_expected.not_to have_text(global_questions[:camp_only].question)
-      is_expected.to have_text(global_questions[:hidden].question)
+      is_expected.to have_text(question_templates[:vegetarian].question.question)
+      is_expected.not_to have_text(question_templates[:camp_only].question.question)
 
       is_expected.not_to have_text("Entfernen")
     end
@@ -276,28 +286,36 @@ describe EventsController, js: true do
       expect(page).to have_content "Anlass Eventus wurde erfolgreich aktualisiert."
     end
 
-    it "requires questions to have disclosure selected before saving" do
-      visit new_group_event_path(groups(:top_group))
-      fill_in(:event_name, with: "Eventus2")
-      click_on("Daten")
-      fill_in(:event_dates_attributes_0_start_at_date, with: "01.01.2025")
+    it "preserves derived state when validation fails" do
+      visit new_group_event_path(groups(:top_layer).id)
       click_save
-      expect(page).to have_content("Anmeldeangaben ist nicht gültig")
+      expect(page).to have_text("muss ausgefüllt werden")
 
-      question_fields_element.all(".fields").each do |question_element| # rubocop:disable Rails/FindEach
-        within(question_element) do
-          choose(Event::Question.disclosure_labels[:optional])
-        end
-      end
+      click_on "Anmeldeangaben"
+
+      expect(page).to have_text "Vegetarian?"
+      expect(page).not_to have_field("Frage", with: "Vegetarian?")
+    end
+
+    it "saves translations from derived questions" do
+      visit new_group_event_path(groups(:top_layer).id)
+      fill_in :event_name, with: "Test Event"
+      click_on "Daten"
+      fill_in :event_dates_attributes_0_start_at_date, with: 10.days.from_now.strftime("%d.%m.%Y")
       click_save
-      expect(page).to have_content "Anlass Eventus2 wurde erfolgreich erstellt."
+      expect(page).to have_content "Anlass Test Event wurde erfolgreich erstellt."
+
+      question = Event::Question.find_by(event: Event.last, question: "Vegetarian?")
+
+      expect(question.question_fr).to eq "Vegetartian? but in french"
+      expect(question.question_it).to eq "Vegetartian? but in italian"
     end
   end
 
   describe "answers for global questions" do
     let(:event_with_questions) do
       event.init_questions
-      event.application_questions.map { |question| question.update!(disclosure: question.disclosure || :optional) }
+      event.application_questions.map { |question| question.update!(required: question.required || false) }
       event.save!
       event
     end
@@ -306,8 +324,8 @@ describe EventsController, js: true do
     subject { page }
 
     before do
-      Event::Question.delete_all
-      global_questions
+      Event::QuestionTemplate.delete_all
+      question_templates
       event_with_questions
       sign_in(user)
       visit contact_data_group_event_participations_path(event.group_ids.first, event.id,
@@ -316,11 +334,10 @@ describe EventsController, js: true do
     end
 
     it "hides hidden questions but shows others" do
-      is_expected.to have_text(global_questions[:vegetarian].question)
-      is_expected.to have_text(global_questions[:required].question + " *")
+      is_expected.to have_text(question_templates[:vegetarian].question.question)
+      is_expected.to have_text(question_templates[:required].question.question + " *")
 
-      is_expected.not_to have_text(global_questions[:camp_only].question)
-      is_expected.not_to have_text(global_questions[:hidden].question)
+      is_expected.not_to have_text(question_templates[:camp_only].question.question)
     end
 
     it "fails with empty required questions" do
@@ -329,7 +346,7 @@ describe EventsController, js: true do
 
       is_expected.to have_content "Antwort muss ausgefüllt werden"
 
-      within find_question_field(global_questions[:required]) do
+      within find_question_field(question_templates[:required].question) do
         answer_element = find('input[type="text"]')
         answer_element.fill_in(with: "Something")
       end

--- a/spec/fixtures/event/question_templates.yml
+++ b/spec/fixtures/event/question_templates.yml
@@ -1,0 +1,19 @@
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito_youth and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_youth.
+
+ga_template:
+  group: top_layer
+  question: ga
+  default: true
+
+vegi_template:
+  group: top_layer
+  question: vegi
+  default: true
+
+schub_template:
+  group: top_layer
+  question: schub
+  default: true

--- a/spec/fixtures/event/questions.yml
+++ b/spec/fixtures/event/questions.yml
@@ -2,28 +2,29 @@
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
+
 top_ov:
   event: top_course
-  disclosure: optional
+  required: false
   type: Event::Question::Default
 
 top_vegi:
   event: top_course
-  disclosure: optional
+  required: false
   type: Event::Question::Default
 
 top_more:
   event: top_course
-  disclosure: optional
+  required: false
   type: Event::Question::Default
 
 # global questions (not assigned to event)
 ga:
-  disclosure: optional
+  required: false
   type: Event::Question::Default
 vegi:
-  disclosure: optional
+  required: false
   type: Event::Question::Default
 schub:
-  disclosure: optional
+  required: false
   type: Event::Question::Default

--- a/spec/mailers/event/participation_mailer_spec.rb
+++ b/spec/mailers/event/participation_mailer_spec.rb
@@ -68,7 +68,7 @@ describe Event::ParticipationMailer do
     it "renders application questions if present" do
       question = event_questions(:top_ov)
       event.questions << event_questions(:top_ov)
-      question2 = event.questions.create!(question: "foo", disclosure: :optional, admin: true)
+      question2 = event.questions.create!(question: "foo", required: false, admin: true)
       participation.answers.detect { |a| a.question_id == question.id }.update!(answer: "GA")
       participation.answers.detect { |a| a.question_id == question2.id }.update!(answer: "Bar")
 

--- a/spec/models/event/answer_spec.rb
+++ b/spec/models/event/answer_spec.rb
@@ -13,7 +13,7 @@ describe Event::Answer do
   subject(:answer) { described_class.new(participation:, question:) }
 
   context "with required question" do
-    before { question.update!(disclosure: :required) }
+    before { question.update!(required: true) }
 
     it "validates required answer" do
       answer.participation.enforce_required_answers = true

--- a/spec/models/event/participation_spec.rb
+++ b/spec/models/event/participation_spec.rb
@@ -9,7 +9,7 @@ require "spec_helper"
 describe Event::Participation do
   let(:course) do
     course = Fabricate(:course, groups: [groups(:top_layer)], kind: event_kinds(:slk))
-    course.questions << Fabricate(:event_question, event: course, disclosure: :required)
+    course.questions << Fabricate(:event_question, event: course, required: true)
     course.questions << Fabricate(:event_question, event: course)
     course
   end

--- a/spec/models/event/question/default_spec.rb
+++ b/spec/models/event/question/default_spec.rb
@@ -4,6 +4,7 @@
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
+
 require "spec_helper"
 
 describe Event::Question::Default do
@@ -48,13 +49,13 @@ describe Event::Question::Default do
     end
 
     it "may be required" do
-      subject.disclosure = :required
+      subject.required = true
 
       is_expected.to be_valid
     end
 
     it "may be optional" do
-      subject.disclosure = :optional
+      subject.required = false
 
       is_expected.to be_valid
     end
@@ -124,7 +125,7 @@ describe Event::Question::Default do
 
     context "validates answers to single-answer questions correctly: " do
       describe "a non-required question" do
-        let(:question) { Fabricate(:event_question, disclosure: :optional, choices: "Ja") }
+        let(:question) { Fabricate(:event_question, required: false, choices: "Ja") }
 
         subject(:no_answer_given) { build_answer("0") } # no choice
 

--- a/spec/models/event/question_spec.rb
+++ b/spec/models/event/question_spec.rb
@@ -4,32 +4,22 @@
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
+
 require "spec_helper"
 
 describe Event::Question do
-  let(:global_question) { described_class.create(question: "Global?", disclosure: :optional, event: nil) }
-
   context "with an event assigned" do
     let(:event) { events(:top_course) }
 
     it "adds answer to participation after create" do
       expect do
-        event.questions.create!(question: "Test?", disclosure: :required)
+        event.questions.create!(question: "Test?", required: true)
       end.to change { Event::Answer.count }.by(1)
-    end
-
-    describe "#global?" do
-      it "returns false if question belongs to an event, even if event is not yet persisted (event_id = nil)" do
-        expect(global_question.global?).to be_truthy
-        event_question = global_question.derive
-        event_question.event = event.dup
-        expect(event_question.global?).not_to be_truthy
-      end
     end
   end
 
   context "has validations" do
-    subject { described_class.new(question: "Is this a Spec", disclosure: :optional) }
+    subject { described_class.new(question: "Is this a Spec", required: false) }
 
     it "is invalid without question" do
       subject.question = ""
@@ -40,14 +30,14 @@ describe Event::Question do
 
   context "missing question" do
     it "admin has correct error message" do
-      subject = described_class.new(admin: true, question: "", disclosure: :optional).tap(&:validate)
+      subject = described_class.new(admin: true, question: "", required: false).tap(&:validate)
       expect(subject.errors.messages[:question]).to eq([
         I18n.t("activerecord.errors.models.event/question.attributes.question.admin_blank")
       ])
     end
 
     it "non-admin has correct error message" do
-      subject = described_class.new(admin: false, question: "", disclosure: :optional).tap(&:validate)
+      subject = described_class.new(admin: false, question: "", required: false).tap(&:validate)
       expect(subject.errors.messages[:question]).to eq([
         I18n.t("activerecord.errors.models.event/question.attributes.question.application_blank")
       ])
@@ -55,106 +45,40 @@ describe Event::Question do
   end
 
   context "with single-choice answer" do
-    subject { described_class.new(question: "Test?", disclosure: :optional) }
+    subject { described_class.new(question: "Test?", required: false) }
 
     it "may be required" do
-      subject.disclosure = :required
+      subject.required = true
 
       is_expected.to be_required
       is_expected.to be_valid
     end
 
     it "may be optional" do
-      subject.disclosure = :optional
+      subject.required = false
 
-      is_expected.to be_optional
+      is_expected.not_to be_required
       is_expected.to be_valid
     end
-
-    it "may be hidden" do
-      subject.disclosure = :hidden
-
-      is_expected.to be_hidden
-      is_expected.to be_valid
-    end
-
-    it "cannot be nil with event" do
-      subject.disclosure = nil
-      subject.event = events(:top_course)
-
-      is_expected.not_to be_valid
-    end
   end
 
-  describe "::seed_global" do
-    subject(:question) { described_class.seed_global(question_attributes) }
-
-    context "with translation attributes" do
-      let(:question_attributes) do
-        {
-          disclosure: nil, # Has to be chosen for every event
-          event_type: nil, # Is derived for every event
-          translation_attributes: [
-            {locale: "de", question: "AHV-Nummer?"},
-            {locale: "fr", question: "Numéro AVS ?"},
-            {locale: "it", question: "Numero AVS?"},
-            {locale: "en", question: "AVS number?"}
-          ]
-        }
+  describe "#copy_translations_for_derived_question" do
+    it "does copy tranlsations from global questions on create" do
+      event = Fabricate.build(:event, dates: [Event::Date.new(start_at: 1.day.ago)])
+      event.init_questions
+      event.application_questions.each do
+        empty_payload = _1.class.globalize_attribute_names
+          .reject { |attribute| attribute.to_s.include?("de") }
+          .index_with(nil)
+        _1.assign_attributes(empty_payload)
       end
+      event.save!
 
-      it "creates the question with given attributes" do
-        is_expected.to be_persisted
-        expect(question).to be_global
-        question_attributes[:translation_attributes].each do |ta|
-          Globalize.with_locale(ta[:locale]) do
-            expect(question.question).to eq(ta[:question])
-          end
-        end
-      end
-
-      it "does not seed the same question twice" do
-        first_run = described_class.seed_global(question_attributes)
-        expect(first_run).to be_truthy
-
-        second_run = described_class.seed_global(question_attributes)
-        expect(second_run).to be_falsy
-      end
-    end
-  end
-
-  describe "#derive" do
-    let(:event) { events(:top_course) }
-
-    it "creates a copy of the question" do
-      derived_question = global_question.derive
-      expect(derived_question.derived_from_question).to eq(global_question)
-      derived_question.event = event
-      expect(derived_question.disclosure).to eq(global_question.disclosure)
-      expect(derived_question).to be_valid
-    end
-
-    it "overrides the disclosure value unless present" do
-      global_question.update(disclosure: nil)
-      derived_question = global_question.derive
-      expect(derived_question.disclosure).to be_nil
-      derived_question = global_question.derive(disclosure: :hidden)
-      expect(derived_question).to be_hidden
-    end
-  end
-
-  describe "#assign_derived_attributes" do
-    let(:event) { events(:top_course) }
-
-    subject(:derived_question) { global_question.derive }
-
-    it "applies only changable attributes for derived questions" do
-      derived_question.update(event: event, question: "No override!", choices: "No,override", multiple_choices: true)
-      derived_question.reload
-      expect(derived_question.question).to eq(global_question.question)
-      expect(derived_question.choices).to eq(global_question.choices)
-      expect(derived_question.multiple_choices).to eq(global_question.multiple_choices)
-      expect(derived_question.event).to eq(event)
+      expect(event.reload.questions.map(&:question_fr)).to eq [
+        "J'ai l'abonnement de transports publics suivant",
+        nil,
+        nil
+      ]
     end
   end
 
@@ -332,7 +256,7 @@ describe Event::Question do
 
     it "sets main to event on create" do
       expect do
-        event.questions.create!(question: "Warum ist die Banane krumm?", disclosure: :required)
+        event.questions.create!(question: "Warum ist die Banane krumm?", required: true)
       end.to change {
                PaperTrail::Version.count
              }.by(3) # creates a version for answers, one per participation and one version for the translation
@@ -344,7 +268,7 @@ describe Event::Question do
 
     it "sets main to event on update" do
       expect do
-        event.questions.first.update!(disclosure: :required)
+        event.questions.first.update!(required: true)
       end.to change { PaperTrail::Version.count }.by(1)
 
       version = PaperTrail::Version.order(:created_at, :id).last

--- a/spec/models/event/question_template_spec.rb
+++ b/spec/models/event/question_template_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+describe Event::QuestionTemplate do
+  let(:template) { event_question_templates(:ga_template) }
+
+  describe "#applicable_to" do
+    it "returns applicable templates" do
+      expect(Event::QuestionTemplate.applicable_to([groups(:top_layer)])).to include(template)
+    end
+
+    it "returns templates for lower layer group if inherit true" do
+      template.update!(inherit: true)
+
+      expect(Event::QuestionTemplate.applicable_to([groups(:bottom_group_one_one)])).to include(template)
+    end
+
+    it "does not return template for lower layer group if inherit false" do
+      template.update!(inherit: false)
+
+      expect(Event::QuestionTemplate.applicable_to([groups(:bottom_group_one_one)])).not_to include(template)
+    end
+
+    it "does not return template of another layer hierarchy" do
+      template.update!(group: groups(:bottom_layer_one), inherit: true)
+
+      expect(Event::QuestionTemplate.applicable_to([groups(:bottom_layer_two)])).not_to include(template)
+    end
+
+    it "does not return template for different event type" do
+      template.update!(event_type: "Event::Course")
+
+      expect(Event::QuestionTemplate.applicable_to([groups(:top_layer)])).not_to include(template)
+    end
+
+    it "does not return template if template is default false" do
+      template.update!(default: false)
+
+      expect(Event::QuestionTemplate.applicable_to([groups(:top_layer)])).not_to include(template)
+    end
+
+    it "returns no template when no groups are passed" do
+      expect(Event::QuestionTemplate.applicable_to([])).to be_blank
+    end
+  end
+
+  describe "#derive_question" do
+    it "creates a new question instance with new translation instances" do
+      derived_question = template.derive_question
+
+      expect(derived_question.new_record?).to be_truthy
+      expect(derived_question.id).to be_nil
+      expect(derived_question.created_at).to be_nil
+      expect(derived_question.updated_at).to be_nil
+      expect(derived_question.derived?).to be_truthy
+
+      expect(derived_question.question_de).to eq "Ich habe folgendes ÖV Abo"
+      expect(derived_question.question_fr).to eq "J'ai l'abonnement de transports publics suivant"
+      expect(derived_question.choices_de).to eq "GA, Halbtax / unter 16, keine Vergünstigung"
+      expect(derived_question.choices_fr).to eq "AG, demi-tarif / moins de 16 ans, pas de réduction"
+
+      travel_to Time.zone.now do
+        derived_question.save!
+
+        expect(derived_question.created_at).to eq Time.zone.now
+        expect(derived_question.updated_at).to eq Time.zone.now
+      end
+    end
+  end
+end

--- a/spec/models/event/role_spec.rb
+++ b/spec/models/event/role_spec.rb
@@ -21,7 +21,7 @@ describe Event::Role do
   context "save together with participation" do
     let(:course) do
       course = Fabricate(:course, groups: [groups(:top_layer)], kind: event_kinds(:slk))
-      course.questions << Fabricate(:event_question, event: course, disclosure: :required)
+      course.questions << Fabricate(:event_question, event: course, required: true)
       course.questions << Fabricate(:event_question, event: course)
       course
     end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -452,7 +452,7 @@ describe Event do
     let(:global_questions) { Event::Question.global }
 
     it "adds 3 default questions" do
-      e = Event.new
+      e = Event.new(groups: [groups(:top_layer)])
       e.init_questions
       expect(global_questions.size).to eq(3)
       expect(e.application_questions.size).to eq(global_questions.size)
@@ -463,7 +463,7 @@ describe Event do
       e.init_questions
       e.save!
 
-      q = e.questions.find_by(derived_from_question_id: event_questions(:ga).id)
+      q = e.questions.first
 
       expect(q.question_translations).to eq({
         "de" => "Ich habe folgendes ÖV Abo",
@@ -479,19 +479,63 @@ describe Event do
         "it" => nil
       })
     end
+
+    it "adds default questions to lower layers if inherit true" do
+      Event::QuestionTemplate.update_all(inherit: true)
+
+      e = Event.new(groups: [groups(:bottom_group_one_one)])
+      e.init_questions
+
+      expect(global_questions.size).to eq(3)
+      expect(e.application_questions.size).to eq(global_questions.size)
+    end
+
+    it "does not add default questions to lower layers if inherit false" do
+      Event::QuestionTemplate.update_all(inherit: false)
+
+      e = Event.new(groups: [groups(:bottom_group_one_one)])
+      e.init_questions
+
+      expect(e.application_questions.size).to eq(0)
+    end
+
+    it "does not add default question of another layer hierarchy tree" do
+      # Set inherit to true to actually check to not add in a different hierarchy
+      # and not only deeper inside the current hierarchy
+      Event::QuestionTemplate.update_all(inherit: true)
+
+      Event::QuestionTemplate.update_all(group_id: groups(:bottom_layer_two).id)
+      e = Event.new(groups: [groups(:top_layer)])
+      e.init_questions
+      expect(e.application_questions.size).to eq(0)
+    end
+
+    it "does not add default question for different event type" do
+      Event::QuestionTemplate.update_all(event_type: "Event::Course")
+      e = Event.new(groups: [groups(:top_layer)])
+      e.init_questions
+      expect(e.application_questions.size).to eq(0)
+    end
+
+    it "does not add question if template is default false" do
+      Event::QuestionTemplate.update_all(default: false)
+      e = Event.new(groups: [groups(:top_layer)])
+      e.init_questions
+      expect(e.application_questions.size).to eq(0)
+    end
   end
 
   describe "admin_questions" do
     it "sorts by id asc" do
-      Event::Question.create!(question: "B", disclosure: :optional, event: event, admin: true)
-      Event::Question.create!(question: "A", disclosure: :optional, event: event, admin: true)
+      Event::Question.create!(question: "B", required: false, event: event, admin: true)
+      Event::Question.create!(question: "A", required: false, event: event, admin: true)
       expect(event.reload.admin_questions.map(&:question)).to eq ["B", "A"]
     end
   end
 
   describe "application_questions" do
     it "sorts by id asc" do
-      Event::Question.create!(question: "A", disclosure: :optional, event: event)
+      Event::Question.create!(question: "A", required: false, event: event)
       expect(event.reload.application_questions.map(&:question)).to eq ["Ich bin Vegetarier", "Sonst noch was?",
         "GA oder Halbtax?", "A"]
     end
@@ -831,7 +875,9 @@ describe Event do
       expect(d.applicant_count).to eq(0)
     end
 
-    it "keeps empty questions" do
+    it "keeps empty questions if event did not have any" do
+      event.questions.destroy_all
+
       d = event.duplicate
       expect(d.application_questions.size).to eq(0)
     end

--- a/spec/views/event/participations/_list.html.haml_spec.rb
+++ b/spec/views/event/participations/_list.html.haml_spec.rb
@@ -37,7 +37,7 @@ describe "event/participations/_list.html.haml" do
   it "marks participations where required questions are unanswered" do
     login_as(people(:top_leader))
 
-    event.questions.create!(question: "dummy", disclosure: :required)
+    event.questions.create!(question: "dummy", required: true)
     participation.reload
     expect(dom).to have_text "Pflichtangaben fehlen"
   end


### PR DESCRIPTION
Only having derived as a boolean tells us if an event question has been created from a global question, but we don't know which one. To be able to validate `prevent_changes_on_derived` I decided to add a `event_question_template_id` which replaces `derived_from_question_id` instead of only having `derived`

Also we decided to remove all global seeds because they won't run again on production, admins will be able to edit these seeded questions from now on anyways. Only question we kept in global seeds is the AHV-Number in the youth wagon, to have it seeded for new wagons using the youth wagon