### PR TITLE
Prepare our usage of bundler for the upgrade to bundler 4.0

### DIFF
--- a/.github/actions/core-ci-setup/action.yml
+++ b/.github/actions/core-ci-setup/action.yml
@@ -47,7 +47,8 @@ runs:
 
     - name: 'Bundle install'
       run: |
-        bundle install --jobs 4 --retry 3 --path vendor/bundle
+        bundle config set path 'vendor/bundle'
+        bundle install --jobs 4 --retry 3
       shell: bash
 
     - name: 'Make changes to Gemfile.lock transparent'

--- a/.github/actions/wagon-ci-setup/action.yml
+++ b/.github/actions/wagon-ci-setup/action.yml
@@ -172,7 +172,8 @@ runs:
 
     - name: "Bundle install core"
       run: |
-        bundle install --jobs 4 --retry 3 --path vendor/bundle
+        bundle config set path 'vendor/bundle'
+        bundle install --jobs 4 --retry 3
       working-directory: hitobito
       shell: bash
 
@@ -188,7 +189,8 @@ runs:
         for d in $hitobito_dir/../hitobito_*; do
           cd $d
           cp -v $hitobito_dir/Gemfile.lock ./
-          bundle install --jobs 4 --retry 3 --path vendor/bundle
+          bundle config set path 'vendor/bundle'
+          bundle install --jobs 4 --retry 3
         done
       working-directory: hitobito
       shell: bash


### PR DESCRIPTION
bundler 4.0.2 complains when using '--path vendor/bundle' thusly:

The `--path` flag has been removed because it relied on being remembered across bundler invocations, which bundler no longer does. Instead please use `bundle config set path 'vendor/bundle'`, and stop using this flag.

See #3689 and its attached PR for reference.