### PR TITLE
Load additional settings files with extra_sources instead of prepend_source

### DIFF
--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -63,14 +63,12 @@ Config.setup do |config|
   #   required(:email).filled(format?: EMAIL_REGEX)
   # end
   config.validation_contract = SettingsContract.new
+
+  # additional config-files
+  settings_dir = Rails.root.join("config", "settings")
+  config.extra_sources = [
+    settings_dir.join("payment_providers.yml").to_s,
+    settings_dir.join("bounce_heuristics.yml").to_s
+  ]
 end
 
-# additional config-files
-# use add_source for extend-only files
-# and prepend_source for files with overwritable settings
-Rails.application.config.to_prepare do
-  settings_dir = Rails.root.join("config", "settings")
-  Settings.add_source!(settings_dir.join("payment_providers.yml").to_s)
-  Settings.prepend_source!(settings_dir.join("bounce_heuristics.yml").to_s)
-  Settings.reload!
-end

--- a/lib/tasks/hitobito.rake
+++ b/lib/tasks/hitobito.rake
@@ -89,7 +89,17 @@ namespace :hitobito do
 
         MESSAGE
       else
-        puts "✅ OAuth configured"
+        begin
+          OpenSSL::PKey::RSA.new(signing_key)
+          puts "✅ OAuth configured"
+        rescue OpenSSL::PKey::RSAError => e
+          puts <<~MESSAGE
+            ❌ OAuth not correctly configured
+
+              JWT Signing Key is incorrect.
+              #{e.message}
+          MESSAGE
+        end
       end
     end
 


### PR DESCRIPTION
prepend_source may cause merge issues with our knockout_prefix '--' and multi-line values such as SSL certificates starting with '-----BEGIN PRIVATE KEY-----`. Such values *must* always be defined in the main config/settings.yml file.

Ich habe nun auf extra_sources umgestellt, da mir dies passender erschien und auch das Issue mit dem doppelten to_prepare Block auch gleich gelöscht ist. Allerdings habe ich nirgends etwas gefunden, was auf das ursprüngliche Problem hindeuten würde, welches dann mit prepend_source gelöst wurde. Könntest du da nochmals nachforschen?

Der SAC wäre froh um einen baldigen Release auf der Integration. Wäre super, wenn du heute noch Feedback geben könntest.