### PR TITLE
Migrate legacy role paper trail versions to new role dates

### DIFF
--- a/db/migrate/20260409141747_migrate_paper_trail_versions_to_new_role_dates.rb
+++ b/db/migrate/20260409141747_migrate_paper_trail_versions_to_new_role_dates.rb
@@ -1,0 +1,30 @@
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class MigratePaperTrailVersionsToNewRoleDates < ActiveRecord::Migration[8.0]
+  def up
+    execute <<-SQL
+      UPDATE versions
+      SET object_changes = REPLACE(
+        REPLACE(object_changes,
+        'created_at:', 'start_on:'),
+        'deleted_at:', 'end_on:'
+      )
+      WHERE item_type = 'Role';
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      UPDATE versions
+      SET object_changes = REPLACE(
+        REPLACE(object_changes,
+        'start_on:', 'created_at:'),
+        'end_on:', 'deleted_at:'
+      )
+      WHERE item_type = 'Role';
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_15_123000) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_09_141747) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
https://glitchtip.puzzle.ch/hitobito/issues/13882

Old paper trail versions of roles still contain deleted_at which doesn't exist anymore.