### PR TITLE
Role start_on improvements

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -162,6 +162,7 @@ class RolesController < CrudController # rubocop:disable Metrics/ClassLength
     type = extract_model_attr(:type)
     attrs = {}
     attrs[:start_on] = extract_date(:start_on) if model_params&.key?(:start_on)
+    attrs[:start_on] ||= Time.zone.today
     attrs[:end_on] = extract_date(:end_on) if model_params&.key?(:end_on)
 
     return Role.new(attrs) if type.blank?

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -130,6 +130,7 @@ class RolesController < CrudController # rubocop:disable Metrics/ClassLength
     new_role.attributes = permitted_params(@type)
     new_role.person_id = entry.person_id
     new_role.group_id = @group.id
+    new_role.start_on = [Time.zone.today, entry.start_on].max
     new_role
   end
 
@@ -162,7 +163,6 @@ class RolesController < CrudController # rubocop:disable Metrics/ClassLength
     type = extract_model_attr(:type)
     attrs = {}
     attrs[:start_on] = extract_date(:start_on) if model_params&.key?(:start_on)
-    attrs[:start_on] ||= Time.zone.today
     attrs[:end_on] = extract_date(:end_on) if model_params&.key?(:end_on)
 
     return Role.new(attrs) if type.blank?

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -114,8 +114,7 @@ class Role < ActiveRecord::Base # rubocop:todo Metrics/ClassLength
   validates_date :end_on,
     allow_blank: true,
     on_or_after: :start_on,
-    on_or_after_message: :must_be_later_than_start_on,
-    if: -> { start_on.present? }
+    on_or_after_message: :must_be_later_than_start_on
 
   validate :assert_type_is_allowed_for_group, on: :create
 
@@ -257,14 +256,6 @@ class Role < ActiveRecord::Base # rubocop:todo Metrics/ClassLength
     end
   end
 
-  # The after_initialize callback `set_start_on_to_today` needs to know if the `start_on` value has
-  # been assigned explicitely. This is done by setting `start_on_assigned` to true in the setter.
-  attr_accessor :start_on_assigned
-  def start_on=(date)
-    self.start_on_assigned = true
-    super
-  end
-
   def ended?
     end_on&.past?
   end
@@ -340,15 +331,8 @@ class Role < ActiveRecord::Base # rubocop:todo Metrics/ClassLength
     person&.update_attribute(:minimized_at, nil) # rubocop:disable Rails/SkipsModelValidations
   end
 
-  # rubocop:todo Layout/LineLength
-  # called as after_initialize callback for new records, sets `start_on` if blank unless blanked explicitely.
-  # rubocop:enable Layout/LineLength
-  # To be able to recognize if the value has been assigned explicitely, the setter `start_on=` sets
-  # an instance variable `@start_on_assigned` to true, which we check here.
   def set_start_on_to_today
-    return if start_on_assigned
-
-    self.start_on ||= Date.current
+    self.start_on ||= Time.zone.today
   end
 
   def set_contact_data_visible

--- a/db/migrate/20260427120000_make_roles_start_on_not_null.rb
+++ b/db/migrate/20260427120000_make_roles_start_on_not_null.rb
@@ -1,0 +1,15 @@
+#  Copyright (c) 2026, hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class MakeRolesStartOnNotNull < ActiveRecord::Migration[8.0]
+  def change
+    reversible do |dir|
+      dir.up { execute "UPDATE roles SET start_on = created_at::date WHERE start_on IS NULL" }
+    end
+
+    change_column_default :roles, :start_on, -> { 'CURRENT_TIMESTAMP::date' }
+    change_column_null :roles, :start_on, false
+  end
+end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -138,7 +138,7 @@ describe RolesController do
       expect(role).to be_kind_of(Group::GlobalGroup::Member)
     end
 
-    it "sets start_on nil if explicitly stated" do
+    it "does not set start_on to nil, even if explicitly stated" do
       g = groups(:toppers)
       post :create, params: {
         group_id: group.id,
@@ -152,7 +152,7 @@ describe RolesController do
 
       role = person.reload.roles.first
       expect(role.group_id).to eq(g.id)
-      expect(role.start_on).to be_nil
+      expect(role.start_on).to eq(Time.zone.today)
       # rubocop:todo Layout/LineLength
       expect(flash[:notice]).to eq("Rolle <i>Member</i> für <i>#{person}</i> in <i>Toppers</i> wurde erfolgreich erstellt.")
       # rubocop:enable Layout/LineLength

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -384,6 +384,7 @@ describe RolesController do
       end.to change { Role.with_inactive.count }.by(1)
       is_expected.to redirect_to(group_person_path(group, person))
       expect(Role.with_inactive.find(role.id)).not_to be_active
+      expect(Role.with_inactive.last.start_on).to eq Time.zone.today
       # rubocop:todo Layout/LineLength
       expect(flash[:notice]).to eq "Rolle <i>Member (bis #{Date.current.yesterday.strftime("%d.%m.%Y")})</i> für <i>#{person}</i> in <i>TopGroup</i> zu <i>Leader</i> geändert."
       # rubocop:enable Layout/LineLength
@@ -399,6 +400,19 @@ describe RolesController do
       # rubocop:todo Layout/LineLength
       expect(flash[:notice]).to eq "Rolle <i>Member</i> für <i>#{person}</i> in <i>TopGroup</i> zu <i>Leader</i> geändert."
       # rubocop:enable Layout/LineLength
+    end
+
+    it "hard destroys and creates new future role if type changes and role has future start_on" do
+      role.update_attribute(:start_on, 1.week.from_now)
+      expect do
+        put :update, params: {group_id: group.id, id: role.id, role: {type: Group::TopGroup::Leader.sti_name}}
+      end.not_to change { Role.with_inactive.count }
+      is_expected.to redirect_to(group_person_path(group, person))
+      expect(Role.with_inactive.where(id: role.id)).not_to be_exists
+      expect(Role.with_inactive.last.start_on).to eq 1.week.from_now.to_date
+      expect(flash[:notice]).to eq(
+        "Rolle <i>Member</i> für <i>#{person}</i> in <i>TopGroup</i> zu <i>Leader</i> geändert."
+      )
     end
 
     it "terminates and creates new role if type and group changes" do

--- a/spec/fixtures/roles.yml
+++ b/spec/fixtures/roles.yml
@@ -29,8 +29,10 @@ top_leader:
   person: top_leader
   group: top_group
   type: Group::TopGroup::Leader
+  start_on: <%= 1.year.ago %>
 
 bottom_member:
   person: bottom_member
   group: bottom_layer_one
   type: Group::BottomLayer::Member
+  start_on: <%= 1.year.ago %>

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -50,11 +50,6 @@ describe Role do
       is_expected.to be_valid
     end
 
-    it "is valid when start_on is blank and end_on is set" do
-      role.attributes = {start_on: nil, end_on: tomorrow}
-      is_expected.to be_valid
-    end
-
     it "is valid when start_on is before end_on" do
       role.attributes = {start_on: yesterday, end_on: tomorrow}
       is_expected.to be_valid
@@ -77,7 +72,7 @@ describe Role do
     end
 
     it "is valid when end_on has a normal 4-digit year" do
-      role.attributes = {start_on: nil, end_on: Date.new(9999, 12, 31)}
+      role.attributes = {end_on: Date.new(9999, 12, 31)}
       is_expected.to be_valid
     end
 
@@ -194,7 +189,7 @@ describe Role do
 
       it "includes ended roles if from anytime if setting is set to nil" do
         allow(Settings.people).to receive(:ended_roles_readable_for).and_return(nil)
-        role.update!(end_on: 100.years.ago)
+        role.update!(start_on: 100.years.ago, end_on: 100.years.ago)
         expect(Role.with_ended_readable).to include(role)
       end
     end
@@ -583,11 +578,6 @@ describe Role do
       date = Date.new(2025, 3, 17)
       r = Role.new(start_on: date)
       expect(r.start_on).to eq(date)
-    end
-
-    it "does not override given blank start_on" do
-      r = Role.new(start_on: nil)
-      expect(r.start_on).to be_nil
     end
   end
 


### PR DESCRIPTION
- start_on should never be nil
- When mutating the type of a role, the old role is terminated and a new role is created. We fix the start_on date of the new role