### PR TITLE
Improve post address sync (hitobito/hitobito_sac_cas#2434)

### DIFF
--- a/app/domain/synchronize/addresses/swiss_post/result_processor.rb
+++ b/app/domain/synchronize/addresses/swiss_post/result_processor.rb
@@ -9,20 +9,12 @@ module Synchronize::Addresses::SwissPost
   class ResultProcessor
     UPDATING_QSTATS = %w[1 2 3 4]
     LOGGINGS_QSTATS = {
+      "25": [:info, "Verstorben / Firma erloschen"],
       "26": [:info, "Umzug ins Ausland"],
       "27": [:info, "Unbekannt weggezogen"],
       "50": [:warn, "Person an Adresse nicht bekannt"],
       "51": [:warn, "Adresse nicht bekannt"]
     }.stringify_keys
-
-    FIELDS = {
-      first_name: "Prename",
-      last_name: "Name",
-      address_care_of: "CoAddress",
-      street: "StreetName",
-      zip_code: "ZIPCode",
-      town: "TownName"
-    }
 
     CSV_OPTIONS = {
       col_sep: Config::COL_SEP,
@@ -32,10 +24,20 @@ module Synchronize::Addresses::SwissPost
     }
 
     class_attribute :remote_identifier
+    class_attribute :qstat_tag_prefix, default: "Post_Adressenabgleich_QSTAT"
+    class_attribute :fields, default: {
+      first_name: "Prename",
+      last_name: "Name",
+      address_care_of: "CoAddress",
+      street: "StreetName",
+      zip_code: "ZIPCode",
+      town: "TownName"
+    }
 
-    def initialize(text, invalid_tag)
+    def initialize(text, invalid_tag, started_at: Date.current)
       @data = parse(text)
       @invalid_tag = invalid_tag
+      @started_at = started_at
       @updated_people_ids = []
     end
 
@@ -45,6 +47,7 @@ module Synchronize::Addresses::SwissPost
           update(person, row)
         elsif LOGGINGS_QSTATS.key?(qstat)
           create_log_entry(person, *LOGGINGS_QSTATS[qstat])
+          create_qstat_tag(person, qstat)
         end
       end
       destroy_obsolete_taggings
@@ -52,7 +55,7 @@ module Synchronize::Addresses::SwissPost
 
     private
 
-    attr_reader :data, :invalid_tag, :updated_people_ids
+    attr_reader :data, :invalid_tag, :started_at, :updated_people_ids
 
     def each_potential_update
       remote_identifier = self.class.remote_identifier || Generator.fields.invert[:id].to_s
@@ -64,7 +67,7 @@ module Synchronize::Addresses::SwissPost
     end
 
     def update(person, row)
-      attrs = FIELDS.map do |target, source|
+      attrs = fields.map do |target, source|
         [target, row[source]]
       end.to_h
       person.attributes = attrs
@@ -96,6 +99,12 @@ module Synchronize::Addresses::SwissPost
         "übernommen werden"
       create_log_entry(person, :error, message)
       create_tag(person.taggings, message, invalid_tag)
+    end
+
+    def create_qstat_tag(person, qstat)
+      tag_name = "#{qstat_tag_prefix}_#{qstat}_#{started_at.strftime("%Y%m%d")}"
+      tag = ActsAsTaggableOn::Tag.find_or_create_by!(name: tag_name)
+      person.taggings.find_or_create_by!(tag:, context: :tags)
     end
 
     def create_tag(taggings, message, tag)

--- a/app/jobs/address_synchronization_job.rb
+++ b/app/jobs/address_synchronization_job.rb
@@ -9,7 +9,7 @@ class AddressSynchronizationJob < CursorBasedPagingJob
   attr_reader :batch_token, :upload_token, :result_token, :data
 
   self.parameters += [:batch_token, :upload_token, :result_token]
-  self.progress_message = "Post Adressabgleich: Fortschritt %d%%"
+  self.progress_message = "Post Adressabgleich: Fortschritt %d%% (%d/%d)"
   self.log_category = Synchronize::Addresses::SwissPost::Config::LOG_CATEGORY
 
   def self.exists?
@@ -60,7 +60,9 @@ class AddressSynchronizationJob < CursorBasedPagingJob
 
   def process_result
     @data = client.download_file(result_token)
-    Synchronize::Addresses::SwissPost::ResultProcessor.new(data, invalid_tag).process
+    Synchronize::Addresses::SwissPost::ResultProcessor.new(
+      data, invalid_tag, started_at: Date.current
+    ).process
   end
 
   def scope

--- a/app/jobs/cursor_based_paging_job.rb
+++ b/app/jobs/cursor_based_paging_job.rb
@@ -90,7 +90,7 @@ class CursorBasedPagingJob < BaseJob
     HitobitoLogEntry.create!(
       level: :info,
       category: log_category,
-      message: format(progress_message, percent)
+      message: format(progress_message, percent, processed_count + processing_count, total)
     )
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -146,6 +146,18 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   # Configure which Person attributes can be used to identify a person for login.
   class_attribute :devise_login_id_attrs, default: [:email]
 
+  class_attribute :address_sync_relevant_fields, default: %w[
+    last_name
+    first_name
+    address_care_of
+    street
+    housenumber
+    postbox
+    zip_code
+    town
+    country
+  ]
+
   # define devise before other modules
   devise :database_authenticatable,
     :lockable,
@@ -321,6 +333,7 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   before_destroy :destroy_roles
   before_destroy :destroy_person_duplicates
   after_save :update_household_address
+  after_save :remove_address_sync_excluded_tags, if: :address_sync_fields_changed?
 
   ### SCOPES
 
@@ -572,6 +585,20 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   end
 
   private
+
+  def address_sync_fields_changed?
+    FeatureGate.enabled?("address_sync") &&
+      (address_sync_relevant_fields & saved_changes.keys).any?
+  end
+
+  def remove_address_sync_excluded_tags
+    return unless Synchronize::Addresses::SwissPost::Config.exist?
+
+    excluded_tags = Synchronize::Addresses::SwissPost::Config.excluded_tags
+    return if excluded_tags.blank?
+
+    tags.where(name: excluded_tags).destroy_all
+  end
 
   def override_blank_email
     self.email = nil if email.blank?

--- a/doc/developer/people/address_sync.md
+++ b/doc/developer/people/address_sync.md
@@ -21,7 +21,7 @@ information is available as log entries.
 Swiss Post returns a status code (QSTAT) for each person in the result file.
 See the [Swiss Post QSTAT documentation](https://www.post.ch/-/media/portal-opp/pm/dokumente/merkblatt-status-qstat-shortreport.pdf?sc_lang=de&hash=ABCBEDD36A9D36BE68B0ACCAFAED702B) for the full reference.
 
-If a person get's one of the LOGGINGS_QSTATS, a log entry will be created and the person receives a tag with the corresponding QSTAT code and a timestamp.
+If a person gets one of the LOGGINGS_QSTATS, a log entry will be created and the person receives a tag with the corresponding QSTAT code and a timestamp.
 
 ## Excluded Tags
 

--- a/doc/developer/people/address_sync.md
+++ b/doc/developer/people/address_sync.md
@@ -15,3 +15,16 @@ true.
 Once configured and enabled, a button on the top level group appears which
 allows people with `:admin` to start the sync. Progress and debugging
 information is available as log entries.
+
+## QSTAT Codes
+
+Swiss Post returns a status code (QSTAT) for each person in the result file.
+See the [Swiss Post QSTAT documentation](https://www.post.ch/-/media/portal-opp/pm/dokumente/merkblatt-status-qstat-shortreport.pdf?sc_lang=de&hash=ABCBEDD36A9D36BE68B0ACCAFAED702B) for the full reference.
+
+If a person get's one of the LOGGINGS_QSTATS, a log entry will be created and the person receives a tag with the corresponding QSTAT code and a timestamp.
+
+## Excluded Tags
+
+Wagons can configure a list of tags that mark people as excluded from future sync runs. These tags are configured in `config/post-address-sync.yml`
+
+When a person's address fields are manually updated, these excluded tags are automatically removed, showing that the address is fresh and the person should be included in the next sync again.

--- a/spec/domain/synchronize/addresses/swiss_post/result_processor_spec.rb
+++ b/spec/domain/synchronize/addresses/swiss_post/result_processor_spec.rb
@@ -176,6 +176,7 @@ describe Synchronize::Addresses::SwissPost::ResultProcessor do
 
   describe "ignored updates" do
     [
+      ["25", "info", "Verstorben / Firma erloschen"],
       ["26", "info", "Umzug ins Ausland"],
       ["27", "info", "Unbekannt weggezogen"],
       ["50", "warn", "Person an Adresse nicht bekannt"],
@@ -189,6 +190,17 @@ describe Synchronize::Addresses::SwissPost::ResultProcessor do
         end.to change { HitobitoLogEntry.count }
           .and not_change { top_leader.reload.attributes }
         expect(log_entry).to have_attributes(log_entry_attrs.merge(message:, level:))
+      end
+
+      it "creates tag with qstat #{qstat} and timestamp" do
+        travel_to(Time.zone.local(2021, 5, 24)) do
+          expect do
+            process_with do |data|
+              data.entries.last["QSTAT"] = qstat
+            end
+          end.to change { top_leader.tags.count }.by(1)
+          expect(top_leader.tags.last.name).to eq "Post_Adressenabgleich_QSTAT_#{qstat}_20210524"
+        end
       end
     end
   end

--- a/spec/features/admin_left_nav_spec.rb
+++ b/spec/features/admin_left_nav_spec.rb
@@ -11,6 +11,10 @@ describe :admin_left_nav, js: true do
   context "SelfRegistrationReason" do
     let(:path) { label_formats_path }
 
+    before do
+      allow(FeatureGate).to receive(:enabled?).and_return(false)
+    end
+
     context "with necessary ability" do
       before { sign_in(people(:root)) }
 

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -8,7 +8,10 @@ require "spec_helper"
 describe :dashboard do
   let(:user) { people(:top_leader) }
 
-  before { sign_in(user) }
+  before do
+    allow(FeatureGate).to receive(:enabled?).and_return(false)
+    sign_in(user)
+  end
 
   describe "/dashboard" do
     before do

--- a/spec/jobs/address_synchronization_job_spec.rb
+++ b/spec/jobs/address_synchronization_job_spec.rb
@@ -140,7 +140,7 @@ describe AddressSynchronizationJob do
 
       expect(HitobitoLogEntry.last.level).to eq "info"
       expect(HitobitoLogEntry.last.category).to eq "cleanup"
-      expect(HitobitoLogEntry.last.message).to eq "Post Adressabgleich: Fortschritt 0%"
+      expect(HitobitoLogEntry.last.message).to eq "Post Adressabgleich: Fortschritt 0% (0/2)"
     end
 
     it "enqueues follow up job to pull results" do
@@ -240,7 +240,7 @@ describe AddressSynchronizationJob do
           .and not_change { Delayed::Job.count }
         expect(HitobitoLogEntry.last.level).to eq "info"
         expect(HitobitoLogEntry.last.category).to eq "cleanup"
-        expect(HitobitoLogEntry.last.message).to eq "Post Adressabgleich: Fortschritt 100%"
+        expect(HitobitoLogEntry.last.message).to eq "Post Adressabgleich: Fortschritt 100% (2/2)"
       end
 
       it "persists result as attachment via dj callback" do
@@ -292,7 +292,7 @@ describe AddressSynchronizationJob do
 
         expect(HitobitoLogEntry.last.level).to eq "info"
         expect(HitobitoLogEntry.last.category).to eq "cleanup"
-        expect(HitobitoLogEntry.last.message).to eq "Post Adressabgleich: Fortschritt 50%"
+        expect(HitobitoLogEntry.last.message).to eq "Post Adressabgleich: Fortschritt 50% (1/2)"
 
         followup_job = Delayed::Job.last.payload_object
         expect(followup_job.result_token).to eq "out"
@@ -306,7 +306,7 @@ describe AddressSynchronizationJob do
         expect do
           job.perform
         end.to change { HitobitoLogEntry.count }.by(1)
-        expect(HitobitoLogEntry.last.message).to eq "Post Adressabgleich: Fortschritt 0%"
+        expect(HitobitoLogEntry.last.message).to eq "Post Adressabgleich: Fortschritt 0% (0/2)"
         expect(Delayed::Job.last.payload_object.cursor).to eq people(:bottom_member).id
 
         stub_api_request(:get, "/checkbatchstatus/batch",
@@ -324,7 +324,7 @@ describe AddressSynchronizationJob do
           run_next_job
         end.to change { HitobitoLogEntry.count }
           .and not_change { top_leader.reload.housenumber }
-        expect(HitobitoLogEntry.last.message).to eq "Post Adressabgleich: Fortschritt 50%"
+        expect(HitobitoLogEntry.last.message).to eq "Post Adressabgleich: Fortschritt 50% (1/2)"
         expect(Delayed::Job.last.payload_object.cursor).to eq people(:top_leader).id
 
         stub_api_request(:get, "/checkbatchstatus/batch",
@@ -345,7 +345,7 @@ describe AddressSynchronizationJob do
         end.to change { HitobitoLogEntry.count }
           .and change { top_leader.reload.housenumber }
           .and not_change { Delayed::Job.count }
-        expect(HitobitoLogEntry.last.message).to eq "Post Adressabgleich: Fortschritt 100%"
+        expect(HitobitoLogEntry.last.message).to eq "Post Adressabgleich: Fortschritt 100% (2/2)"
       end
 
       it "runs three times before finalizing" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1138,4 +1138,30 @@ describe Person do
       expect(person.needs_web_socket_connection?).to be_falsy
     end
   end
+
+  describe "#remove_address_sync_excluded_tags" do
+    let(:person) { people(:top_leader) }
+    let(:excluded_tag) { ActsAsTaggableOn::Tag.find_or_create_by!(name: "excluded") }
+
+    before do
+      allow(FeatureGate).to receive(:enabled?).and_return(true)
+      allow(Synchronize::Addresses::SwissPost::Config).to receive(:exist?).and_return(true)
+      allow(Synchronize::Addresses::SwissPost::Config).to receive(:excluded_tags).and_return([excluded_tag.name])
+      person.tags << excluded_tag
+    end
+
+    it "removes excluded tags when a relevant address field changes" do
+      expect { person.update!(last_name: "Newname") }.to change { person.tags.reload.count }.by(-1)
+    end
+
+    it "does not remove excluded tags when some other field changes" do
+      expect { person.update!(nickname: "nick") }.not_to change { person.tags.reload.count }
+    end
+
+    it "does not remove excluded tags when address_sync feature is disabled" do
+      allow(FeatureGate).to receive(:enabled?).with("address_sync").and_return(false)
+
+      expect { person.update!(last_name: "Newname") }.not_to change { person.tags.reload.count }
+    end
+  end
 end


### PR DESCRIPTION
This includes multiple changes to the post address sync, QSTAT 25 is now also handled, QSTAT person tags are created, progress log has more details and excluded tags are removed on manual address updates