### PR TITLE
Move register_people special case to the correct location

### DIFF
--- a/app/abilities/concerns/api_scope_ability.rb
+++ b/app/abilities/concerns/api_scope_ability.rb
@@ -61,6 +61,19 @@ module ApiScopeAbility
   # In some cases, the accessed model does not match the required scope,
   # e.g. the people scope can grant a permission on Group, :index_people
   def acceptable_special_case?(subject_class_name, action)
+    return true if legacy_api_special_case?(subject_class_name, action)
+
+    case [subject_class_name, action.to_sym]
+    when ["Group", :register_people]
+      write_permission? && acceptable?(:register_people)
+    end
+  end
+
+  # These permissions are used in the legacy API only.
+  # The JSON:API does not nest e.g. people inside groups, so it checks
+  # `can?(:index, Person)` and uses PersonReadables instead of checking
+  # `can?(:index_people, group)`
+  def legacy_api_special_case?(subject_class_name, action)
     case [subject_class_name, action.to_sym]
     when ["Group", :index_people]
       acceptable?(:people)

--- a/app/abilities/doorkeeper_token_ability.rb
+++ b/app/abilities/doorkeeper_token_ability.rb
@@ -35,11 +35,4 @@ class DoorkeeperTokenAbility < Ability
     # it's allowed to write where the user is allowed to write.
     true
   end
-
-  def acceptable_special_case?(subject_class_name, action)
-    if subject_class_name == "Group" && action == :register_people
-      return write_permission? && acceptable?(:register_people)
-    end
-    super
-  end
 end

--- a/app/abilities/token_ability.rb
+++ b/app/abilities/token_ability.rb
@@ -20,10 +20,6 @@ class TokenAbility < Ability
     @token = token
     super(token.dynamic_user)
 
-    # Service tokens, unlike normal users, may not use the self registration API outside
-    # of their permission range (e.g. layer_full or layer_and_below_full). Therefore,
-    # we declare this permission as a separate `can` instead of inheriting this permission
-    # from the dynamic_user.
     can :register_people, Group, id: registerable_groups if can_register_people?
   end
 
@@ -32,6 +28,15 @@ class TokenAbility < Ability
   end
 
   private
+
+  def acceptable_special_case?(subject_class_name, action)
+    # Service tokens, unlike normal users, may not use the self registration API outside
+    # their permission range (e.g. layer_full or layer_and_below_full). Therefore,
+    # we declare this permission as a separate `can` instead of inheriting this permission
+    # from the dynamic_user.
+    return false if subject_class_name == "Group" && action == :register_people
+    super
+  end
 
   def acceptable?(scope) = token.send(:"#{scope}?")
 


### PR DESCRIPTION
Actually, service tokens are the odd one out. Doorkeeper tokens should work exactly the same as session cookies, but service tokens restrict the register_people permission further.