### PR TITLE
Do not crash bin/wagon gemfile if BUNDLE_GEMFILE is not set

### DIFF
--- a/bin/wagon
+++ b/bin/wagon
@@ -198,7 +198,7 @@ gemfile)
   bundle check || bundle install
   $0 configs Gemfile.lock
 
-  if [ -n "${BUNDLE_GEMFILE}" ]; then
+  if [ -n "${BUNDLE_GEMFILE:-}" ]; then
     $0 configs "${BUNDLE_GEMFILE}.lock"
   fi
   ;;


### PR DESCRIPTION
While it has an if clause to guard the process would exit anyways since `set -u` was set. By substituting a default we fix this.