### PR TITLE
Use .lft instead of .name for layer sorting

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -226,11 +226,11 @@ class Group < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
     end
 
     # order groups based on order in Group.all_types
-    # group.name as second order attribute, to get same output for all
+    # group.lft as second order attribute, to get same output for all
     # queries where multiple groups have the same type
     def order_by_type
       joins("INNER JOIN group_type_orders ON group_type_orders.name = groups.type")
-        .reorder("group_type_orders.order_weight ASC, groups.name ASC")
+        .reorder("group_type_orders.order_weight ASC, groups.lft ASC")
     end
 
     private

--- a/app/views/groups/_child_groups.html.haml
+++ b/app/views/groups/_child_groups.html.haml
@@ -4,7 +4,7 @@
 -#  https://github.com/hitobito/hitobito.
 
 - @sub_groups.each do |label, groups|
-  = section_table(label, groups.sort_by(&:sorting_name)) do |item|
+  = section_table(label, groups) do |item|
     %td
       = link_to(item.to_s, group_path(item.id))
 


### PR DESCRIPTION
This uses the sorting defined by sorting_name (which defaults to display_name).

I think this fixes #1720. Can @carlobeltrame or @nilsrauch confirm?

Before:
<img width="1136" height="410" alt="image" src="https://github.com/user-attachments/assets/c9895034-6c95-4f8d-bcfc-7dbb10ec3053" />

After:
<img width="1236" height="448" alt="image" src="https://github.com/user-attachments/assets/6d995200-0b57-45a3-baa3-6a685f5f5d47" />
