### PR TITLE
Generate a filename, even if no invoices are exported

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -170,7 +170,7 @@ class InvoicesController < CrudController # rubocop:disable Metrics/ClassLength
   end
 
   def filename(invoices)
-    if invoices.size > 1
+    if invoices.size != 1
       t("activerecord.models.invoice.other").downcase
     else
       invoices.first.filename(nil)

--- a/spec/controllers/invoices_controller_spec.rb
+++ b/spec/controllers/invoices_controller_spec.rb
@@ -250,6 +250,29 @@ describe InvoicesController do
       end
     end
 
+    it "handles exporting only one invoice" do
+      expected_ids = [invoice.id]
+      expected_options = {filename: /^Rechnung[-_].*/i}
+
+      expect(Export::InvoicesJob).to receive(:new)
+        .with(:csv, anything, expected_ids, expected_options).and_call_original
+
+      expect do
+        get :index, params: {group_id: group.id, state: :draft}, format: :csv
+      end.to change { Delayed::Job.count }.by(1)
+    end
+
+    it "handles exporting no invoices" do
+      expected_options = {filename: /^rechnungen[-_].*/i}
+
+      expect(Export::InvoicesJob).to receive(:new)
+        .with(:csv, anything, [], expected_options).and_call_original
+
+      expect do
+        get :index, params: {group_id: group.id, q: "dummy"}, format: :csv
+      end.to change { Delayed::Job.count }.by(1)
+    end
+
     it "renders json" do
       update_issued_at_to_current_year
       get :index, params: {group_id: group.id}, format: :json


### PR DESCRIPTION
It might happen for a variety of reasons, some of which are legit and the others the wish of a user. Either way, presenting a 500 is more expensive than returning an empty file, mostly due to support requests and error-tracking.

Fixes https://glitchtip.puzzle.ch/hitobito/issues/14460

**Maybe** this needs to be a hotfix, should be possible easily enough. the fix has been tested against master and stable.