### PR TITLE
 Add group_id presence validation to role api

### DIFF
--- a/app/abilities/ability_dsl/constraints/group.rb
+++ b/app/abilities/ability_dsl/constraints/group.rb
@@ -27,7 +27,7 @@ module AbilityDsl::Constraints
     end
 
     def group_not_deleted
-      !group.deleted?
+      group && !group.deleted?
     end
 
     def group_not_deleted_or_archived
@@ -35,7 +35,7 @@ module AbilityDsl::Constraints
     end
 
     def if_layer_group
-      group.layer?
+      group&.layer?
     end
 
     def if_layer_group_if_active
@@ -43,11 +43,11 @@ module AbilityDsl::Constraints
     end
 
     def in_active_group
-      !group.archived?
+      group && !group.archived?
     end
 
     def in_archived_group
-      group.archived?
+      group&.archived?
     end
 
     def in_same_group_if_active
@@ -67,7 +67,7 @@ module AbilityDsl::Constraints
     end
 
     def on_root_group
-      group.root?
+      group&.root?
     end
 
     private

--- a/app/resources/role_resource.rb
+++ b/app/resources/role_resource.rb
@@ -51,7 +51,7 @@ class RoleResource < ApplicationResource
   private
 
   def authorize_create(model)
-    invalid_request!(:group_id, :blank) unless model.group_id.present?
+    invalid_request!(:group_id, :blank) if model.group_id.blank?
     super
   end
 

--- a/app/resources/role_resource.rb
+++ b/app/resources/role_resource.rb
@@ -50,6 +50,11 @@ class RoleResource < ApplicationResource
 
   private
 
+  def authorize_create(model)
+    invalid_request!(:group_id, :blank) unless model.group_id.present?
+    super
+  end
+
   def raise_when_changing_readonly_attr(model)
     changed = [:group_id, :person_id, :type].filter { |attr| model.changes.key?(attr.to_s) }
     invalid_request!(*changed, :unwritable_attribute) if changed.any?

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -1432,6 +1432,7 @@ de:
         id_must_not_be_set: ID darf nicht gesetzt sein
         role_resource:
           group_id:
+            blank: muss ausgefüllt werden
             unwritable_attribute: kann nicht geändert werden
           person_id:
             unwritable_attribute: kann nicht geändert werden

--- a/spec/resources/role/writes_spec.rb
+++ b/spec/resources/role/writes_spec.rb
@@ -42,6 +42,14 @@ describe RoleResource, type: :resource do
       expect(new_role.label).to eq "test"
     end
 
+    context "without group_id" do
+      before { payload[:data][:attributes].delete(:group_id) }
+
+      it "raises an invalid request error" do
+        expect { instance.save }.to raise_error(Graphiti::Errors::InvalidRequest)
+      end
+    end
+
     context "other user" do
       let(:ability) { Ability.new(people(:bottom_member)) }
 


### PR DESCRIPTION
fixes: https://glitchtip.puzzle.ch/hitobito/issues/15657

Making the group constraint nil safe solves the issue by itself but I think the validation just makes sense, so the request does not return Forbidden and rather InvalidRequest