### PR TITLE
Add timestamptz to timestamp formats

### DIFF
--- a/app/helpers/format_helper.rb
+++ b/app/helpers/format_helper.rb
@@ -141,7 +141,7 @@ module FormatHelper
     case type
     when :time then f(val.to_time)
     when :date then f(val.to_date)
-    when :datetime, :timestamp then "#{f(val.to_date)} #{f(val.to_time)}"
+    when :datetime, :timestamp, :timestamptz then "#{f(val.to_date)} #{f(val.to_time)}"
     when :text then val.present? ? h(val) : EMPTY_STRING
     when :decimal then f(val.to_s.to_f)
     else f(val)


### PR DESCRIPTION
All environments from before the migration to postgresql migrated timestamps to timestamptz instead of datetime. To format these columns correctly in views, we add the type to all the different timestamp formats we already use, beautiful, isn't it?

This issue cannot be recreated locally with the current setup, because it will always use datetime. It is possible to recreate the wrong behaviour on the rails console of older wagons . Wagons like SAC or SWB don't have this issue because they were born a.P. (after Postgres)