### PR TITLE
Fix order_by_role returning ambiguous participation records

### DIFF
--- a/app/controllers/concerns/sortable.rb
+++ b/app/controllers/concerns/sortable.rb
@@ -48,37 +48,51 @@ module Sortable
       scope.select(select_values, sort_expression_attrs)
     end
 
-    # rubocop:todo Metrics/MethodLength
-    def sort_by_sort_expression(entries) # rubocop:todo Metrics/AbcSize
+    def sort_by_sort_expression(entries)
       return entries unless sorting?
 
-      if sort_expression_attrs.empty? # no join needed
+      if sort_expression_attrs.empty?
         entries.reorder(sort_expression)
-      # rubocop:todo Layout/LineLength
-      elsif entries.to_sql.match?(SUBQUERY) # already selecting from a subquery (e.g. people_controller)
-        # rubocop:enable Layout/LineLength
-        entries.reorder(sort_expression.gsub(TABLE_WITH_COLUMN, '\1'))
-      # rubocop:todo Layout/LineLength
-      elsif entries.to_sql.match?(GROUPED_QUERY) # already selecting from a grouped query (e.g. sbv/song_counts_controller.rb)
-        # rubocop:enable Layout/LineLength
-        entries.select(entries.select_values,
-          "MAX(#{sort_expression_attrs}) AS #{sort_expression_attrs.gsub(TABLE_WITH_COLUMN, '\1')}")
-          .joins(join_tables)
-          .reorder(Arel.sql(sort_expression.gsub(TABLE_WITH_COLUMN, '\1')))
+      elsif entries.to_sql.match?(SUBQUERY)
+        sort_subquery(entries)
+      elsif entries.to_sql.match?(GROUPED_QUERY)
+        sort_grouped_query(entries)
       else
-        # rubocop:todo Layout/LineLength
-        subquery = entries.select(sort_expression_attrs).joins(join_tables).unscope(:order).distinct_on(:id)
-        # rubocop:enable Layout/LineLength
-        # rubocop:todo Layout/LineLength
-        order_statement = order_alias ? "#{order_alias} #{sort_dir} NULLS LAST" : Arel.sql(sort_expression.gsub(
-          # rubocop:enable Layout/LineLength
-          TABLE_WITH_COLUMN, '\1'
-        ))
-        model_class.select("*").from(subquery, :subquery)
-          .reorder(order_statement)
+        sort_with_join(entries)
       end
     end
-    # rubocop:enable Metrics/MethodLength
+
+    # Subquery case (e.g. people_controller).
+    # With order_alias, wraps again to add the sort join and select the alias column.
+    def sort_subquery(entries)
+      return entries.reorder(Arel.sql(sort_expression_columns)) unless order_alias
+
+      entries.unscope(:order)
+        .select("#{model_class.table_name}.*", Arel.sql(sort_expression_attrs))
+        .joins(join_tables)
+        .reorder(Arel.sql("#{order_alias} #{sort_dir} NULLS LAST"))
+    end
+
+    # Grouped query case (e.g. sbv/song_counts_controller.rb).
+    def sort_grouped_query(entries)
+      col = sort_expression_attrs.gsub(TABLE_WITH_COLUMN, '\1')
+      entries
+        .select(entries.select_values, "MAX(#{sort_expression_attrs}) AS #{col}")
+        .joins(join_tables)
+        .reorder(Arel.sql(sort_expression_columns))
+    end
+
+    # Build a subquery that selects and joins the sort column, then wrap and order.
+    def sort_with_join(entries)
+      subquery = entries.select(sort_expression_attrs)
+        .joins(join_tables)
+        .unscope(:order)
+        .distinct_on(:id)
+
+      order = order_alias ? "#{order_alias} #{sort_dir} NULLS LAST" : sort_expression_columns
+
+      model_class.select("*").from(subquery, :subquery).reorder(Arel.sql(order))
+    end
 
     def sorting?
       params[:sort].present? && sortable?(params[:sort])
@@ -106,6 +120,10 @@ module Sortable
     # Return the sort expression to be used in the list query.
     def sort_expression
       Array(sort_columns).collect { |c| "#{c} #{sort_dir}" }.join(", ") + " NULLS LAST"
+    end
+
+    def sort_expression_columns
+      sort_expression.gsub(TABLE_WITH_COLUMN, '\1')
     end
 
     # Return the sort expression attributes without sort directory, to add to query select list

--- a/app/domain/event/participation_filter/list.rb
+++ b/app/domain/event/participation_filter/list.rb
@@ -52,10 +52,11 @@ class Event::ParticipationFilter::List
   end
 
   def apply_default_sort(records)
-    records = records.order_by_role(event) if Settings.people.default_sort == "role"
-
-    records.order_by_name
-      .select(Event::Participation.column_names)
+    if Settings.people.default_sort == "role"
+      records.order_by_role(event)
+    else
+      records.order_by_name.select(Event::Participation.column_names)
+    end
   end
 
   def populate_counts(records)

--- a/app/models/event/participation.rb
+++ b/app/models/event/participation.rb
@@ -57,6 +57,11 @@ class Event::Participation < ActiveRecord::Base
           "event_participations.participant_id = event_guests.id")
   }
 
+  scope :with_role_type_orders, -> {
+    joins(:roles)
+      .joins("INNER JOIN event_role_type_orders ON event_roles.type = event_role_type_orders.name")
+  }
+
   scope :guests_of, ->(main_participation) {
     joins("INNER JOIN event_guests " \
           "ON event_participations.participant_type = 'Event::Guest' " \
@@ -120,11 +125,19 @@ class Event::Participation < ActiveRecord::Base
 
     # Order people by the order participation types are listed in their event types.
     def order_by_role(event_type)
-      joins(:roles)
-        .select("event_participations.*", :order_weight)
-        .joins("INNER JOIN event_role_type_orders " \
-               "ON event_roles.type = event_role_type_orders.name")
-        .order("event_role_type_orders.order_weight ASC")
+      subquery = with_role_type_orders
+        .with_person_participants
+        .with_guest_participants
+        .reselect(
+          "event_participations.*",
+          :order_weight,
+          order_by_name_statement.as("order_by_name_statement")
+        )
+        .order("event_participations.id, order_weight")
+        .distinct_on(:id)
+
+      Event::Participation.from(subquery, "event_participations")
+        .order(:order_weight, :order_by_name_statement)
     end
 
     def active

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -26,11 +26,34 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
+      "fingerprint": "15ba790037c755c2171f2d18f1a768518173597396ca251bda33349df7fb45e4",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/controllers/concerns/sortable.rb",
+      "line": 73,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Arel.sql(\"#{order_alias} #{sort_dir} NULLS LAST\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Sortable::Prepends",
+        "method": "sort_subquery"
+      },
+      "user_input": "order_alias",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "No SQL Injection possible here, because no user data is handled"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
       "fingerprint": "3a4aa5477a1a1e079bb24001f19c237f1075d2c547f3f814dcef0fa113de2d23",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/qualification.rb",
-      "line": 110,
+      "line": 109,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "where(\"qualifications.finish_at <= :date AND NOT EXISTS (#{\"SELECT 1 FROM qualifications q2\\nINNER JOIN qualification_kinds qk ON qk.id = q2.qualification_kind_id\\nWHERE q2.person_id = qualifications.person_id\\nAND #{subselect_kind_condition(qualification_kind_ids)}\\nAND (\\n  (q2.start_at <= :date AND (q2.finish_at IS NULL OR q2.finish_at >= :date)) OR\\n  (q2.finish_at < :date AND q2.finish_at + INTERVAL '1 YEAR' * qk.reactivateable >= :date)\\n)\\n\"})\", :date => Time.zone.today, :qualification_kind_ids => qualification_kind_ids)",
       "render_path": null,
@@ -103,32 +126,13 @@
       "note": "HTML Tags ARE allowed here"
     },
     {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 123,
-      "fingerprint": "edf687f759ec9765bd5db185dbc615c80af77d6e7e19386fc42934e7a80307af",
-      "check_name": "EOLRuby",
-      "message": "Support for Ruby 3.2.6 ends on 2026-03-31",
-      "file": ".ruby-version",
-      "line": 1,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "High",
-      "cwe_id": [
-        1104
-      ],
-      "note": "Ticket exists and is planned for this quarter, see https://github.com/hitobito/hitobito/issues/3689"
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "47199546b5f194a214b8b478c8e5639c808086f95e5c918e7bc4e3a8923e13bd",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/qualification.rb",
-      "line": 92,
+      "line": 91,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "where(\"NOT EXISTS (SELECT 1 FROM qualifications q2 WHERE q2.person_id = qualifications.person_id AND #{subselect_kind_condition(qualification_kind_ids)} AND q2.start_at <= :date AND (q2.finish_at IS NULL OR q2.finish_at >= :date))\", :qualification_kind_ids => qualification_kind_ids, :date => Time.zone.today)",
       "render_path": null,
@@ -189,6 +193,29 @@
         89
       ],
       "note": "only used internally"
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "5edf6ee8a7fefec9dabcf24c14538da019fcf06e4d8e92a52672919027aece7c",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/controllers/concerns/sortable.rb",
+      "line": 94,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Arel.sql((\"#{order_alias} #{sort_dir} NULLS LAST\" or sort_expression_columns))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Sortable::Prepends",
+        "method": "sort_with_join"
+      },
+      "user_input": "order_alias",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": "No SQL Injection possible here, because no user data is handled"
     },
     {
       "warning_type": "SQL Injection",
@@ -266,7 +293,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/event/participation.rb",
-      "line": 112,
+      "line": 118,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "Arel.sql(\"CASE event_participations.participant_type\\n  WHEN 'Person' THEN #{Person.order_by_name_statement}\\n  WHEN 'Event::Guest' THEN #{Event::Guest.order_by_name_statement}\\n  ELSE ''\\nEND\\n\".squish)",
       "render_path": null,
@@ -327,6 +354,25 @@
         89
       ],
       "note": "All input values are ensured to be integer and thus not dangerous"
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 121,
+      "fingerprint": "edf687f759ec9765bd5db185dbc615c80af77d6e7e19386fc42934e7a80307af",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 3.2.6 ended on 2026-03-31",
+      "file": ".ruby-version",
+      "line": 1,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "High",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Ticket exists and is planned for this quarter, see https://github.com/hitobito/hitobito/issues/3689"
     },
     {
       "warning_type": "SQL Injection",

--- a/spec/controllers/event/participations_controller_spec.rb
+++ b/spec/controllers/event/participations_controller_spec.rb
@@ -75,6 +75,14 @@ describe Event::ParticipationsController do
       expect(assigns(:participations)).to eq [@leader, @participant]
     end
 
+    it "does not return ambiguous records when ordering by role" do
+      allow(Settings.people).to receive_messages(default_sort: "role")
+      @leader.roles.create!(type: Event::Role::Participant)
+
+      get :index, params: {group_id: group.id, event_id: course.id}
+      expect(assigns(:participations).count).to eq 2
+    end
+
     it "lists only leader_group" do
       get :index, params: {group_id: group.id, event_id: course.id, filters: {participant_type: :teamers}}
       expect(assigns(:participations)).to eq [@leader]

--- a/spec/fixtures/event/participations.yml
+++ b/spec/fixtures/event/participations.yml
@@ -2,6 +2,7 @@
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
+
 top:
   event: top_course
   participant: bottom_member

--- a/spec/models/event/participation_spec.rb
+++ b/spec/models/event/participation_spec.rb
@@ -136,11 +136,33 @@ describe Event::Participation do
     end
   end
 
-  context ".order_by_role_statement" do
-    it "orders by index of role_types" do
-      event_type = double("event_type", role_types: [Event::Role::Leader, Event::Role::Participant])
-      ordered_participations = Event::Participation.order_by_role(event_type)
-      expect(ordered_participations.to_sql).to include "ORDER BY event_role_type_orders.order_weight ASC"
+  context "#order_by_role" do
+    let(:event_type) { double("event_type", role_types: [Event::Role::Leader, Event::Role::Participant]) }
+    let(:participation_1) { subject }
+    let(:participation_2) { event_participations(:top) }
+    let(:ordered_participations) { Event::Participation.order_by_role(event_type) }
+
+    before do
+      Fabricate(Event::Role::Participant.sti_name, participation: participation_1).participation
+      Fabricate(Event::Role::Leader.sti_name, participation: participation_2).participation
+    end
+
+    it "orders by role type" do
+      expect(ordered_participations).to eq [participation_2, participation_1]
+    end
+
+    it "orders by name if two participations have the same role type" do
+      Fabricate(Event::Role::Leader.sti_name, participation: participation_1)
+      participation_1.person.update!(last_name: "AAA")
+
+      expect(ordered_participations).to eq [participation_1, participation_2]
+    end
+
+    it "does not duplicate participations with multiple event roles" do
+      Fabricate(Event::Role::Participant.sti_name, participation: participation_1)
+
+      expect(participation_1.reload.roles.count).to eq 2
+      expect(ordered_participations.count).to eq 2
     end
   end
 


### PR DESCRIPTION
This is a bug existing since the migration to PostgreSql. Participation Lists show ambiguous entries when a participation has multiple event roles. We had similar issues with people lists and so on.

I noticed that the order_by_role statement for participations never actually worked as it should while working on https://github.com/hitobito/hitobito_sac_cas/issues/2525

The reason no one noticed this is because the `people.default_sort` is `name` for all wagons besides Jubla (where it is `role`). And in the Jubla wagon there most likely never was a participation with multiple roles since then.

The bug is actually recreateable on integration: https://jubla.puzzle.ch/groups/680/events/887/participations
