### PR TITLE
Bug/Fix unclickable section in mobile layout

### DIFF
--- a/app/javascript/stylesheets/hitobito/modules/_profil.scss
+++ b/app/javascript/stylesheets/hitobito/modules/_profil.scss
@@ -6,6 +6,7 @@
   @include border-radius(3px);
 }
 .profile-image-overlay {
+  visibility: hidden;
   // Hide image above page by default
   opacity: 0;
   top: -100%;
@@ -22,6 +23,7 @@
   background-color: rgba($color: $black, $alpha: 0.5);
   cursor: pointer;
   &.active {
+    visibility: visible;
     opacity: 1;
     top: 0;
   }

--- a/app/javascript/stylesheets/hitobito/modules/_profil.scss
+++ b/app/javascript/stylesheets/hitobito/modules/_profil.scss
@@ -6,8 +6,8 @@
   @include border-radius(3px);
 }
 .profile-image-overlay {
-  visibility: hidden;
   // Hide image above page by default
+  visibility: hidden;
   opacity: 0;
   top: -100%;
   transition: opacity 0.5s ease, top 0.5s ease;


### PR DESCRIPTION
The profile image overlay is they gray backdrop that appears when clicking on a profile picture to see a bigger version of it. This overlay is outside of the viewport by default because its top property is set to a negative value. On smaller viewports however it started overlapping with the page. Because it was hidden with opacity 0, click events on it were still registered when hidden and thus underlying elements were not clickable anymore. This is fixed by adding visibility hidden in addition to the opacity property. Opacity is still needed because the transition from visibilty hidden to visible cant be gradualy animated.