### PR TITLE
feature/sww 246 add shipping attrs to invoices and invoice runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Optionale PP-Zeile auf Rechnungen (hitobito/hitobito_swb#246)
 - Vereinheitlichung der Filtergrundlagen von Personen und Anlässen (hitobito/hitobito_sac_cas#2366)
 - Filtermöglichkeiten auf Anlässen (hitobito/hitobito_sac_cas#2367)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Optionale PP-Zeile auf Rechnungen (hitobito/hitobito_swb#246)
 - Vereinheitlichung der Filtergrundlagen von Personen und Anlässen (hitobito/hitobito_sac_cas#2366)
 - Filtermöglichkeiten auf Anlässen (hitobito/hitobito_sac_cas#2367)
 - API-Keys und Kalender Feeds befinden sich neu im Bearbeiten Dropdown der Gruppe (hitobito/hitobito_sac_cas#2314)

--- a/app/controllers/invoice_runs_controller.rb
+++ b/app/controllers/invoice_runs_controller.rb
@@ -21,6 +21,7 @@ class InvoiceRunsController < CrudController
       :payment_purpose,
       :hide_total,
       :issued_at,
+      :shipping_method, :pp_post,
       invoice_items_attributes: [
         :name,
         :description,

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -29,6 +29,7 @@ class InvoicesController < CrudController # rubocop:disable Metrics/ClassLength
     :recipient_address_care_of, :recipient_street, :recipient_housenumber, :recipient_postbox,
     :recipient_town, :recipient_zip_code, :recipient_country,
     :payment_information, :payment_purpose, :hide_total,
+    :shipping_method, :pp_post,
     invoice_items_attributes: [
       :id,
       :name,

--- a/app/domain/export/pdf/address_renderers.rb
+++ b/app/domain/export/pdf/address_renderers.rb
@@ -11,6 +11,8 @@ module Export::Pdf::AddressRenderers
   included do
     class_attribute :left_address_x, default: 0
     class_attribute :right_address_x, default: 290
+    class_attribute :address_box_width, default: 58.mm
+    class_attribute :address_box_height, default: 60
   end
 
   def address_position(position)

--- a/app/domain/export/pdf/invoice/header.rb
+++ b/app/domain/export/pdf/invoice/header.rb
@@ -16,6 +16,7 @@ module Export::Pdf::Invoice
 
       render_logo if invoice.invoice_config.logo_enabled?
 
+      render_shipping_info
       render_address
     end
 
@@ -45,6 +46,41 @@ module Export::Pdf::Invoice
 
     def address_x_position
       address_position((invoice.logo_position == "left") ? "right" : "left")
+    end
+
+    def render_shipping_info
+      if invoice.pp_post.present? || !invoice.own?
+        pdf.move_down 36.mm
+        render_shipping_info_post_logo unless invoice.own?
+        render_shipping_info_text
+        render_shipping_info_line
+      end
+    end
+
+    def render_shipping_info_text
+      shipping_method, text_height = shipping_methods[invoice.shipping_method.to_sym]
+      text = "#{shipping_method}<font size='8'>#{invoice.pp_post}</font>"
+      position = [0, cursor + (text_height * 0.75)]
+      text_box(text, inline_format: true, overflow: :truncate, single_line: true, at: position)
+    end
+
+    def render_shipping_info_line
+      pdf.move_down 4.mm
+      pdf.stroke do
+        pdf.horizontal_line 0, 58.mm
+      end
+    end
+
+    def render_shipping_info_post_logo(width: 58.mm)
+      text_box("Post CH AG", align: :center, size: 7.pt, width: width, at: [0, cursor + 12.pt])
+    end
+
+    def shipping_methods
+      {
+        own: ["", 8.pt],
+        normal: ["<b><font size='12'>P.P.</font></b> ", 12.pt],
+        priority: ["<b><font size='12'>P.P.</font> <font size='24pt'>A</font></b> ", 24.pt]
+      }
     end
   end
 end

--- a/app/domain/export/pdf/invoice/header.rb
+++ b/app/domain/export/pdf/invoice/header.rb
@@ -16,7 +16,6 @@ module Export::Pdf::Invoice
 
       render_logo if invoice.invoice_config.logo_enabled?
 
-      render_shipping_info
       render_address
     end
 
@@ -46,41 +45,6 @@ module Export::Pdf::Invoice
 
     def address_x_position
       address_position((invoice.logo_position == "left") ? "right" : "left")
-    end
-
-    def render_shipping_info
-      if invoice.pp_post.present? || !invoice.own?
-        pdf.move_down 36.mm
-        render_shipping_info_post_logo unless invoice.own?
-        render_shipping_info_text
-        render_shipping_info_line
-      end
-    end
-
-    def render_shipping_info_text
-      shipping_method, text_height = shipping_methods[invoice.shipping_method.to_sym]
-      text = "#{shipping_method}<font size='8'>#{invoice.pp_post}</font>"
-      position = [0, cursor + (text_height * 0.75)]
-      text_box(text, inline_format: true, overflow: :truncate, single_line: true, at: position)
-    end
-
-    def render_shipping_info_line
-      pdf.move_down 4.mm
-      pdf.stroke do
-        pdf.horizontal_line 0, 58.mm
-      end
-    end
-
-    def render_shipping_info_post_logo(width: 58.mm)
-      text_box("Post CH AG", align: :center, size: 7.pt, width: width, at: [0, cursor + 12.pt])
-    end
-
-    def shipping_methods
-      {
-        own: ["", 8.pt],
-        normal: ["<b><font size='12'>P.P.</font></b> ", 12.pt],
-        priority: ["<b><font size='12'>P.P.</font> <font size='24pt'>A</font></b> ", 24.pt]
-      }
     end
   end
 end

--- a/app/domain/export/pdf/invoice/receiver_address.rb
+++ b/app/domain/export/pdf/invoice/receiver_address.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -6,12 +6,16 @@
 module Export::Pdf::Invoice
   class ReceiverAddress < Section
     include Export::Pdf::AddressRenderers
+    include Export::Pdf::ShippingInfoRenderers
 
     def render
       float do
         offset_cursor_from_top 5.1.cm
-        bounding_box(address_position(invoice.letter_address_position), width: bounds.width,
-          height: 80) do
+        bounding_box(address_position(invoice.letter_address_position), width: address_box_width) do
+          unless shipping_info_empty?(invoice)
+            render_shipping_info(invoice, width: address_box_width)
+            pdf.move_down 4.mm
+          end
           table(receiver_address_data, cell_style: {borders: [], padding: [0, 0, 0, 0]})
         end
       end

--- a/app/domain/export/pdf/messages/letter/header.rb
+++ b/app/domain/export/pdf/messages/letter/header.rb
@@ -8,10 +8,10 @@
 class Export::Pdf::Messages::Letter
   class Header < Section
     include Export::Pdf::AddressRenderers
+    include Export::Pdf::ShippingInfoRenderers
 
     LOGO_BOX = [450, 40].freeze
-    ADDRESS_BOX = [58.mm, 60].freeze
-    SHIPPING_INFO_BOX = [ADDRESS_BOX.first, 24].freeze
+    ADDRESS_BOX = [address_box_width, address_box_height].freeze
 
     delegate :group, to: "letter"
 
@@ -19,9 +19,8 @@ class Export::Pdf::Messages::Letter
       stamped :render_logo_right
 
       offset_cursor_from_top 60.mm
-      bounding_box(address_position(group.letter_address_position), width: ADDRESS_BOX.first) do
-        stamped :render_shipping_info
-
+      bounding_box(address_position(group.letter_address_position), width: address_box_width) do
+        stamped :render_shipping_info_block
         pdf.move_down 4.mm # 3mm + 1mm from text baseline, according to post factsheet
         render_address(recipient)
       end
@@ -33,6 +32,10 @@ class Export::Pdf::Messages::Letter
     end
 
     private
+
+    def render_shipping_info_block
+      render_shipping_info(letter, width: address_box_width)
+    end
 
     def render_date_location_text
       offset_cursor_from_top 97.5.mm
@@ -55,40 +58,10 @@ class Export::Pdf::Messages::Letter
       ).render
     end
 
-    def render_address(recipient, width: ADDRESS_BOX.first, height: ADDRESS_BOX.second)
+    def render_address(recipient, width: address_box_width, height: address_box_height)
       bounding_box([0, cursor], width: width, height: height) do
         text recipient.address
       end
-    end
-
-    def render_shipping_info(width: SHIPPING_INFO_BOX.first, height: SHIPPING_INFO_BOX.second)
-      render_shipping_info_post_logo(width) unless letter.own?
-      render_shipping_info_text(width, height)
-      render_shipping_info_line unless shipping_info_empty?
-    end
-
-    def render_shipping_info_post_logo(width)
-      text_box("Post CH AG", align: :center, size: 7.pt, width: width, at: [0, cursor + 18.pt])
-    end
-
-    def render_shipping_info_text(width, height)
-      shipping_method, text_height = shipping_methods[letter.shipping_method.to_sym]
-      text_box("#{shipping_method}<font size='8'>#{letter.pp_post}</font>",
-        inline_format: true, overflow: :truncate, single_line: true,
-        width: width, height: height, at: [0, cursor + (text_height * 0.75)])
-    end
-
-    def render_shipping_info_line
-      pdf.stroke do
-        pdf.move_down 1.mm
-        # post factsheet: max. 11 cm, start and end of the line MUST be visible in the window
-        pdf.horizontal_line 0, ADDRESS_BOX.first
-        pdf.move_up 1.mm
-      end
-    end
-
-    def shipping_info_empty?
-      letter.own? && letter.pp_post.to_s.strip.blank?
     end
 
     def logo_attachment
@@ -117,12 +90,6 @@ class Export::Pdf::Messages::Letter
 
     def address_present?(group)
       [:address, :town].all? { |a| group.send(a)&.strip.present? }
-    end
-
-    def shipping_methods
-      {own: ["", 8.pt],
-       normal: ["<b><font size='12'>P.P.</font></b> ", 12.pt],
-       priority: ["<b><font size='12'>P.P.</font> <font size='24pt'>A</font></b> ", 24.pt]}
     end
   end
 end

--- a/app/domain/export/pdf/shipping_info_renderers.rb
+++ b/app/domain/export/pdf/shipping_info_renderers.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020-2026, CVP Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Export::Pdf::ShippingInfoRenderers
+  SHIPPING_INFO_FONT = "NotoSans"
+  SHIPPING_METHODS = {
+    own: ["", 8.pt],
+    normal: ["<b><font size='12'>P.P.</font></b> ", 12.pt],
+    priority: ["<b><font size='12'>P.P.</font> <font size='24pt'>A</font></b> ", 24.pt]
+  }.freeze
+
+  def render_shipping_info(shippable, width:)
+    pdf.font(SHIPPING_INFO_FONT) do
+      render_shipping_info_post_logo(width) unless shippable.own?
+      render_shipping_info_text(shippable, width)
+      render_shipping_info_line(width) unless shipping_info_empty?(shippable)
+    end
+  end
+
+  def shipping_info_empty?(shippable)
+    shippable.own? && shippable.pp_post.to_s.strip.blank?
+  end
+
+  private
+
+  def render_shipping_info_post_logo(width)
+    text_box("Post CH AG", align: :center, size: 7.pt, width: width, at: [0, cursor + 18.pt])
+  end
+
+  def render_shipping_info_text(shippable, width)
+    shipping_method_text, text_height = SHIPPING_METHODS[shippable.shipping_method.to_sym]
+    text_box("#{shipping_method_text}<font size='8'>#{shippable.pp_post}</font>",
+      inline_format: true, overflow: :truncate, single_line: true,
+      width: width, at: [0, cursor + text_height])
+  end
+
+  def render_shipping_info_line(width)
+    pdf.stroke do
+      pdf.move_down 2.mm
+      pdf.horizontal_line 0, width
+      pdf.move_up 2.mm
+    end
+  end
+end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -75,16 +75,6 @@ module MessagesHelper
     Salutation.all[message.salutation] || I18n.t("global.associations.no_entry")
   end
 
-  def format_message_shipping_method(message)
-    message.shipping_method_label
-  end
-
-  def message_letter_shipping_methods(message)
-    Message::Letter::SHIPPING_METHODS.map do |shipping_method|
-      [shipping_method, message.shipping_method_label(shipping_method)]
-    end
-  end
-
   def message_send_to_household_options
     [[false, t(".send_to_households_options.false")],
       [true, t(".send_to_households_options.true")]]

--- a/app/helpers/shippables_helper.rb
+++ b/app/helpers/shippables_helper.rb
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, Schweizer Wanderwege. This file is part of
+# hitobito and licensed under the Affero General Public License version 3
+# or later. See the COPYING file at the top-level directory or at
+# https://github.com/hitobito/hitobito.
+
+module ShippablesHelper
+  def format_shipping_method(model)
+    message.shipping_method_label
+  end
+end

--- a/app/models/concerns/shippable.rb
+++ b/app/models/concerns/shippable.rb
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, Schweizer Wanderwege. This file is part of
+# hitobito and licensed under the Affero General Public License version 3
+# or later. See the COPYING file at the top-level directory or at
+# https://github.com/hitobito/hitobito.
+
+module Shippable
+  extend ActiveSupport::Concern
+
+  SHIPPING_METHODS = %w[own normal priority].freeze
+
+  included do
+    i18n_enum :shipping_method, SHIPPING_METHODS, scopes: true, queries: true,
+      i18n_prefix: "activerecord.attributes.message/letter.shipping_methods"
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -57,6 +57,7 @@ class Invoice < ActiveRecord::Base # rubocop:todo Metrics/ClassLength
   include I18nEnums
   include PaymentSlips
   include FullTextSearchable
+  include Shippable
 
   ROUND_TO = BigDecimal("0.05")
 

--- a/app/models/invoice_run.rb
+++ b/app/models/invoice_run.rb
@@ -33,6 +33,8 @@
 #
 
 class InvoiceRun < ActiveRecord::Base
+  include I18nEnums
+  include Shippable
   include Globalized
 
   translates :title

--- a/app/models/message/letter.rb
+++ b/app/models/message/letter.rb
@@ -42,13 +42,12 @@
 #
 
 class Message::Letter < Message
+  include Shippable
+
   has_rich_text :body
   self.icon = :"envelope-open-text"
 
-  SHIPPING_METHODS = %w[own normal priority].freeze
-  i18n_enum :shipping_method, SHIPPING_METHODS, scopes: true, queries: true
   validates :subject, presence: true
-  validates :shipping_method, inclusion: {in: SHIPPING_METHODS}
 
   validates :body, presence: true
 

--- a/app/views/invoice_runs/_form.html.haml
+++ b/app/views/invoice_runs/_form.html.haml
@@ -28,6 +28,7 @@
     = fi.labeled_input_field :payment_purpose
     = fi.labeled_date_field :issued_at
     = render_extensions :form_invoice_fields, locals: { f: fi }
+    = render 'shippable/shipping_fields', f: f
     = field_set_tag do
       = render "invoice_articles", f: fi, group: group
 

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -41,6 +41,8 @@
       .shown.ms-0
         = f.country_field :recipient_country
 
+  = render 'shippable/shipping_fields', f: f
+
   = f.labeled_input_field :payment_information, rows: 2
   - if entry.qr?
     = f.labeled_input_field :payment_purpose, rows: 2

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -42,6 +42,8 @@
       .shown.ms-0
         = f.country_field :recipient_country
 
+  = render 'shippable/shipping_fields', f: f
+
   = f.labeled_input_field :payment_information, rows: 2
   - if entry.qr?
     = f.labeled_input_field :payment_purpose, rows: 2

--- a/app/views/invoices/_infos.html.haml
+++ b/app/views/invoices/_infos.html.haml
@@ -15,6 +15,8 @@
       = labeled(Invoice.human_attribute_name(:payee), invoice_payee_address(entry))
       = labeled_attr(entry, :beneficiary) if entry.bank?
       = labeled_attr(entry, :address)
+      = labeled_attr(entry, :shipping_method) if entry.shipping_method?
+      = labeled_attr(entry, :pp_post) if entry.pp_post?
       = labeled_attr(entry, :account_number) if entry.account_number?
       = labeled_attr(entry, :participant_number) if entry.with_reference?
       = labeled_attr(entry, :iban) if entry.iban.present?

--- a/app/views/messages/letter/_fields.html.haml
+++ b/app/views/messages/letter/_fields.html.haml
@@ -6,14 +6,7 @@
 - if entry.class.sti_name == Message::Letter.sti_name
   = f.labeled_collection_select :send_to_households, message_send_to_household_options, :first, :last, {}, { data: { remote: true, url: group_mailing_list_recipient_counts_path(message_type: entry.type), 'on-page-load': true, spin: '#recipient-count-spinner .spinner' }, class: 'form-select form-select-sm' }
 = f.labeled_input_fields :date_location_text, :subject
-= f.labeled_collection_select :shipping_method, message_letter_shipping_methods(entry), :first, :last, {},  { class: 'form-select form-select-sm' }
-= f.labeled(:pp_post) do
-  .input-group.input-group-sm
-    %span.input-group-text
-      = 'P.P.'
-    = f.input_field :pp_post, :placeholder => 'CH-3030 Bern'
-    %span.input-group-text
-      = 'Post CH AG'
+= render 'shippable/shipping_fields', f: f
 = f.labeled_input_field :donation_confirmation if entry.invoice?
 = render_extensions :fields, locals: { f: f }
 = f.labeled_collection_select :salutation, Salutation.all, :first, :last, { include_blank: I18n.t('global.associations.no_entry') }, { class: 'form-select form-select-sm' }

--- a/app/views/shippable/_shipping_fields.html.haml
+++ b/app/views/shippable/_shipping_fields.html.haml
@@ -1,0 +1,13 @@
+-# Copyright (c) 2026, Schweizer Wanderwege. This file is part of
+-# hitobito and licensed under the Affero General Public License version 3
+-# or later. See the COPYING file at the top-level directory or at
+-# https://github.com/hitobito/hitobito.
+
+= f.labeled_collection_select :shipping_method, entry.class.shipping_method_labels, :first, :last, {},  { class: 'form-select form-select-sm' }
+= f.labeled(:pp_post) do
+  .input-group.input-group-sm
+    %span.input-group-text
+      = 'P.P.'
+    = f.input_field :pp_post, :placeholder => 'CH-3030 Bern'
+    %span.input-group-text
+      = 'Post CH AG'

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -1240,6 +1240,8 @@ de:
         cost_centers: Kostenstellen
         accounts: Konten
         payments: Zahlungseingänge
+        pp_post: PP-Zeile
+        shipping_method: Liefermethode
 
       invoice_article:
         number: Artikelnummer
@@ -1307,6 +1309,8 @@ de:
         recipients_paid: Empfänger Bezahlt
         amount_total: Betrag insgesamt
         amount_paid: Betrag bezahlt
+        pp_post: PP-Zeile
+        shipping_method: Liefermethode
 
       # used for nested attributes
       invoice_items:

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -1241,6 +1241,8 @@ de:
         cost_centers: Kostenstellen
         accounts: Konten
         payments: Zahlungseingänge
+        pp_post: PP-Zeile
+        shipping_method: Liefermethode
 
       invoice_article:
         number: Artikelnummer
@@ -1308,6 +1310,8 @@ de:
         recipients_paid: Empfänger Bezahlt
         amount_total: Betrag insgesamt
         amount_paid: Betrag bezahlt
+        pp_post: PP-Zeile
+        shipping_method: Liefermethode
 
       # used for nested attributes
       invoice_items:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -6,6 +6,9 @@
 mailchimp:
   enabled: false
 
+messages:
+  enable_writing: true
+
 auth:
   skip_2fa: true
 

--- a/db/migrate/20251223110127_refill_structured_addresses_for_necessary_invoices.rb
+++ b/db/migrate/20251223110127_refill_structured_addresses_for_necessary_invoices.rb
@@ -1,6 +1,13 @@
 class RefillStructuredAddressesForNecessaryInvoices < ActiveRecord::Migration[8.0]
+  # Define local models to avoid loading full models with concerns that reference
+  # columns (like shipping_method) that may not exist yet in tenant schemas
+  class MigrationInvoice < ActiveRecord::Base
+    self.table_name = "invoices"
+    belongs_to :recipient, polymorphic: true
+  end
+
   def up
-    Invoice.transaction do
+    MigrationInvoice.transaction do
       relevant_invoices.find_each do |invoice|
         # I dont know how exactly but there are invoices to recipient_ids that arent found. Presumably the people got deleted
         next unless invoice.recipient
@@ -13,10 +20,9 @@ class RefillStructuredAddressesForNecessaryInvoices < ActiveRecord::Migration[8.
   end
 
   def relevant_invoices
-    Invoice.where(created_at: year_range,
-      recipient_type: Person.sti_name)
+    MigrationInvoice.where(created_at: year_range, recipient_type: "Person")
       .where("recipient_id IS NOT NULL")
-      .includes(:recipient, :invoice_items, :invoice_run, recipient: :additional_addresses)
+      .includes(:recipient)
   end
 
   def year_range

--- a/db/migrate/20260415070232_add_shipping_attrs_to_invoice_runs_and_invoices.rb
+++ b/db/migrate/20260415070232_add_shipping_attrs_to_invoice_runs_and_invoices.rb
@@ -1,0 +1,18 @@
+#  Copyright (c) 2026, Schweizer Wanderwege. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class AddShippingAttrsToInvoiceRunsAndInvoices < ActiveRecord::Migration[8.0]
+  def change
+    change_table(:invoices) do |t|
+      t.column :shipping_method, :string, default: :own
+      t.column :pp_post, :string
+    end
+
+    change_table(:invoice_runs) do |t|
+      t.column :shipping_method, :string, default: :own
+      t.column :pp_post, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_09_141747) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_15_070232) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -677,6 +677,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_09_141747) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "period_invoice_template_id"
+    t.string "shipping_method", default: "own"
+    t.string "pp_post"
     t.index ["creator_id"], name: "index_invoice_runs_on_creator_id"
     t.index ["group_id"], name: "index_invoice_runs_on_group_id"
     t.index ["period_invoice_template_id"], name: "index_invoice_runs_on_period_invoice_template_id"
@@ -730,6 +732,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_09_141747) do
     t.string "recipient_address_care_of"
     t.string "recipient_postbox"
     t.string "recipient_type"
+    t.string "shipping_method", default: "own"
+    t.string "pp_post"
     t.index ["esr_number"], name: "index_invoices_on_esr_number"
     t.index ["group_id"], name: "index_invoices_on_group_id"
     t.index ["invoice_run_id"], name: "index_invoices_on_invoice_run_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_09_153100) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_15_070232) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -677,6 +677,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_09_153100) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "period_invoice_template_id"
+    t.string "shipping_method", default: "own"
+    t.string "pp_post"
     t.index ["creator_id"], name: "index_invoice_runs_on_creator_id"
     t.index ["group_id"], name: "index_invoice_runs_on_group_id"
     t.index ["period_invoice_template_id"], name: "index_invoice_runs_on_period_invoice_template_id"
@@ -730,6 +732,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_09_153100) do
     t.string "recipient_address_care_of"
     t.string "recipient_postbox"
     t.string "recipient_type"
+    t.string "shipping_method", default: "own"
+    t.string "pp_post"
     t.index ["esr_number"], name: "index_invoices_on_esr_number"
     t.index ["group_id"], name: "index_invoices_on_group_id"
     t.index ["invoice_run_id"], name: "index_invoices_on_invoice_run_id"

--- a/spec/domain/export/pdf/invoice_spec.rb
+++ b/spec/domain/export/pdf/invoice_spec.rb
@@ -1206,30 +1206,30 @@ describe Export::Pdf::Invoice do
   context "pp_post and shipment_method" do
     it "renders pp row" do
       invoice.update!(pp_post: "CH-3000")
-      expect(text_with_position).to include([57, 711, "CH-3000"])
-      expect(text_with_position).to include([57, 686, "Top Leader"])
+      expect(text_with_position).to include([57, 697, "CH-3000"])
+      expect(text_with_position).to include([57, 675, "Top Leader"])
       expect(text_with_position).to include([347, 685, "Rechnungsnummer:"])
     end
 
     it "renders pp row and post header" do
       invoice.update!(pp_post: "CH-3000", shipping_method: :normal)
-      expect(text_with_position).to include([120, 718, "Post CH AG"])
-      expect(text_with_position).to include([57, 709, "P.P."])
-      expect(text_with_position).to include([78, 709, " "])
-      expect(text_with_position).to include([81, 709, "CH-3000"])
-      expect(text_with_position).to include([57, 686, "Top Leader"])
+      expect(text_with_position).to include([120, 708, "Post CH AG"])
+      expect(text_with_position).to include([57, 696, "P.P."])
+      expect(text_with_position).to include([78, 696, " "])
+      expect(text_with_position).to include([81, 696, "CH-3000"])
+      expect(text_with_position).to include([57, 675, "Top Leader"])
       expect(text_with_position).to include([347, 685, "Rechnungsnummer:"])
     end
 
     it "renders pp row and post header with priority" do
       invoice.update!(pp_post: "CH-3000", shipping_method: :priority)
-      expect(text_with_position).to include([120, 718, "Post CH AG"])
-      expect(text_with_position).to include([57, 705, "P.P."])
-      expect(text_with_position).to include([78, 705, " "])
-      expect(text_with_position).to include([81, 705, "A"])
-      expect(text_with_position).to include([97, 705, " "])
-      expect(text_with_position).to include([100, 705, "CH-3000"])
-      expect(text_with_position).to include([57, 686, "Top Leader"])
+      expect(text_with_position).to include([120, 708, "Post CH AG"])
+      expect(text_with_position).to include([57, 696, "P.P."])
+      expect(text_with_position).to include([78, 696, " "])
+      expect(text_with_position).to include([81, 696, "A"])
+      expect(text_with_position).to include([97, 696, " "])
+      expect(text_with_position).to include([100, 696, "CH-3000"])
+      expect(text_with_position).to include([57, 675, "Top Leader"])
       expect(text_with_position).to include([347, 685, "Rechnungsnummer:"])
     end
   end

--- a/spec/domain/export/pdf/invoice_spec.rb
+++ b/spec/domain/export/pdf/invoice_spec.rb
@@ -1202,4 +1202,35 @@ describe Export::Pdf::Invoice do
       end
     end
   end
+
+  context "pp_post and shipment_method" do
+    it "renders pp row" do
+      invoice.update!(pp_post: "CH-3000")
+      expect(text_with_position).to include([57, 711, "CH-3000"])
+      expect(text_with_position).to include([57, 686, "Top Leader"])
+      expect(text_with_position).to include([347, 685, "Rechnungsnummer:"])
+    end
+
+    it "renders pp row and post header" do
+      invoice.update!(pp_post: "CH-3000", shipping_method: :normal)
+      expect(text_with_position).to include([120, 718, "Post CH AG"])
+      expect(text_with_position).to include([57, 709, "P.P."])
+      expect(text_with_position).to include([78, 709, " "])
+      expect(text_with_position).to include([81, 709, "CH-3000"])
+      expect(text_with_position).to include([57, 686, "Top Leader"])
+      expect(text_with_position).to include([347, 685, "Rechnungsnummer:"])
+    end
+
+    it "renders pp row and post header with priority" do
+      invoice.update!(pp_post: "CH-3000", shipping_method: :priority)
+      expect(text_with_position).to include([120, 718, "Post CH AG"])
+      expect(text_with_position).to include([57, 705, "P.P."])
+      expect(text_with_position).to include([78, 705, " "])
+      expect(text_with_position).to include([81, 705, "A"])
+      expect(text_with_position).to include([97, 705, " "])
+      expect(text_with_position).to include([100, 705, "CH-3000"])
+      expect(text_with_position).to include([57, 686, "Top Leader"])
+      expect(text_with_position).to include([347, 685, "Rechnungsnummer:"])
+    end
+  end
 end

--- a/spec/domain/export/pdf/messages/letter/header_spec.rb
+++ b/spec/domain/export/pdf/messages/letter/header_spec.rb
@@ -33,18 +33,18 @@ describe Export::Pdf::Messages::Letter::Header do
 
   let(:shipping_info_with_position_left) do
     [
-      [71, 668, "P.P."],
-      [93, 668, " "],
+      [71, 671, "P.P."],
+      [93, 671, " "],
       [134, 682, "Post CH AG"],
-      [95, 668, "CH-3030 Bern, Belpstrasse 37"]
+      [95, 671, "CH-3030 Bern, Belpstrasse 37"]
     ]
   end
   let(:shipping_info_with_position_right) do
     [
       [424, 682, "Post CH AG"],
-      [361, 668, "P.P."],
-      [383, 668, " "],
-      [385, 668, "CH-3030 Bern, Belpstrasse 37"]
+      [361, 671, "P.P."],
+      [383, 671, " "],
+      [385, 671, "CH-3030 Bern, Belpstrasse 37"]
     ]
   end
 
@@ -175,12 +175,12 @@ describe Export::Pdf::Messages::Letter::Header do
         subject.render(recipient)
         pdf.start_new_page
         subject.render(recipient)
-        expect(stamps.keys).to eq [:render_logo_right, :render_shipping_info]
+        expect(stamps.keys).to eq [:render_logo_right, :render_shipping_info_block]
         expect(text_with_position_without_shipping_info).to eq [
           [71, 651, "Top Leader"],
           [71, 626, "Greattown"],
-          [71, 654, "Top Leader"],
-          [71, 629, "Greattown"]
+          [71, 657, "Top Leader"],
+          [71, 632, "Greattown"]
         ]
       end
 
@@ -189,12 +189,12 @@ describe Export::Pdf::Messages::Letter::Header do
         subject.render(recipient)
         pdf.start_new_page
         subject.render(recipient)
-        expect(stamps.keys).to eq [:render_logo_right, :render_shipping_info]
+        expect(stamps.keys).to eq [:render_logo_right, :render_shipping_info_block]
         expect(text_with_position_without_shipping_info).to eq [
           [71, 651, "Top Leader"],
           [71, 626, "Greattown"],
-          [71, 654, "Top Leader"],
-          [71, 629, "Greattown"]
+          [71, 657, "Top Leader"],
+          [71, 632, "Greattown"]
         ]
       end
 

--- a/spec/domain/export/pdf/messages/letter_spec.rb
+++ b/spec/domain/export/pdf/messages/letter_spec.rb
@@ -65,7 +65,7 @@ describe Export::Pdf::Messages::Letter do
       it "renders text at positions with group sender address" do
         letter.update!(pp_post: "Group 11, Lakeview 42, 4242 Wanaka")
         expect(text_with_position).to match_array [
-          [71, 672, "Group 11, Lakeview 42, 4242 Wanaka"],
+          [71, 671, "Group 11, Lakeview 42, 4242 Wanaka"],
           [71, 654, "Bottom Member"],
           [71, 644, "Greatstreet 345"],
           [71, 634, "3456 Greattown"],
@@ -199,7 +199,7 @@ describe Export::Pdf::Messages::Letter do
           [71, 644, "Greatstreet 345"],
           [71, 634, "3456 Greattown"]
         ]
-        expect(stamps.keys).to eq [:render_logo_right, :render_shipping_info, :render_subject,
+        expect(stamps.keys).to eq [:render_logo_right, :render_shipping_info_block, :render_subject,
           :render_content]
       end
 


### PR DESCRIPTION
Ich habe den code aus dem Letter übernommen und das sieht damit in etwa so aus 

<img width="2393" height="573" alt="image" src="https://github.com/user-attachments/assets/2dae6c73-f302-4cf8-9fae-0bd18473b4cb" />

ist nicht pixel perfekt aber recht na drann. Ist das ausreichend? Kann das jemand beurteilen @daniel-illi @carlobeltrame?

Ich denke es wäre doch noch einiges an Aufwand notwenig, wenn man den pp rendering text extrahiern wollte