### PR TITLE
add Event.default_visible_contact_attributes

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -127,6 +127,14 @@ module EventsHelper
       entry.used_attributes(:required_contact_attrs, :hidden_contact_attrs).any?
   end
 
+  def visible_contact_attribute_checked?(event, attr)
+    if event.new_record?
+      event.class.default_visible_contact_attributes.include?(attr.to_s)
+    else
+      event.visible_contact_attributes.include?(attr.to_s)
+    end
+  end
+
   def attachment_visibility_button(attachment, visibility)
     label = I18n.t(visibility, scope: "activerecord.attributes.event/attachment.visibilities")
     active = attachment.visibility.to_s == visibility.to_s

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -94,6 +94,9 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
     social_account
   ].freeze
 
+  class_attribute :default_visible_contact_attributes
+  self.default_visible_contact_attributes = ALLOWED_VISIBLE_CONTACT_ATTRIBUTES
+
   SEARCHABLE_ATTRS = [:number, {event_translations: [:name], groups: [:name]}]
 
   include Event::Participatable

--- a/app/views/events/_general_fields.html.haml
+++ b/app/views/events/_general_fields.html.haml
@@ -39,7 +39,8 @@
           - Event::ALLOWED_VISIBLE_CONTACT_ATTRIBUTES.each do |option|
             .form-check
               = label_tag do
-                = check_box_tag("event[visible_contact_attributes][#{option}]]", class: "form-check-input", checked: entry.new_record? || entry.visible_contact_attributes.include?(option.to_s))
+                - checked = entry.new_record? ? entry.class.default_visible_contact_attributes.include?(option.to_s) : entry.visible_contact_attributes.include?(option.to_s)
+                = check_box_tag("event[visible_contact_attributes][#{option}]]", class: "form-check-input", checked: checked)
                 = t(".visible_contact_attributes.#{option}")
 
   = render 'location_fields', f: f

--- a/app/views/events/_general_fields.html.haml
+++ b/app/views/events/_general_fields.html.haml
@@ -39,8 +39,7 @@
           - Event::ALLOWED_VISIBLE_CONTACT_ATTRIBUTES.each do |option|
             .form-check
               = label_tag do
-                - checked = entry.new_record? ? entry.class.default_visible_contact_attributes.include?(option.to_s) : entry.visible_contact_attributes.include?(option.to_s)
-                = check_box_tag("event[visible_contact_attributes][#{option}]]", class: "form-check-input", checked: checked)
+                = check_box_tag("event[visible_contact_attributes][#{option}]]", class: "form-check-input", checked: visible_contact_attribute_checked?(entry, option))
                 = t(".visible_contact_attributes.#{option}")
 
   = render 'location_fields', f: f

--- a/spec/requests/events/general_fields_spec.rb
+++ b/spec/requests/events/general_fields_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+RSpec.describe "events/_general_fields", type: :request do
+  let(:group) { groups(:top_group) }
+
+  before { sign_in(people(:top_leader)) }
+
+  def visible_contact_attribute_checkbox(name)
+    Nokogiri::HTML(response.body).at_css(
+      %(input[name="event[visible_contact_attributes][#{name}]]"])
+    )
+  end
+
+  it "only checks default_visible_contact_attributes by default on a new event" do
+    allow(Event).to receive(:default_visible_contact_attributes).and_return(%w[name email])
+
+    get new_group_event_path(group_id: group.id, event: {type: "Event"})
+
+    expect(visible_contact_attribute_checkbox("name")[:checked]).to eq("checked")
+    expect(visible_contact_attribute_checkbox("email")[:checked]).to eq("checked")
+    expect(visible_contact_attribute_checkbox("picture")[:checked]).to be_nil
+    expect(visible_contact_attribute_checkbox("address")[:checked]).to be_nil
+    expect(visible_contact_attribute_checkbox("phone_number")[:checked]).to be_nil
+    expect(visible_contact_attribute_checkbox("social_account")[:checked]).to be_nil
+  end
+end


### PR DESCRIPTION
This allows a wagon to override the behavior so only some of the `ALLOWED_VISIBLE_CONTACT_ATTRIBUTES` are checked by default for new records. E.g. in `wagon.rb`

```ruby
  config.to_prepare do
      Event.default_visible_contact_attributes = %w[name]
```