### PR TITLE
Save item_label to paper_trail version (hitobito/hitobito_sac_cas#2320)

### DIFF
--- a/app/decorators/paper_trail/version_association_change_presenter.rb
+++ b/app/decorators/paper_trail/version_association_change_presenter.rb
@@ -7,7 +7,8 @@ module PaperTrail
   class VersionAssociationChangePresenter
     attr_reader :version, :h
 
-    delegate :event, :changeset, :item, :item_type, :item_id, :main_type, :main_id, to: :version
+    delegate :event, :changeset, :item_type, :item_id, :item_label, :main_type, :main_id,
+      to: :version
 
     def initialize(version, view_context)
       @version = version
@@ -17,9 +18,8 @@ module PaperTrail
     def render
       h.content_tag(:div) do
         changeset = (event == "update") ? changeset_list : nil
-        item = reifyed_item
 
-        text = association_change_text(changeset, item)
+        text = association_change_text(changeset)
 
         h.sanitize(text, tags: %w[i])
       end
@@ -37,19 +37,24 @@ module PaperTrail
       h.safe_join(rendered_changes, ", ")
     end
 
-    def association_change_text(changeset, item)
-      return changeset if item_type.include?("Translation") && main_type
+    def association_change_text(changeset)
+      return changeset if translation_change?
 
       if item_type == PeopleManager.sti_name
-        return association_change_text_with_people_manager(changeset,
-          item)
+        association_change_text_with_people_manager(changeset, reifyed_item)
+      else
+        translate_association_change(item_label || label_with_fallback(reifyed_item), changeset)
       end
+    end
 
-      I18n.t("version.association_change.#{item_class.name.underscore}.#{event}",
+    def translate_association_change(label, changeset)
+      I18n.t(
+        "version.association_change.#{item_class.name.underscore}.#{event}",
         default: :"version.association_change.#{event}",
         model: item_class.model_name.human,
-        label: item ? label_with_fallback(item) : "",
-        changeset: changeset)
+        label: label,
+        changeset: changeset
+      )
     end
 
     def association_change_text_with_people_manager(changeset, _item) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize
@@ -93,7 +98,7 @@ module PaperTrail
     end
 
     def reify_exisiting
-      item || build_new_instance
+      version.item || build_new_instance
     end
 
     def build_new_instance
@@ -107,7 +112,11 @@ module PaperTrail
 
     def item_class = @item_class ||= version.item_type.constantize
 
+    def translation_change? = item_type.include?("Translation") && main_type
+
     def label_with_fallback(item)
+      return "" unless item
+
       if item.respond_to?(:translation_class)
         item_class.find_by(id: item_id).to_s(:long)
       else

--- a/app/decorators/paper_trail/version_association_change_presenter.rb
+++ b/app/decorators/paper_trail/version_association_change_presenter.rb
@@ -115,15 +115,21 @@ module PaperTrail
     def translation_change? = item_type.include?("Translation") && main_type
 
     def label_with_fallback(item)
-      return "" unless item
+      return I18n.t("global.unknown") unless item
 
       if item.respond_to?(:translation_class)
-        item_class.find_by(id: item_id).to_s(:long)
+        label_method(item_class.find_by(id: item_id))
       else
-        item.to_s(:long)
+        label_method(item)
       end
-    rescue
-      I18n.t("global.unknown")
+    end
+
+    def label_method(object)
+      if object.method(:to_s).arity != 0
+        object.to_s(:long)
+      else
+        object.to_s
+      end
     end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -117,7 +117,7 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
     # This is used to display in log what language record actually changed. Currently those
     # values are just the strings from settings.yml, so the log does not display translated
     # language names
-    def to_s(format = :default)
+    def to_s
       locale.to_s
     end
   end

--- a/app/models/event/question.rb
+++ b/app/models/event/question.rb
@@ -128,7 +128,7 @@ class Event::Question < ActiveRecord::Base
     question&.truncate(30)
   end
 
-  def to_s(format = :default)
+  def to_s
     label
   end
 

--- a/app/models/event/question.rb
+++ b/app/models/event/question.rb
@@ -56,7 +56,7 @@ class Event::Question < ActiveRecord::Base
     # This is used to display in log what language record actually changed. Currently those
     # values are just the strings from settings.yml, so the log does not display translated
     # language names
-    def to_s(format = :default)
+    def to_s
       locale.to_s
     end
   end

--- a/app/models/person/add_request/mailing_list.rb
+++ b/app/models/person/add_request/mailing_list.rb
@@ -6,6 +6,8 @@ class Person::AddRequest::MailingList < Person::AddRequest
   belongs_to :body, class_name: "::MailingList"
 
   def to_s(_format = :default)
+    return I18n.t("global.unknown") unless body
+
     group = body.group
     list_label = body_label
     group_label = "#{group.model_name.human} #{group}"

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -18,3 +18,32 @@ PaperTrail.config.has_paper_trail_defaults = {
   on: %i[create update destroy],
   skip: %i[updated_at]
 }
+
+# We want to save the current to_s value of the item directly to the version
+# This is used for displaying association texts in the logs
+# e.g. Anhang foo wurde hinzugefügt
+#
+# If we don't save this label directly to the version and use paper trails reify to
+# determine the label inside the logs, we run into an issue as soon as the label
+# of an item is from a association and not directly on the item itself.
+#
+# This happens for attachments for example. The attachment label is the file name
+# The file itself is a has_one_attached association that is not tracked by paper_trail
+# So that association can't be reifyed. This results in log texts without labels as soon
+# as the attachment get's deleted (Also older version of that attachment)
+#
+# This also improves performance when showing the log, since we don't have to reify all
+# the items (well at least for versions from now on...)
+ActiveSupport.on_load(:active_record) do
+  def self.has_paper_trail(options = {})
+    options[:meta] ||= {}
+
+    options[:meta][:item_label] = lambda do |item|
+      item.present? ? item.to_s(:long) : nil
+    rescue ArgumentError
+      nil
+    end
+
+    super(options)
+  end
+end

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -39,9 +39,13 @@ ActiveSupport.on_load(:active_record) do
     options[:meta] ||= {}
 
     options[:meta][:item_label] = lambda do |item|
-      item.present? ? item.to_s(:long) : nil
-    rescue ArgumentError
-      nil
+      return nil if item.blank?
+
+      if item.method(:to_s).arity != 0
+        item.to_s(:long)
+      else
+        item.to_s
+      end
     end
 
     super(options)

--- a/db/migrate/20260430065720_add_item_label_to_paper_trail_version.rb
+++ b/db/migrate/20260430065720_add_item_label_to_paper_trail_version.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class AddItemLabelToPaperTrailVersion < ActiveRecord::Migration[8.0]
+  def change
+    add_column :versions, :item_label, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_24_135223) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_30_065720) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -1345,6 +1345,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_24_135223) do
     t.string "whodunnit_type", default: "Person", null: false
     t.string "mutation_id"
     t.string "item_subtype"
+    t.string "item_label"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
     t.index ["main_id", "main_type"], name: "index_versions_on_main_id_and_main_type"
     t.index ["mutation_id"], name: "index_versions_on_mutation_id"

--- a/doc/architecture/gems/papertrail.md
+++ b/doc/architecture/gems/papertrail.md
@@ -42,7 +42,7 @@ To maintain a clean version history, we prevent PaperTrail from creating version
     # This is used to display in log what language record actually changed. Currently those
     # values are just the strings from settings.yml, so the log does not display translated
     # language names
-    def to_s(format = :default)
+    def to_s
       locale.to_s
     end
   end

--- a/spec/decorators/paper_trail/version_association_change_presenter_spec.rb
+++ b/spec/decorators/paper_trail/version_association_change_presenter_spec.rb
@@ -42,7 +42,7 @@ describe PaperTrail::VersionAssociationChangePresenter, :draper_with_helpers, ve
     account = Fabricate(:social_account, contactable: person, label: "Foo", name: "Bar")
     account.update!(name: "Boo")
 
-    is_expected.to eq("<div>Social Media Adresse <i>Bar (Foo)</i> wurde aktualisiert: " \
+    is_expected.to eq("<div>Social Media Adresse <i>Boo (Foo)</i> wurde aktualisiert: " \
                       "Name wurde von <i>Bar</i> auf <i>Boo</i> geändert.</div>")
   end
 
@@ -92,12 +92,12 @@ describe PaperTrail::VersionAssociationChangePresenter, :draper_with_helpers, ve
       )
     end
 
-    it "destroyed mailing list" do
+    it "destroyed mailing list still shows label" do
       Person::AddRequest::MailingList.create!(
         person: person, body: list, requester: people(:top_leader)
       )
       list.destroy
-      expect(subject).to eq "<div>Zugriffsanfrage für <i>unbekannt</i> wurde beantwortet.</div>"
+      expect(subject).to eq "<div>Zugriffsanfrage für <i>Abo Leaders in Top Layer Top</i> wurde beantwortet.</div>"
     end
   end
 
@@ -179,6 +179,20 @@ describe PaperTrail::VersionAssociationChangePresenter, :draper_with_helpers, ve
 
         is_expected.to eq("<div><i>(Gelöschte Person)</i> wurde als Verwalter*in entfernt.</div>")
       end
+    end
+  end
+
+  context "without item_label" do
+    before do
+      allow_any_instance_of(PaperTrail::Version).to receive(:item_label).and_return(nil)
+    end
+
+    it "displays unbekannt for version with label from untracked association" do
+      Person::AddRequest::MailingList.create!(
+        person: person, body: mailing_lists(:leaders), requester: people(:top_leader)
+      )
+      mailing_lists(:leaders).destroy
+      expect(subject).to eq "<div>Zugriffsanfrage für <i>unbekannt</i> wurde beantwortet.</div>"
     end
   end
 

--- a/spec/models/paper_trail/version_spec.rb
+++ b/spec/models/paper_trail/version_spec.rb
@@ -1,0 +1,19 @@
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+describe PaperTrail::Version, versioning: true do
+  it "verifies all paper_trailed models have item_label lambda" do
+    ActiveRecord::Base.descendants.select { _1.respond_to?(:paper_trail_options) }.each do |model_class|
+      expect(model_class.paper_trail_options[:meta][:item_label]).to be_a(Proc)
+    end
+  end
+
+  it "safes item_label to version" do
+    people(:top_leader).update!(first_name: "Foo")
+    expect(PaperTrail::Version.last.item_label).to eq "Foo Leader"
+  end
+end


### PR DESCRIPTION
https://saccas.atlassian.net/browse/HIT-1496?focusedCommentId=102099

We will currently not implemented translated save labels, that would kill performance since we would have todo locale switching for every record we save, if we would implement this, switching away from to_s here would be cleaner, since we could load translations directly per record and not switch locales all the time