### PR TITLE
Nullify template_id of derived event questions (hitobito/hitobito_sac_cas#2322)

### DIFF
--- a/app/models/event/question.rb
+++ b/app/models/event/question.rb
@@ -159,7 +159,9 @@ class Event::Question < ActiveRecord::Base
     end
   end
 
-  def self.reflect_on_all_associations
+  def self.reflect_on_all_associations(*args)
+    return super if args.any?
+
     super + [Choice::Reflection.new]
   end
 

--- a/app/models/event/question_template.rb
+++ b/app/models/event/question_template.rb
@@ -25,6 +25,9 @@ class Event::QuestionTemplate < ActiveRecord::Base
   belongs_to :question, dependent: :destroy
   belongs_to :group
 
+  has_many :derived_questions, class_name: "Event::Question", foreign_key: :template_id,
+    dependent: :nullify, inverse_of: false
+
   accepts_nested_attributes_for :question
 
   scope :in_hierarchy, ->(groups) {

--- a/db/migrate/20260701094113_nullify_template_id_of_orphaned_event_questions.rb
+++ b/db/migrate/20260701094113_nullify_template_id_of_orphaned_event_questions.rb
@@ -1,0 +1,15 @@
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class NullifyTemplateIdOfOrphanedEventQuestions < ActiveRecord::Migration[8.0]
+  def up
+    execute <<-SQL
+      UPDATE "event_questions"
+      SET "template_id" = NULL
+      WHERE "template_id" IS NOT NULL
+        AND "template_id" NOT IN (SELECT "id" FROM "event_question_templates");
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_26_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_01_094113) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/spec/models/event/question_template_spec.rb
+++ b/spec/models/event/question_template_spec.rb
@@ -50,6 +50,16 @@ describe Event::QuestionTemplate do
     end
   end
 
+  describe "#derived_questions" do
+    it "nullifies template_id of derived questions when template is destroyed" do
+      derived_question = template.derive_question
+      derived_question.save!
+
+      expect { template.destroy }
+        .to change { derived_question.reload.template_id }.to(nil)
+    end
+  end
+
   describe "#derive_question" do
     it "creates a new question instance with new translation instances" do
       derived_question = template.derive_question


### PR DESCRIPTION
`copy_attributes_for_derived_question` funktioniert nicht mehr wenn das Template nicht mehr existiert

https://github.com/cevi/hitobito_cevi/issues/260#issuecomment-4836499621