### PR TITLE
Support wagon pack entry points in production builds

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -58,12 +58,18 @@ environment.plugins.append('exclude unused moment locales',
 
 // Register webpack entry points from wagon directories (../hitobito_*/app/javascript/packs/*)
 // This allows wagons to define their own layouts/pack files that get compiled into the manifest.
+
+// For this to work in PRE_BUILD_SCRIPT, we need a pathJoin from
+// vendor wagons aswell, instead of the local setup
 const wagonExtGlob = extensions.length === 1
   ? `**/*${extensions[0]}`
   : `**/*{${extensions.join(',')}}`
 
-const wagonPacksPattern = pathJoin('..', 'hitobito_*', 'app', 'javascript', 'packs', wagonExtGlob)
-globSync(wagonPacksPattern).forEach((packPath) => {
+const wagonPacksPatterns = [
+  pathJoin('..', 'hitobito_*', 'app', 'javascript', 'packs', wagonExtGlob),
+  pathJoin('vendor', 'wagons', 'hitobito_*', 'app', 'javascript', 'packs', wagonExtGlob),
+]
+wagonPacksPatterns.flatMap((pattern) => globSync(pattern)).forEach((packPath) => {
   const name = basename(packPath, pathCompleteExtname(packPath))
   environment.entry.set(name, pathResolve(packPath))
 })


### PR DESCRIPTION
The PRE_BUILD_SCRIPT in our Dockerfile moves wagon directories into 'vendor/wagons/xy' before webpacker compile runs. The first approach covered a local setup but never actually found the packs during an actual build.

https://glitchtip.puzzle.ch/hitobito/issues/15230?project=20