### PR TITLE
Fix failing CI case because of missing dependency wagon ref

### DIFF
--- a/.github/actions/wagon-ci-setup/action.yml
+++ b/.github/actions/wagon-ci-setup/action.yml
@@ -45,13 +45,14 @@ runs:
 
     - name: "Determine common branch and set branch name for dependency repo"
       if: inputs.wagon_dependency_repository != ''
+      working-directory: .hitobito_core_repo
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         INPUT_CORE_REF: ${{ inputs.core_ref }}
         WAGON_DEPENDENCY_REPO: ${{ inputs.wagon_dependency_repository }}
         INPUT_WDEP_REF: ${{ inputs.wagon_dependency_ref }}
         INPUT_WAGON_REF: ${{ inputs.wagon_ref }}
-        GITHUB_REF: ${{github.head_ref || github.ref_name}}
+        WAGON_HEAD_REF: ${{github.head_ref || github.ref_name}}
       run: |
         REPO_URL="https://github.com/hitobito/$WAGON_DEPENDENCY_REPO"
         REMOTE_BRANCHES=$(git ls-remote --heads "$REPO_URL" | awk -F'refs/heads/' '{print $2}')
@@ -60,17 +61,24 @@ runs:
           RESOLVED_REF="$INPUT_WDEP_REF"
         else
           PR_BRANCH=""
-          if [[ "$INPUT_CORE_REF" =~ ^refs/pull/([0-9]+)/ ]]; then
-            PR_NUMBER="${BASH_REMATCH[1]}"
-            PR_BRANCH=$(gh pr view "$PR_NUMBER" --repo hitobito/hitobito --json headRefName -q '.headRefName')
+          if [[ "$INPUT_CORE_REF" =~ refs/pull/([0-9]+)/ ]]; then
+            PR_BRANCH=$(gh pr view "${BASH_REMATCH[1]}" --repo hitobito/hitobito --json headRefName -q '.headRefName' 2>/dev/null || echo "")
           fi
 
-          for candidate in "$INPUT_CORE_REF" "$PR_BRANCH" "$INPUT_WAGON_REF" "$GITHUB_REF"; do
-            [ -z "$candidate" ] && continue
+          for candidate_name in "INPUT_CORE_REF" "PR_BRANCH" "INPUT_WAGON_REF" "WAGON_HEAD_REF"; do
+            candidate="${!candidate_name}"
+
+            if [ -z "$candidate" ]; then
+              echo "INFO: Skipping $candidate_name, candidate value is empty"
+              continue
+            fi
 
             if echo "$REMOTE_BRANCHES" | grep -xq "$candidate"; then
               RESOLVED_REF="$candidate"
+              echo "INFO: MATCH FOUND in $candidate_name: $RESOLVED_REF"
               break
+            else
+              echo "INFO: No match for $candidate_name ('$candidate')"
             fi
           done
         fi

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: hitobito/hitobito
-          ref: ${{ inputs.core_ref }}
+          ref: ${{ inputs.core_ref || github.head_ref || github.ref_name }}
           path: .hitobito_core_repo
           fetch-depth: 1
 
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: hitobito/hitobito
-          ref: ${{ inputs.core_ref }}
+          ref: ${{ inputs.core_ref || github.head_ref || github.ref_name }}
           path: .hitobito_core_repo
           fetch-depth: 1
 
@@ -164,7 +164,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: hitobito/hitobito
-          ref: ${{ inputs.core_ref }}
+          ref: ${{ inputs.core_ref || github.head_ref || github.ref_name }}
           path: .hitobito_core_repo
           fetch-depth: 1
 
@@ -219,7 +219,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: hitobito/hitobito
-          ref: ${{ inputs.core_ref }}
+          ref: ${{ inputs.core_ref || github.head_ref || github.ref_name }}
           path: .hitobito_core_repo
           fetch-depth: 1
 
@@ -274,7 +274,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: hitobito/hitobito
-          ref: ${{ inputs.core_ref }}
+          ref: ${{ inputs.core_ref || github.head_ref || github.ref_name }}
           path: .hitobito_core_repo
           fetch-depth: 1
 


### PR DESCRIPTION
Read commit messages/info for information about why these changes are needed.

Action to test it all:
https://github.com/hitobito/hitobito_sac_cas/actions/runs/25054310954/job/73390241465?pr=2381
Raw logs to see the INFO statements and what refs were checked/found/skipped:
https://productionresultssa14.blob.core.windows.net/actions-results/194ff96a-d839-4c8d-9068-15f55484d3be/workflow-job-run-239f2a03-ec3c-5109-8e0f-7accbad3ba91/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-04-28T13%3A39%3A59Z&sig=r%2FIN2o%2FZmOMfWaouIwX%2BpKeMpZkP%2BvOi2VDkmp%2FZ%2FLM%3D&ske=2026-04-28T14%3A34%3A14Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-04-28T10%3A34%3A14Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-04-28T13%3A29%3A54Z&sv=2025-11-05
