### PR TITLE
Apply filter to invoice export and actions

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -200,7 +200,7 @@ class InvoicesController < CrudController # rubocop:disable Metrics/ClassLength
       LEFT JOIN groups ON groups.id = invoices.recipient_id AND invoices.recipient_type = 'Group'
     SQL
     scope = scope.standalone unless parents.any?(InvoiceRun)
-    scope = scope.page(params[:page]) unless params[:ids]
+    scope = scope.page(params[:page]) if params[:ids].blank?
     Invoice::Filter.new(params.merge(filter_params)).apply(scope).with_recipients
   end
 

--- a/app/domain/invoice/filter.rb
+++ b/app/domain/invoice/filter.rb
@@ -60,7 +60,7 @@ class Invoice::Filter
   end
 
   def filter_by_ids(relation)
-    return relation if params[:ids].nil? || all_invoices?
+    return relation if params[:ids].blank? || all_invoices?
 
     relation.where(id: invoice_ids)
   end

--- a/app/helpers/dropdown/invoice_sending.rb
+++ b/app/helpers/dropdown/invoice_sending.rb
@@ -12,6 +12,7 @@ module Dropdown
     def initialize(template)
       super(template, translate(:button), :envelope)
       @invoice_run_id = template.invoice_run&.id
+      @filter_params = filter_params
       init_items
     end
 
@@ -28,8 +29,16 @@ module Dropdown
 
     def add_item(key, options = {})
       group = template.parent.is_a?(Group) ? template.parent : template.parent.group
-      path = template.group_invoice_run_path(group, options)
+      path = template.group_invoice_run_path(group, options.merge(@filter_params))
       super(translate(key), path, data: {method: :put, checkable: true})
+    end
+
+    def filter_params
+      if template.respond_to?(:filter_params)
+        template.filter_params
+      else
+        {}
+      end
     end
   end
 end

--- a/spec/controllers/invoice_runs_controller_spec.rb
+++ b/spec/controllers/invoice_runs_controller_spec.rb
@@ -277,8 +277,8 @@ describe InvoiceRunsController do
       expect(response).to redirect_to group_invoice_runs_path(group)
     end
 
-    it "PUT#update informs if not invoice has been selected" do
-      post :update, params: {group_id: group.id}
+    it "PUT#update informs if no invoice has been selected" do
+      post :update, params: {group_id: group.id, from: 1.year.from_now, to: 2.years.from_now}
       expect(response).to redirect_to group_invoices_path(group, returning: true)
       expect(flash[:alert]).to include "Es muss mindestens eine Rechnung ausgewählt werden."
     end
@@ -364,7 +364,7 @@ describe InvoiceRunsController do
 
     describe "DELETE#destroy" do
       it "informs if no invoice has been selected" do
-        delete :destroy, params: {group_id: group.id}
+        delete :destroy, params: {group_id: group.id, from: 1.year.from_now, to: 2.years.from_now}
         expect(response).to redirect_to group_invoices_path(group, returning: true)
         expect(flash[:alert]).to include "Zuerst muss eine Rechnung ausgewählt werden."
       end


### PR DESCRIPTION
Firstly, this preserves the currently selected filters in the dropdown-actions

Otherwise too many item might be filtered out if the selected filters do not match the default ones. A good example is the date-filter, which defaults to the current year, even a manual selection of ids would not matter if those ids belong to past years. With the selected filter passed along, the visually selected ids are again in the available set.

Secondly (but committed earlier), the `ids`-parameter is sent often as empty string. This is neither `nil` nor "falsey" in any way. In order to get a more predictable behaviour, we now check for blankness of the ids instead their inexistance in the ephemral plane of HTTP-Request-Parameters.

Together, both changes (which I suggest we keep separate) result in the visible filters to be applied to the invoice export and actions.