### PR TITLE
Allow creating invoices via JSON:API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 - Konfigurierbare Ausweise mit Apple und Google Wallet Integration (#3911)
+- Rechnungen können neu via JSON:API erstellt werden (`POST /api/invoices`), inklusive Sideposting der Positionen (#4257)
 - Gruppen Sammelrechnungen können kopiert werden (#3754)
 - Spezifische E-Mails je nach Zustand der Teilnahme (Nicht zugeteilt, Zugeteilt, Warteliste) (hitobito_sww#289)
 - Optionale PP-Zeile auf Rechnungen (hitobito_swb#246)

--- a/app/controllers/json_api/invoices_controller.rb
+++ b/app/controllers/json_api/invoices_controller.rb
@@ -11,6 +11,11 @@ class JsonApi::InvoicesController < JsonApiController
     super
   end
 
+  def create
+    authorize!(:create, Invoice)
+    super
+  end
+
   def update
     authorize!(:update, entry)
     super

--- a/app/resources/invoice_resource.rb
+++ b/app/resources/invoice_resource.rb
@@ -6,7 +6,7 @@
 #  https://github.com/hitobito/hitobito.
 
 class InvoiceResource < ApplicationResource
-  primary_endpoint "invoices", [:index, :show, :update]
+  primary_endpoint "invoices", [:index, :create, :show, :update]
 
   self.readable_class = JsonApi::InvoiceAbility
   self.acceptable_scopes += %w[invoices]
@@ -17,16 +17,36 @@ class InvoiceResource < ApplicationResource
     attribute :state, :string
     attribute :group_id, :integer, filterable: true
     attribute :recipient_id, :integer, filterable: true
+    attribute :recipient_type, :string
     attribute :due_at, :date
     attribute :issued_at, :date
     attribute :recipient_email, :string
+    attribute :recipient_first_name, :string
+    attribute :recipient_last_name, :string
+    attribute :recipient_company_name, :string
+    attribute :recipient_address_care_of, :string
+    attribute :recipient_street, :string
+    attribute :recipient_housenumber, :string
+    attribute :recipient_postbox, :string
+    attribute :recipient_zip_code, :string
+    attribute :recipient_town, :string
+    attribute :recipient_country, :string
     attribute :payment_information, :string
     attribute :payment_purpose, :string
     attribute :hide_total, :boolean
+    attribute :shipping_method, :string
+    attribute :pp_post, :string
   end
 
   belongs_to :group
   belongs_to :recipient, resource: PersonResource
 
   has_many :invoice_items
+
+  private
+
+  def authorize_create(model)
+    invalid_request!(:group_id, :blank) if model.group_id.blank?
+    super
+  end
 end

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -1526,6 +1526,9 @@ de:
     errors:
       resources:
         id_must_not_be_set: ID darf nicht gesetzt sein
+        invoice_resource:
+          group_id:
+            blank: muss ausgefüllt werden
         role_resource:
           group_id:
             blank: muss ausgefüllt werden

--- a/config/locales/models.en.yml
+++ b/config/locales/models.en.yml
@@ -1521,6 +1521,9 @@ en:
     errors:
       resources:
         id_must_not_be_set: ID must not be set
+        invoice_resource:
+          group_id:
+            blank: must be filled in
         role_resource:
           group_id:
             blank: muss ausgefüllt werden

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -1607,6 +1607,9 @@ fr:
     errors:
       resources:
         id_must_not_be_set: ID ne doit pas être défini
+        invoice_resource:
+          group_id:
+            blank: doit être renseigné
         role_resource:
           group_id:
             blank: muss ausgefüllt werden

--- a/config/locales/models.it.yml
+++ b/config/locales/models.it.yml
@@ -1606,6 +1606,9 @@ it:
     errors:
       resources:
         id_must_not_be_set: L'ID non deve essere configurato
+        invoice_resource:
+          group_id:
+            blank: deve essere indicato
         role_resource:
           group_id:
             blank: muss ausgefüllt werden

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -489,7 +489,7 @@ Hitobito::Application.routes.draw do
     resources :event_kind_categories, module: :event, controller: :kind_categories,
       only: [:index, :show]
     resources :event_participations, module: :event, controller: :participations, only: [:index, :show]
-    resources :invoices, only: [:index, :show, :update]
+    resources :invoices, only: [:index, :show, :create, :update]
     resources :roles, except: [:edit, :new]
     resources :mailing_lists, only: [:index, :show]
     resources :qualifications, only: [:index, :show, :create, :destroy]

--- a/spec/resources/invoice/reads_spec.rb
+++ b/spec/resources/invoice/reads_spec.rb
@@ -24,7 +24,20 @@ describe InvoiceResource, type: :resource do
         :payment_purpose,
         :hide_total,
         :group_id,
-        :recipient_id
+        :recipient_id,
+        :recipient_type,
+        :recipient_first_name,
+        :recipient_last_name,
+        :recipient_company_name,
+        :recipient_address_care_of,
+        :recipient_street,
+        :recipient_housenumber,
+        :recipient_postbox,
+        :recipient_zip_code,
+        :recipient_town,
+        :recipient_country,
+        :shipping_method,
+        :pp_post
       ]
     end
 

--- a/spec/resources/invoice/writes_spec.rb
+++ b/spec/resources/invoice/writes_spec.rb
@@ -12,6 +12,145 @@ describe InvoiceResource, type: :resource do
   let(:person) { people(:bottom_member) }
   let(:pens) { invoice_items(:pens) }
 
+  describe "creating" do
+    let(:group) { groups(:bottom_layer_one) }
+    let(:recipient) { people(:top_leader) }
+
+    let(:payload) do
+      {
+        data: {
+          type: "invoices",
+          attributes: {
+            group_id: group.id,
+            title: "Membership 2026",
+            recipient_type: "Person",
+            recipient_id: recipient.id
+          }
+        }
+      }
+    end
+
+    let(:instance) { InvoiceResource.build(payload) }
+
+    it "works" do
+      expect {
+        expect(instance.save).to eq(true), instance.errors.full_messages.to_sentence
+      }.to change { Invoice.count }.by(1)
+
+      new_invoice = Invoice.order(:created_at).last
+      expect(new_invoice.title).to eq("Membership 2026")
+      expect(new_invoice.group).to eq(group)
+      expect(new_invoice.recipient).to eq(recipient)
+      # before_validation :set_recipient_fields populates address from the
+      # polymorphic recipient association.
+      expect(new_invoice.recipient_first_name).to be_present
+      expect(new_invoice.recipient_last_name).to be_present
+      expect(new_invoice.state).to eq("draft")
+    end
+
+    context "without group_id" do
+      before { payload[:data][:attributes].delete(:group_id) }
+
+      it "raises an invalid request error" do
+        expect { instance.save }.to raise_error(Graphiti::Errors::InvalidRequest)
+      end
+    end
+
+    describe "sideposting invoice_items" do
+      it "creates invoice with line items in one request" do
+        attrs = payload.deep_merge(
+          data: {
+            relationships: {
+              invoice_items: {
+                data: [
+                  {"temp-id": "item-1", type: "invoice_items", method: "create"},
+                  {"temp-id": "item-2", type: "invoice_items", method: "create"}
+                ]
+              }
+            }
+          },
+          included: [
+            {
+              "temp-id": "item-1",
+              type: "invoice_items",
+              attributes: {name: "Member fee", unit_cost: 65.0, count: 1}
+            },
+            {
+              "temp-id": "item-2",
+              type: "invoice_items",
+              attributes: {name: "Camp surcharge", unit_cost: 10.0, count: 1}
+            }
+          ]
+        )
+        instance = InvoiceResource.build(attrs)
+        expect {
+          expect(instance.save).to eq(true), instance.errors.full_messages.to_sentence
+        }.to change { Invoice.count }.by(1)
+          .and change { InvoiceItem.count }.by(2)
+
+        new_invoice = Invoice.order(:created_at).last
+        expect(new_invoice.invoice_items.pluck(:name))
+          .to contain_exactly("Member fee", "Camp surcharge")
+      end
+
+      it "fails when a sideposted invoice_item is invalid" do
+        # InvoiceItem.validates :name, presence: true — an empty name aborts
+        # the sideposted save and no Invoice row is created.
+        attrs = payload.deep_merge(
+          data: {
+            relationships: {
+              invoice_items: {
+                data: [
+                  {"temp-id": "item-1", type: "invoice_items", method: "create"}
+                ]
+              }
+            }
+          },
+          included: [
+            {
+              "temp-id": "item-1",
+              type: "invoice_items",
+              attributes: {name: "", unit_cost: 65.0, count: 1}
+            }
+          ]
+        )
+        instance = InvoiceResource.build(attrs)
+        expect {
+          expect(instance.save).to eq(false)
+        }.not_to change { Invoice.count }
+      end
+    end
+
+    context "service token" do
+      let(:token) { service_tokens(:permitted_top_layer_token) }
+      let(:current_ability) { TokenAbility.new(token) }
+
+      it "can create with finance permission" do
+        expect {
+          expect(instance.save).to eq(true), instance.errors.full_messages.to_sentence
+        }.to change { Invoice.count }.by(1)
+      end
+
+      it "cannot create when token has layer_read only" do
+        token.update!(permission: :layer_read)
+        allow(Graphiti.context[:object]).to receive(:current_ability)
+          .and_return(TokenAbility.new(token))
+        expect {
+          expect(instance.save).to eq(true)
+        }.to raise_error(CanCan::AccessDenied)
+      end
+
+      it "cannot create when token lacks invoices scope" do
+        token.update!(invoices: false)
+        allow(Graphiti.context[:object]).to receive(:current_ability)
+          .and_return(TokenAbility.new(token))
+        expect {
+          expect(instance.save).to eq(true)
+        }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+  end
+
   describe "updating" do
     def payload(**attrs)
       {


### PR DESCRIPTION
Adds :create to the Graphiti InvoiceResource and an authorize!(:create, Invoice) action to JsonApi::InvoicesController so that service tokens (and OAuth clients) with the invoices scope and finance permission in the target layer can create invoices through the JSON:API.

Mirrors the pattern established for roles in #2699: no new ServiceToken permission flag — write authorisation flows through the existing TokenAbility -> dynamic_user -> InvoiceAbility#in_layer_if_active chain. creator_id stays nil under service-token auth (column is nullable, no model validation); the audit log carries the service-token id for traceability.

Line items can be posted in the same request via Graphiti's native JSON:API sideposting on the has_many :invoice_items relationship. recipient_first_name, _last_name, _street, etc. are exposed as writable attributes for callers that need to override the auto-population that Invoice#set_recipient_fields does from the polymorphic recipient.

Spec coverage: spec/resources/invoice/writes_spec.rb adds a "creating" describe block with the happy path, a missing-group_id rejection, and a sidepost-creates-invoice-items scenario.

Closes #4257