### PR TITLE
Consistent version for many productions

### DIFF
--- a/.github/workflows/update-productions.yml
+++ b/.github/workflows/update-productions.yml
@@ -39,6 +39,41 @@ jobs:
             echo "No release type selected. Aborting."
             exit 1
           fi
+
+  determine-version:
+    name: Determine version from core
+    runs-on: ubuntu-latest
+    needs:
+      - check-release-type
+    outputs:
+      version: ${{ steps.determine.outputs.version }}
+    steps:
+      - name: Checkout hitobito core
+        uses: actions/checkout@v6
+        with:
+          repository: hitobito/hitobito
+          ref: master
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler: none
+
+      - name: Install dependencies
+        run: gem install cmdparse
+
+      - name: Fetch tags
+        run: git fetch --tags
+
+      - name: Determine next version
+        id: determine
+        env:
+          RELEASE_TYPE: ${{ inputs.release }}
+          NEXT_VERSION: ${{ inputs.version }}
+        run: |
+          next_version=$(bin/version suggest "$RELEASE_TYPE" "$NEXT_VERSION")
+          echo "version=${next_version}" >> "$GITHUB_OUTPUT"
+
   find-instances:
     name: Find all selected hitobito instances
     runs-on: ubuntu-latest
@@ -55,8 +90,8 @@ jobs:
   release:
     name: Update ${{ matrix.instance }} production
     needs:
-      - check-release-type
       - find-instances
+      - determine-version
     strategy:
       fail-fast: false
       matrix:
@@ -65,8 +100,8 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       composition: hitobito/ose_composition_${{ matrix.instance }}
-      release_type: ${{ inputs.release }}
-      next_version: ${{ inputs.version }}
+      release_type: custom
+      next_version: ${{ needs.determine-version.outputs.version }}
       stage: production
       target_branch: ${{ inputs.target_branch }}
     secrets: inherit


### PR DESCRIPTION
Determine the version once, from the core, for all updated productions. This helps in the cases that one instance skipped a releases. Without this, the version is determined in the scope of the composition-repo, which can result in different versions for each composition. With this, the version is determined once from the core-tags and then passed as fixed custom versionnumber to each one.