### PR TITLE
Bug/Fix setting capybara driver inconsistently

### DIFF
--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -11,6 +11,7 @@
 #
 #  id             :integer          not null, primary key
 #  event          :string           not null
+#  item_label     :string
 #  item_subtype   :string
 #  item_type      :string           not null
 #  main_type      :string

--- a/spec/features/oauth_workflow_spec.rb
+++ b/spec/features/oauth_workflow_spec.rb
@@ -36,10 +36,9 @@ describe "OauthWorkflow", js: true do
     end
 
     it "creates access_grant with consent screen" do
-      authorization_code = nil
       authorization_page = window_opened_by { click_link "Autorisieren" }
 
-      within_window authorization_page do
+      authorization_code = within_window authorization_page do
         expect(page).to have_text "Autorisierung erforderlich"
         expect(page).to have_content "Soll MyApp zur Nutzung dieses Kontos autorisiert werden?"
         expect(page).to have_content "Diese Anwendung erhält folgende Berechtigungen:"
@@ -50,13 +49,14 @@ describe "OauthWorkflow", js: true do
           expect(page).to have_content "Autorisierungscode"
         end.to change { app.access_grants.count }.by(1)
 
-        authorization_code = find("#authorization_code").text
+        find("#authorization_code").text
       end
 
       visit oauth_application_path(app)
       click_link "Autorisierungen"
+      expect(page).to have_content("Aktive OAuth Autorisierungen")
 
-      raise "Did not find authorization code after consenting to access" if authorization_code.blank?
+      raise "OAuth authorization code not found on consent screen" if authorization_code.blank?
       expect(page).not_to have_content authorization_code
     end
 

--- a/spec/features/oauth_workflow_spec.rb
+++ b/spec/features/oauth_workflow_spec.rb
@@ -6,7 +6,7 @@
 
 require "spec_helper"
 
-describe "OauthWorkflow" do
+describe "OauthWorkflow", js: true do
   let(:user) { people(:top_leader) }
   let(:redirect_uri) { "urn:ietf:wg:oauth:2.0:oob" }
   let(:app) { Oauth::Application.create!(name: "MyApp", redirect_uri: redirect_uri) }
@@ -36,29 +36,39 @@ describe "OauthWorkflow" do
     end
 
     it "creates access_grant with consent screen" do
-      click_link "Autorisieren"
-      expect(page).to have_text "Autorisierung erforderlich"
-      expect(page).to have_content "Soll MyApp zur Nutzung dieses Kontos autorisiert werden?"
-      expect(page).to have_content "Diese Anwendung erhält folgende Berechtigungen:"
-      expect(page).to have_content "Lesen deiner E-Mail Adresse"
+      authorization_code = nil
+      authorization_page = window_opened_by { click_link "Autorisieren" }
 
-      expect do
-        click_button "Autorisieren"
-        expect(page).to have_content "Autorisierungscode"
-      end.to change { app.access_grants.count }.by(1)
+      within_window authorization_page do
+        expect(page).to have_text "Autorisierung erforderlich"
+        expect(page).to have_content "Soll MyApp zur Nutzung dieses Kontos autorisiert werden?"
+        expect(page).to have_content "Diese Anwendung erhält folgende Berechtigungen:"
+        expect(page).to have_content "Lesen deiner E-Mail Adresse"
 
-      code = find("#authorization_code").text
+        expect do
+          click_button "Autorisieren"
+          expect(page).to have_content "Autorisierungscode"
+        end.to change { app.access_grants.count }.by(1)
+
+        authorization_code = find("#authorization_code").text
+      end
+
       visit oauth_application_path(app)
       click_link "Autorisierungen"
-      expect(page).not_to have_content code
+
+      raise "Did not find authorization code after consenting to access" if authorization_code.blank?
+      expect(page).not_to have_content authorization_code
     end
 
     it "creates access_grant and skips consent screen" do
       app.update!(skip_consent_screen: true)
       expect do
-        click_link "Autorisieren"
-        expect(page).to have_text "Autorisierungscode"
-        expect(page).not_to have_text "Autorisierung erforderlich"
+        authorization_page = window_opened_by { click_link "Autorisieren" }
+
+        within_window authorization_page do
+          expect(page).to have_text "Autorisierungscode"
+          expect(page).not_to have_text "Autorisierung erforderlich"
+        end
       end.to change { app.access_grants.count }.by(1)
     end
   end

--- a/spec/features/person/csv_import_spec.rb
+++ b/spec/features/person/csv_import_spec.rb
@@ -7,7 +7,7 @@
 
 require "spec_helper"
 
-describe "Person::CsvImport" do
+describe "Person::CsvImport", js: true do
   include CsvImportMacros
   let(:role) { roles(:top_leader) }
   let(:person) { people(:top_leader) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -250,7 +250,6 @@ Capybara.register_driver :chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
-Capybara.current_driver = :chrome
 Capybara.javascript_driver = :chrome
 
 Devise::Test::ControllerHelpers.prepend(Module.new do


### PR DESCRIPTION
Capybara.current_driver is intended to be used to change the driver for
specific specs e.g. in a before hook. Because of this, the driver set
with current_driver is automatically reset to the standard driver after
a test runs runs. In our case this is the Rack::Test driver since we dont
specify Capybara.default_driver. Because we specified current_driver in the
spec_helper, which is loaded before all specs run, the first feature
spec would always run with the chrome driver, regardless of the presence
or rather absence of `js: true`. This would lead to seemingly flaky
specs when either the test only worked with the js driver and `js: true`
wasnt specified or the test for some reason only worked with the
Rack::Test driver.

Going forward, only test that explicitly define `js: true` should
actually run with the chrome driver.