### PR TITLE
Include stage in wallet pass ids (refs #3911)

### DIFF
--- a/app/domain/wallets/apple_wallet/pass_service.rb
+++ b/app/domain/wallets/apple_wallet/pass_service.rb
@@ -165,10 +165,11 @@ module Wallets
         "#{Settings.application.protocol}://#{Settings.application.hostname}#{WEB_SERVICE_PATH}"
       end
 
-      # In a multi-tenant environment (multiple instances sharing the same
-      # pass_type_identifier), the wagon must override this method to include a
-      # tenant-specific identifier to ensure global uniqueness of serial numbers.
-      def id_prefix = ["hitobito", id_prefix_addition&.call].compact.join(".")
+      def id_prefix = [
+        "hitobito",
+        Settings.application.stage,
+        id_prefix_addition&.call
+      ].compact.join(".")
 
       def barcode
         {

--- a/app/domain/wallets/google_wallet/pass_service.rb
+++ b/app/domain/wallets/google_wallet/pass_service.rb
@@ -60,7 +60,12 @@ module Wallets
       # Currently always :generic. Event ticket support planned for future phase.
       def pass_type = :generic
 
-      def id_prefix = [config.issuer_id, "hitobito", id_prefix_addition&.call].compact.join(".")
+      def id_prefix = [
+        config.issuer_id,
+        "hitobito",
+        Settings.application.stage,
+        id_prefix_addition&.call
+      ].compact.join(".")
 
       # Identifies the pass template shared by all holders of the same PassDefinition.
       def class_id

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,6 +8,7 @@
 
 application:
   name: hitobito  # set same name in email.sender and email.mass_recipient
+  stage: <%= ENV.fetch('HITOBITO_STAGE', Rails.env) %>
   logo:
     image: logo.png # put under app/assets/images
     height: 30 # pixel, has to bet set as the logo is a background image,

--- a/spec/domain/wallets/apple_wallet/pass_service_spec.rb
+++ b/spec/domain/wallets/apple_wallet/pass_service_spec.rb
@@ -66,12 +66,12 @@ describe Wallets::AppleWallet::PassService do
     end
 
     it "contains serialNumber from pass_installation.wallet_identifier" do
-      expect(data[:serialNumber]).to eq("hitobito.#{installation.id}")
+      expect(data[:serialNumber]).to eq("hitobito.test.#{installation.id}")
     end
 
     it "contains serialNumber contains custom prefix if set" do
       described_class.id_prefix_addition = -> { :test }
-      expect(data[:serialNumber]).to eq("hitobito.test.#{installation.id}")
+      expect(data[:serialNumber]).to eq("hitobito.test.test.#{installation.id}")
     end
 
     it "contains teamIdentifier from Config" do

--- a/spec/domain/wallets/google_wallet/pass_service_spec.rb
+++ b/spec/domain/wallets/google_wallet/pass_service_spec.rb
@@ -33,7 +33,7 @@ describe Wallets::GoogleWallet::PassService do
 
   describe "#save_url" do
     it "returns the Google Wallet save URL without syncing" do
-      expected_id = "#{issuer_id}.hitobito.pass.#{service.pass.id}.#{pass_installation.id}"
+      expected_id = "#{issuer_id}.hitobito.test.pass.#{service.pass.id}.#{pass_installation.id}"
       expect(client).to receive(:generate_save_url)
         .with(expected_id, type: :generic)
         .and_return("https://pay.google.com/gp/v/save/jwt-token")
@@ -76,7 +76,7 @@ describe Wallets::GoogleWallet::PassService do
 
         service.create_or_update
 
-        expect(payload[:id]).to eq("#{issuer_id}.hitobito.class.#{definition.id}")
+        expect(payload[:id]).to eq("#{issuer_id}.hitobito.test.class.#{definition.id}")
         expect(payload[:issuerName]).to eq("TopLayer Member Pass")
         expect(payload[:reviewStatus]).to eq("UNDER_REVIEW")
         expect(payload[:multipleDevicesAndHoldersAllowedStatus]).to eq("MULTIPLE_HOLDERS")
@@ -85,7 +85,7 @@ describe Wallets::GoogleWallet::PassService do
     end
 
     describe "generic_object payload" do
-      let(:prefix) { "#{issuer_id}.hitobito" }
+      let(:prefix) { "#{issuer_id}.hitobito.test" }
 
       after { described_class.id_prefix_addition = nil }
 
@@ -201,7 +201,7 @@ describe Wallets::GoogleWallet::PassService do
 
   describe "#revoke" do
     it "sends INACTIVE state to client" do
-      expected_id = "#{issuer_id}.hitobito.pass.#{service.pass.id}.#{pass_installation.id}"
+      expected_id = "#{issuer_id}.hitobito.test.pass.#{service.pass.id}.#{pass_installation.id}"
 
       expect(client).to receive(:create_or_update_object).with(
         {id: expected_id, state: "INACTIVE"},


### PR DESCRIPTION
In case both the integration and production instance use the same
wallet provider account/configuration, we must include the
$HITOBITO_STAGE env variable in the pass id to make it globally unique.
