### PR TITLE
Display correct sti model label in flash messages

### DIFF
--- a/app/controllers/crud_controller.rb
+++ b/app/controllers/crud_controller.rb
@@ -133,7 +133,8 @@ class CrudController < ListController
 
   # A label for the current entry, including the model name.
   def full_entry_label
-    "#{models_label(false)} <i>#{ERB::Util.h(entry.to_s)}</i>".html_safe # rubocop:disable Rails/OutputSafety
+    label = entry.class.model_name.human
+    "#{label} <i>#{ERB::Util.h(entry.to_s)}</i>".html_safe
   end
 
   # Url of the index page to return to

--- a/spec/features/event/edit_spec.rb
+++ b/spec/features/event/edit_spec.rb
@@ -29,7 +29,7 @@ describe "event edit page", js: true do
       fill_in "Kontaktperson", with: ""
       click_save
 
-      expect(page).to have_text "Anlass #{event.name} wurde erfolgreich aktualisiert."
+      expect(page).to have_text "Kurs #{event.name} wurde erfolgreich aktualisiert."
       expect(event.reload.contact).to be_nil
     end
   end

--- a/spec/features/globalized_input_fields_spec.rb
+++ b/spec/features/globalized_input_fields_spec.rb
@@ -34,7 +34,7 @@ describe "Globalized input fields", js: true do
 
     # Should successfully save all translations
     click_button("Speichern")
-    expect(page).to have_content("Gruppe #{group.name} wurde erfolgreich aktualisiert")
+    expect(page).to have_content("Bottom Layer #{group.name} wurde erfolgreich aktualisiert")
     expected_value = {
       de: "German privacy policy title",
       en: "English privacy policy title",


### PR DESCRIPTION
Der Crud Controller beachtet aktuell keine STI Übersetzungen, da er nach dem Controller geht. Da wir im Crud Controller ein entry Objekt haben könnten wir das auch so lösen und somit bei Touren folgende Flash Message anzeigen:
`Tour Singhi Kangri wurde erfolgreich aktualisiert.`
anstatt:
`Anlass Singhi Kangri wurde erfolgreich aktualisiert.`

@codez spricht hier etwas dagegen das so anzupassen? Neben allen Specs welche dadurch kaputt gehene und angepasst werden müssen :upside_down_face: Ich passe mal noch nichts an, falls dies aus anderen Gründen keine gute Idee ist.