### PR TITLE
Display label export as people export on joboverview (#4343)

### DIFF
--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -1521,7 +1521,7 @@ de:
     export/export_base_job: Basis-Export
     export/invitations_export_job: Einladungs-Export
     export/invoices_job: Rechnungs-Export
-    export/labels_job: Etiketten-Export
+    export/labels_job: Personen-Export
     export/message_job: Nachrichten-Export
     export/payments_export_job: Zahlungs-Export
     export/people_export_job: Personen-Export


### PR DESCRIPTION
Currently we use the same job class for pdf exports of people lists as for label exports. This can lead to confusion when starting a people export and then finding a label export on the job overview. As a mitigating fix we now display label export jobs as people export jobs on the job overview. This should lead to less confusion than people exports being called label export. In the long run it would probably be better to redesign the people export job, so it can actually handle pdf exports of people lists.