### PR TITLE
Do not filter by daterange for single invoices

### DIFF
--- a/app/domain/invoice/filter.rb
+++ b/app/domain/invoice/filter.rb
@@ -19,7 +19,10 @@ class Invoice::Filter
     scope = apply_scope(scope, params[:due_since], Invoice::DUE_SINCE)
     scope = filter_by_ids(scope)
     scope = filter_by_invoice_run_id(scope)
-    scope = scope.draft_or_issued(from: params[:from], to: params[:to])
+
+    unless params[:singular]
+      scope = scope.draft_or_issued(from: params[:from], to: params[:to])
+    end
 
     cancelled? ? scope : scope.visible
   end

--- a/spec/domain/invoice/filter_spec.rb
+++ b/spec/domain/invoice/filter_spec.rb
@@ -32,4 +32,10 @@ describe Invoice::Filter do
     filtered = Invoice::Filter.new(invoice_run_id: 1).apply(Invoice)
     expect(filtered.count).to eq 1
   end
+
+  it "does not filter by year for singular invoices" do
+    invoice.update(issued_at: 5.year.ago)
+    filtered = Invoice::Filter.new(ids: invoice.id, singular: true).apply(Invoice)
+    expect(filtered.count).to eq 1
+  end
 end


### PR DESCRIPTION
- https://glitchtip.puzzle.ch/hitobito/issues/13956
- https://help.puzzle.ch/#ticket/zoom/11067

Single invoices also use the invoice_run controller for some invoice actions, just with a single id. The issue is that invoices in the invoice_runs controller run through this filter, but because there are no filter options for from and to on single invoices we don't want to filter. It always looked at the current year when nil was passed for from and to in the case of a singular invoice. So all invoices created and issued in the past year can't be reminded on the show page of a single invoice