### PR TITLE
Revert "Override method_missing for globalized models to prevent issues with STI models (#4060)"

### DIFF
--- a/app/models/concerns/globalized.rb
+++ b/app/models/concerns/globalized.rb
@@ -22,25 +22,6 @@ module Globalized
 
     class_attribute :list_alphabetically
     self.list_alphabetically = true
-
-    # When translating attributes on a sti_model, the translations are in a shared
-    # translation table aswell
-    # Globalized adds all the known translation from that table to methods like #attributes
-    # This leads to the issue of other sti_models not being able to evaluate that method
-    # because it doesn't know about the translation for that certain attribute
-    #
-    # In the case of an attribute being in the translated_attribute_names of
-    # globalized (table columns). We want to just return nil instead of throwing a
-    # method_missing error
-    def method_missing(method_name, *args, &block)
-      return nil if translated_attribute_names.include?(method_name)
-
-      super
-    end
-
-    def respond_to_missing?(method_name, include_private = false)
-      translated_attribute_names.include?(method_name.to_sym) || super
-    end
   end
 
   module ClassMethods

--- a/spec/models/globalized_model_spec.rb
+++ b/spec/models/globalized_model_spec.rb
@@ -11,22 +11,6 @@ describe "Globalized model" do
   let(:group) { groups(:top_layer) }
   let(:custom_content) { custom_contents(:assignment_assignee_notification) }
 
-  describe "#method_missing" do
-    let(:model_instance) { Event.new } # can be anything that includes globalized
-
-    it "returns nil for a translated attribute that isn't defined on this specific STI child" do
-      allow(model_instance).to receive(:translated_attribute_names).and_return([:title])
-
-      expect(model_instance.title).to be_nil
-    end
-
-    it "still raises NoMethodError for attributes not in the translation list" do
-      allow(model_instance).to receive(:translated_attribute_names).and_return([:title])
-
-      expect { model_instance.unknown_field }.to raise_error(NoMethodError)
-    end
-  end
-
   it "should create globalized accessors" do
     privacy_policy_titles = Globalized.languages.each_with_object({}) do |lang, hash|
       hash[:"privacy_policy_title_#{lang}"] = "Privacy policy title in #{lang}"


### PR DESCRIPTION
This reverts commit 1c8b81b044e7312a80992cce6b2263baa8a512be.

It is easier to fix the root cause (always declare translations in the base class). Furthermore, setters or query methods, and possibly others, have not been handled.