### PR TITLE
Pass default filter_params to invoce filter in invoice runs controller

### DIFF
--- a/app/controllers/invoice_runs_controller.rb
+++ b/app/controllers/invoice_runs_controller.rb
@@ -127,7 +127,7 @@ class InvoiceRunsController < CrudController
   end
 
   def invoices
-    Invoice::Filter.new(params).apply_or_none(group.issued_invoices)
+    Invoice::Filter.new(params.merge(filter_params)).apply_or_none(group.issued_invoices)
   end
 
   def flash_message(action: action_name, count: nil, title: nil)
@@ -204,5 +204,17 @@ class InvoiceRunsController < CrudController
     model_params&.permit(GlobalizedPermittedAttrs.new(
       InvoiceRun, [:title]
     ).permitted_attrs) || {}
+  end
+
+  def filter_params
+    {
+      from: params[:from] || "1.1.#{default_filter_year}",
+      to: params[:to] || "31.12.#{default_filter_year}",
+      ids: params[:ids] || []
+    }
+  end
+
+  def default_filter_year
+    entry&.created_at&.year || Time.zone.today.year
   end
 end

--- a/app/domain/invoice/filter.rb
+++ b/app/domain/invoice/filter.rb
@@ -60,7 +60,7 @@ class Invoice::Filter
   end
 
   def filter_by_ids(relation)
-    return relation if params[:ids].blank? || all_invoices?
+    return relation if params[:ids].nil? || all_invoices?
 
     relation.where(id: invoice_ids)
   end
@@ -70,8 +70,6 @@ class Invoice::Filter
   end
 
   def invoice_ids
-    # return [] if all_invoices?
-
     @invoice_ids = params[:ids].to_s.split(",")
   end
 end

--- a/spec/controllers/invoice_runs_controller_spec.rb
+++ b/spec/controllers/invoice_runs_controller_spec.rb
@@ -352,6 +352,16 @@ describe InvoiceRunsController do
       expect(flash[:notice][1]).to match(/Rechnung \d+-\d+ wird im Hintergrund per E-Mail verschickt./)
     end
 
+    it "PUT#update uses year of invoice_run created_at as default filter_param from and to" do
+      invoice_run = InvoiceRun.create!(title: :title, group: group, recipient_source: PeopleFilter.new,
+        created_at: 10.years.ago)
+      invoice = Invoice.create!(group: group, title: "test", recipient: person, invoice_run: invoice_run)
+
+      expect(Invoice::Filter).to receive(:new).with(hash_including(from: "1.1.#{10.years.ago.year}",
+        to: "31.12.#{10.years.ago.year}")).and_call_original
+      post :update, params: {group_id: group.id, invoice_run_id: invoice_run.id, ids: invoice.id}
+    end
+
     describe "DELETE#destroy" do
       it "informs if no invoice has been selected" do
         delete :destroy, params: {group_id: group.id}


### PR DESCRIPTION
fixes second issue of: https://help.puzzle.ch/#ticket/zoom/11067

The issue was from and to of the filters were not being passed into the filter and due to that, it used the current year in Invoice#draft_or_issued. When a user does not change these date filters it uses the pre filled values (or to be exact the params are nil, due to them not being in the URL). The pre filled values get built based on the invoice_run created_at (InvoicesController#filter_params). That means that for the show page of these invoices (which is handled by the InvoicesController) we always merge these filter_param values into the params before passing it to the filter, to use the year of the invoice_run per default.

Because the updates of these invoices are handled in the invoice_runs controller, these params get lost because we never merged default values for the filter (the filter itself then returns no invoice because it uses the current year instead of the one from the invoice_run). I added the filter_params to the invoice_runs controller aswell so we handle it the same way as the actual list of invoices. This fixed the issue of not being able to run an update on the invoices selected.

Then a second issue appeared where if we passed (ids: []) so no invoice is selected, it counts as blank and returns EVERY invoice. So I switched that to .nil? in the filter. The issue was the spec `InvoiceRunsControllerSpec#366` and another that failed.

Why?
Because when we passed no selected ids, it should display "Zuerst muss eine Rechnung ausgewählt werden.". That never actually worked tho, the test did not pass because no invoice was selected, it passed because the dates scope removed the invoices from the filter. Which then means that if someone would in theory pass something like
```
ids: [],
from: 20 years ago,
to: 10 years from now
```
It would actually not return no invoice, rather EVERY invoice in that year scope and update it... The filter should return every invoice if ids is nil because then it should not filter, but not when no invoice is actually selected, because then, it should execute all actions for no invoices at all.