### PR TITLE
Add interactive mode to form_field_check_dependent_controller (hitobito/hitobito_sac_cas#2400)

### DIFF
--- a/app/javascript/controllers/form_field_check_dependent_controller.js
+++ b/app/javascript/controllers/form_field_check_dependent_controller.js
@@ -8,24 +8,37 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = ["main", "dependent"];
   static values = {
-    selectDependentCheckboxes: { type: Boolean, default: false },
+    interactionMode: { type: String, default: "default" },
+    selectDependentCheckboxes: { type: Boolean, default: false }
   }
 
-  // unselects all dependent checkboxes when unchecking master checkbox
-  toggleMain() {
-    if (!event.target.checked) {
-      this.dependentTargets.forEach((checkbox) => {
-        checkbox.checked = false;
-      });
-    } else if (this.selectDependentCheckboxesValue) {
-      this.dependentTargets.forEach((checkbox) => {
-        checkbox.checked = true;
-      });
+  toggleMain(event) {
+    const isChecked = event.target.checked;
+
+    if (this.interactionModeValue === "exclusive") {
+      if (isChecked) {
+        this.dependentTargets.forEach(cb => cb.checked = false);
+      }
+    } else {
+      if (!isChecked) {
+        this.dependentTargets.forEach(cb => cb.checked = false);
+      } else if (this.selectDependentCheckboxesValue) {
+        this.dependentTargets.forEach(cb => cb.checked = true);
+      }
     }
   }
 
-  // selects master checkbox if any dependent checkbox is checked
-  toggleDependent() {
-    this.mainTarget.checked = true;
+  toggleDependent(event) {
+    const isChecked = event.target.checked;
+
+    if (this.interactionModeValue === "exclusive") {
+      if (isChecked && this.hasMainTarget) {
+        this.mainTarget.checked = false;
+      }
+    } else {
+      if (this.hasMainTarget) {
+        this.mainTarget.checked = true;
+      }
+    }
   }
 }

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -52,6 +52,7 @@ de:
       add_another: Speichern und weitere erfassen
       cancel: Abbrechen
       close: Schliessen
+      confirm: Bestätigen
       search: Suchen
       back: Zurück
       refresh: Aktualisieren


### PR DESCRIPTION
The Stimulus Controller gets a bit messy at this point, because it now handles three different ways of selecting/deselecting dependent check boxes...

If the `interactionMode` is a nice approach to solve this it's nice, otherwise I would probably split this up into multiple controllers because there will most likely be another option where the dependent behavior is a slight bit different to the other three we already have.