### PR TITLE
Add some configuration for claude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "plansDirectory": "./.claude/plans"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ Gemfile.local.lock
 # git knows to ignore its directory, other tools only using this file do not
 .git/
 .claude/settings.local.json
+.claude/plans

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
- Fügt ein CLAUDE.md hinzu, welches vorerst nur auf AGENTS.md referenziert. Wir haben sonst noch nirgends softlinks im Einsatz, daher referenziere ich mal via `@AGENTS.md` auf die single source of truth. Bei Bedarf können später noch Claude-spezifische Instruktionen ergänzt werden.
- Generierte Plan .md Dateien sollten im Repo statt im Home Directory landen (besser für Kompatibilität mit devcontainers und mit `git reset`). Aber sie sollen nicht in git eingecheckt werden, da sie zu schnell veralten und später widersprüchliche Informationen bieten könnten.