### PR TITLE
Replace delete_on with end_on in role paper trail versions

### DIFF
--- a/db/migrate/20260622104312_migrate_role_delete_on_paper_trail_versions_to_end_on.rb
+++ b/db/migrate/20260622104312_migrate_role_delete_on_paper_trail_versions_to_end_on.rb
@@ -1,0 +1,28 @@
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class MigrateRoleDeleteOnPaperTrailVersionsToEndOn < ActiveRecord::Migration[8.0]
+  def up
+    execute <<-SQL
+      UPDATE versions
+      SET object_changes = REPLACE(
+        object_changes,
+        'delete_on:', 'end_on:'
+      )
+      WHERE item_type = 'Role';
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      UPDATE versions
+      SET object_changes = REPLACE(
+        object_changes,
+        'end_on:', 'delete_on:'
+      )
+      WHERE item_type = 'Role';
+    SQL
+  end
+end


### PR DESCRIPTION
Fixes: https://glitchtip.puzzle.ch/hitobito/issues/14523

Addition to: https://github.com/hitobito/hitobito/commit/6341145d0637f17d30879cbbcc5b5f2ab929c526

This would not happen anymore up from the next release due to: https://github.com/hitobito/hitobito/commit/3e3e5b343b53ae13e61f642cbf819e2bf180cc5c

But displaying the version instead of nothing is still better so we migrate the attribute we know
