### PR TITLE
Add github refs to wagon-ci-setup

### DIFF
--- a/.github/actions/wagon-ci-setup/action.yml
+++ b/.github/actions/wagon-ci-setup/action.yml
@@ -51,6 +51,7 @@ runs:
         WAGON_DEPENDENCY_REPO: ${{ inputs.wagon_dependency_repository }}
         INPUT_WDEP_REF: ${{ inputs.wagon_dependency_ref }}
         INPUT_WAGON_REF: ${{ inputs.wagon_ref }}
+        GITHUB_REF: ${{github.head_ref || github.ref_name}}
       run: |
         REPO_URL="https://github.com/hitobito/$WAGON_DEPENDENCY_REPO"
         REMOTE_BRANCHES=$(git ls-remote --heads "$REPO_URL" | awk -F'refs/heads/' '{print $2}')
@@ -64,7 +65,7 @@ runs:
             PR_BRANCH=$(gh pr view "$PR_NUMBER" --repo hitobito/hitobito --json headRefName -q '.headRefName')
           fi
 
-          for candidate in "$INPUT_CORE_REF" "$PR_BRANCH" "$INPUT_WAGON_REF"; do
+          for candidate in "$INPUT_CORE_REF" "$PR_BRANCH" "$INPUT_WAGON_REF" "$GITHUB_REF"; do
             [ -z "$candidate" ] && continue
 
             if echo "$REMOTE_BRANCHES" | grep -xq "$candidate"; then


### PR DESCRIPTION
With #3919 this script was changed to check for PR_BRANCH for the run-all-wagon script. The Github ref used when running the wagon specs from the single wagon context was accidentaly removed. This leads to all wagon ci runs ran from a branch that are not manually triggered with a INPUT_WDEP_REF it always falls back to master instead of trying to checkout the current wagon branch. This change ensures that if no manual override is present, the script correctly attempts to match the current branch name in the dependency repo too before falling back to master