### PR TITLE
Return empty list of receivers when recipient_source has been destroyed

### DIFF
--- a/app/models/invoice_run.rb
+++ b/app/models/invoice_run.rb
@@ -100,7 +100,7 @@ class InvoiceRun < ActiveRecord::Base
 
   # rubocop:disable Metrics/AbcSize
   def recipients(current_user)
-    return [] if recipient_source_type.nil?
+    return Person.none if recipient_source.nil?
 
     case recipient_source_type
     when MailingList.sti_name

--- a/spec/models/invoice_run_spec.rb
+++ b/spec/models/invoice_run_spec.rb
@@ -30,6 +30,21 @@ describe InvoiceRun do
       subject.recipient_source = Event::ParticipationsFilter.new(event: events(:top_course))
       expect(subject.recipients(leader)).to eq [member]
     end
+
+    it "returns none if recipient_source is nil" do
+      subject.recipient_source = nil
+
+      expect(subject.recipients(leader)).to eq []
+    end
+
+    it "returns none if recipient_source has been destroyed" do
+      subject.recipient_source = list
+      list.destroy!
+
+      expect(subject.recipient_source_type).to eq "MailingList"
+      expect(subject.recipient_source_id).to eq list.id
+      expect(subject.recipients(leader)).to eq []
+    end
   end
 
   describe "recipient_source" do


### PR DESCRIPTION
fixes: https://glitchtip.puzzle.ch/hitobito/issues/15473