### PR TITLE
Update ALL the actions to their current latest version

### DIFF
--- a/.github/actions/core-ci-setup/action.yml
+++ b/.github/actions/core-ci-setup/action.yml
@@ -20,7 +20,7 @@ runs:
       id: readToolVersions
 
     - name: Set up Node.js ${{ steps.readToolVersions.outputs.nodejs }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ steps.readToolVersions.outputs.nodejs }}
 
@@ -38,7 +38,7 @@ runs:
       run: cp Gemfile.lock Gemfile.lock.backup
       shell: bash
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
@@ -55,7 +55,7 @@ runs:
       run: git diff Gemfile.lock || true
       shell: bash
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       if: inputs.assets == 'true'
       with:
         path: node_modules

--- a/.github/actions/wagon-ci-setup/action.yml
+++ b/.github/actions/wagon-ci-setup/action.yml
@@ -102,7 +102,7 @@ runs:
       shell: bash
 
     - name: "Checkout hitobito at ${{ env.CORE_REF }}"
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: "hitobito/hitobito"
         ref: ${{ env.CORE_REF }}
@@ -115,7 +115,7 @@ runs:
         working-directory: hitobito
 
     - name: "Set up Node"
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "14"
 
@@ -136,7 +136,7 @@ runs:
       shell: bash
 
     - name: "Checkout dependency ${{ inputs.wagon_dependency_repository }} at ${{ env.WAGON_DEPENDENCY_REF }}"
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       if: ${{ inputs.wagon_dependency_repository != '' }}
       with:
         repository: hitobito/${{ inputs.wagon_dependency_repository }}
@@ -145,7 +145,7 @@ runs:
         path: ${{ inputs.wagon_dependency_repository }}
 
     - name: Checkout ${{ inputs.wagon_repository }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: hitobito/${{ inputs.wagon_repository }}
         ref: ${{ env.WAGON_REF }}
@@ -157,14 +157,14 @@ runs:
       working-directory: hitobito
       shell: bash
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: hitobito/vendor/bundle
         key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
         restore-keys: |
           ${{ runner.os }}-ruby-bundle-
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       if: ${{ inputs.wagon_dependency_repository != '' }}
       with:
         path: ${{ inputs.wagon_dependency_repository }}/vendor/bundle
@@ -172,7 +172,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-ruby-bundle-
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: ${{ inputs.wagon_repository }}/vendor/bundle
         key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
@@ -204,7 +204,7 @@ runs:
       working-directory: hitobito
       shell: bash
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       if: inputs.assets == 'true'
       with:
         path: node_modules

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout composition repo'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.composition }}
           ref: ${{ inputs.source_ref }}

--- a/.github/workflows/next-version.yml
+++ b/.github/workflows/next-version.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout composition"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.composition_repo }}
           ref: ${{ inputs.composition_ref }}

--- a/.github/workflows/prepare-version.yml
+++ b/.github/workflows/prepare-version.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: "Checkout hitobito"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "hitobito/hitobito"
           ref: ${{ inputs.target_branch }}
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: "Checkout composition repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ needs.settings.outputs.repo_name }}
           ref: ${{ needs.settings.outputs.composition_branch }}

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: "Checkout composition repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.composition }}
           ref: ${{ inputs.composition_branch }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: 'Checkout composition repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Checkout hitobito core submodule and wagon submodules'
         run: git submodule update --init --recursive
@@ -60,7 +60,7 @@ jobs:
           working-directory: hitobito
 
       - name: 'Set up Node'
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -80,14 +80,14 @@ jobs:
         working-directory: hitobito
         run: cp Gemfile.lock Gemfile.lock.backup
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: hitobito/vendor/bundle
           key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
           restore-keys: |
             ${{ runner.os }}-ruby-bundle-
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         if: ${{ inputs.wagon_dependency_repository != '' }}
         with:
           path: ${{ inputs.wagon_dependency_repository }}/vendor/bundle
@@ -96,7 +96,7 @@ jobs:
             ${{ runner.os }}-ruby-bundle-
 
       # Commented out for now because we would have to loop over all used wagons doing this
-#      - uses: actions/cache@v4
+#      - uses: actions/cache@v5
 #        with:
 #          path: ${{ env.WAGON_NAME }}/vendor/bundle
 #          key: ${{ runner.os }}-ruby-bundle-${{ hashFiles('**/Gemfile.lock.backup') }}
@@ -122,7 +122,7 @@ jobs:
 #            bundle install --jobs 4 --retry 3 --path vendor/bundle
 #          done
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: hitobito/node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
@@ -170,7 +170,7 @@ jobs:
           --form "projectVersion=latest" \
           --form "bom=@sbom.json"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: sboms

--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Prepare'
         uses: ./.github/actions/core-ci-setup
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-tags: true
 
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Prepare'
         uses: ./.github/actions/core-ci-setup
@@ -128,7 +128,7 @@ jobs:
           bundle exec rake ci:setup:env spec:features:lenient
 
       - name: 'Make capybara output downloadable'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: capybara-output
@@ -170,7 +170,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-tags: true
 

--- a/.github/workflows/update-all-wagon-graphiti-schemas.yml
+++ b/.github/workflows/update-all-wagon-graphiti-schemas.yml
@@ -94,7 +94,7 @@ jobs:
           fi
 
       - name: Check out core with shared setup action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: hitobito/hitobito
           ref: ${{ github.ref || inputs.core_ref }}

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.RELEASE_PREPARATION_TOKEN }}

--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -53,7 +53,7 @@ jobs:
         working-directory: .
 
       - name: Check out core with shared setup action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: hitobito/hitobito
           ref: ${{ inputs.core_ref }}
@@ -108,7 +108,7 @@ jobs:
         working-directory: .
 
       - name: Check out core with shared setup action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: hitobito/hitobito
           ref: ${{ inputs.core_ref }}
@@ -161,7 +161,7 @@ jobs:
           --health-retries 10
     steps:
       - name: Check out the core, which contains the shared setup action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: hitobito/hitobito
           ref: ${{ inputs.core_ref }}
@@ -216,7 +216,7 @@ jobs:
 
     steps:
       - name: Check out the core, which contains the shared setup action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: hitobito/hitobito
           ref: ${{ inputs.core_ref }}
@@ -271,7 +271,7 @@ jobs:
 
     steps:
       - name: Check out core with shared setup action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: hitobito/hitobito
           ref: ${{ inputs.core_ref }}
@@ -301,7 +301,7 @@ jobs:
           bundle exec rake app:ci:setup:rspec app:spec:features:lenient
 
       - name: "Make capybara output downloadable"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: capybara-output-wagon

--- a/.github/workflows/wagon-update-patches.yml
+++ b/.github/workflows/wagon-update-patches.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Check out the core, which contains the shared setup action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: hitobito/hitobito
           ref: ${{ inputs.core_ref }}


### PR DESCRIPTION
The changelog did not reveal any changes that would require us to change parameters or our workflows in general.

This allows to use the actions beyond the planned node20-removal from the runner-images.

fixes #4243 