### PR TITLE
Fix reported paper trail log bugs

### DIFF
--- a/app/controllers/event/log_controller.rb
+++ b/app/controllers/event/log_controller.rb
@@ -15,7 +15,7 @@ class Event::LogController < ApplicationController
     @versions = event_related_versions
       .changed
       .reorder(created_at: :desc, id: :desc)
-      .includes(:item)
+      .includes(item: [:translations, :participant])
       .page(params[:page])
   end
 

--- a/app/controllers/event/participations/log_controller.rb
+++ b/app/controllers/event/participations/log_controller.rb
@@ -17,7 +17,7 @@ class Event::Participations::LogController < ApplicationController
       .changed
       .where(version_conditions)
       .reorder("created_at DESC, id DESC")
-      .includes(:item)
+      .includes(item: [:translations, {question: :translations}])
       .page(params[:page])
   end
 

--- a/app/decorators/paper_trail/version_association_change_presenter.rb
+++ b/app/decorators/paper_trail/version_association_change_presenter.rb
@@ -7,7 +7,7 @@ module PaperTrail
   class VersionAssociationChangePresenter
     attr_reader :version, :h
 
-    delegate :event, :changeset, :item, :item_type, :main_type, :main_id, to: :version
+    delegate :event, :changeset, :item, :item_type, :item_id, :main_type, :main_id, to: :version
 
     def initialize(version, view_context)
       @version = version
@@ -108,7 +108,11 @@ module PaperTrail
     def item_class = @item_class ||= version.item_type.constantize
 
     def label_with_fallback(item)
-      item.to_s(:long)
+      if item.respond_to?(:translation_class)
+        item_class.find_by(id: item_id).to_s(:long)
+      else
+        item.to_s(:long)
+      end
     rescue
       I18n.t("global.unknown")
     end

--- a/app/models/event/attachment.rb
+++ b/app/models/event/attachment.rb
@@ -42,7 +42,9 @@ class Event::Attachment < ActiveRecord::Base
   scope :visible_for_participants, -> { where(visibility: [:participants, :global]) }
   scope :visible_globally, -> { where(visibility: :global) }
 
-  def to_s
+  def to_s(format = :default)
+    return file.filename if format == :long
+
     file
   end
 

--- a/app/models/event/role.rb
+++ b/app/models/event/role.rb
@@ -101,7 +101,7 @@ class Event::Role < ActiveRecord::Base
     model_name = self.class.label
 
     if format == :long
-      I18n.t("activerecord.attributes.event/role.string_long", role: model_name,
+      I18n.t("activerecord.attributes.event/role.string_long", role: type.safe_constantize&.label,
         participation: participation.to_s)
     elsif label?
       "#{label} (#{model_name})"


### PR DESCRIPTION
fixes:

>  Testergebnisse, siehe https://portal-test.sac-cas.ch/de/groups/8284/events/5110
> 
>     - Anhang wird mit “unbekannt” betitelt - kann dies angepasst werden, sodass der Dateiname protokolliert wird?
> 
>     - Ändert man den Typ einer Anmelde-/Administrationsangabe bspw. von “obligatorisch” zu “optional” wird dies zwar protokolliert, aber man kann nicht nachvollziehen bei welcher Anmelde-/Administrationsangabe diese Mutation vorgenommen wurde - kann dies angepasst werden (analog Eintrag vom 13. April 2026, 12:07 Uhr)?

PaperTrail speichert im object Feld nur die Attribute der Haupttabelle, in der die Globalize Übersetzungen technisch gar nicht existieren. Da reify ein Objekt ohne aktive Verbindung zur Translation-Tabelle rekonstruiert, bleiben die Translations (in diesem Fall question) leer. 

Es gibt bei reify die Möglichkeit mit (has_many: true) die Associations zu laden. Dabei wird immer nach einem Paper Trail Eintrag zum gleichen Zeitpunkt gesucht (gibt es hier nicht da wir die Translation nicht verändert haben), wird dieser nicht gefunden, sollte es es den aktuellen Eintrag suchen. Aber auch so, ist die translation nicht korrekt geladen, da der globalized Mechanismus Probleme hat mit diesen "Fake" wiederhergestellten Objekten von Papertrail.

Es gäbe die Möglichkeit ein neues Meta Attribut hinzuzufügen, welches immer das aktuelle "Label" (to_s Wert) der Version speichert und wir danach immer diesen anzeigen, wenn diese vorhanden ist. Das wäre aber wieder zusätzliche Konfiguration für alle übersetzten Tabellen mit PaperTrail... Man müsste sich in diesem Fall auch überlegen das grundsätzlich bei allen Versionen zu machen, auch wenn das Label selbst nicht übersetzt ist, da dieses Meta Feld sonst nur zu Verwirrung führt. Dieser Approach wird oft verwendet wenn man PaperTrails in einem Log anzeigen möchte, jedoch wird dabei noch einiges mehr gemacht um die Darstellung im Log einfach zu machen.

Die andere einfachere Möglichkeit ist diese welche ich mal implementiert habe, es lädt einfach das item aus der Datenbank und kennt so die aktuellen Translations. Das führt halt dazu das wir eigentlich eine Art .reload machen, löst aber so das Problem, da er die Translation nicht mehr über das wiederhergestellte Objekt holt.

@codez Was denkst du ist hier der beste Ansatz?