### PR TITLE
Define field_order_id for Mail::OptionalField

### DIFF
--- a/app/domain/messages/bulk_mail/mail_factory.rb
+++ b/app/domain/messages/bulk_mail/mail_factory.rb
@@ -57,6 +57,15 @@ module Messages
         # OptionalField does not implement the method #<() which is used by #insert_field.
         @mail.to = "" # ← makes sure the To header exists, so we can replace it later
         undisclosed = Mail::OptionalField.new("To", "Undisclosed recipients:;")
+
+        # Mail::OptionalField does not have field_order_id because it does not
+        # inherit from Mail::Field.
+        # Mail::Field#<=> calls "other.field_order_id" when sorting headers
+        # during delivery.
+        # We define field_order_id here to prevent this from happening
+        undisclosed.define_singleton_method(:field_order_id) do
+          Mail::Field::FIELD_ORDER_LOOKUP.fetch(name.to_s.downcase, 100)
+        end
         @mail.header.fields.replace_field(undisclosed)
       end
 


### PR DESCRIPTION
fixes: https://glitchtip.puzzle.ch/hitobito/issues/15476

Mail::OptionalField does not have field_order_id because it inherits from CommonField and not Mail::Field. Since Mail::Field uses field_order_id to sort headers during delivery, this fails. We dfine a singleton method here for OptionalField the same way Mail::Field does.
https://github.com/mikel/mail/blob/master/lib/mail/field.rb#L258