### PR TITLE
Fix calculating group_for_deleted

### DIFF
--- a/app/domain/group/deleted_people.rb
+++ b/app/domain/group/deleted_people.rb
@@ -18,7 +18,8 @@ class Group::DeletedPeople
     end
 
     def group_for_deleted(person)
-      Group.where(id: new.roles_of_deleted_people.select(:group_id)).first
+      Group.where(id: new.roles_of_deleted_people.where(person_id: person.id).select(:group_id))
+        .first
     end
   end
 

--- a/spec/domain/group/deleted_people_spec.rb
+++ b/spec/domain/group/deleted_people_spec.rb
@@ -89,6 +89,33 @@ describe Group::DeletedPeople do
     end
   end
 
+  context "group_for_deleted" do
+    let(:group) { groups(:top_layer) }
+    let(:person) { role.person.reload }
+    let(:role) do
+      Fabricate(Group::TopLayer::TopAdmin.name, group: group,
+        start_on: 1.year.ago)
+    end
+
+    let(:child_group) { groups(:bottom_layer_one) }
+    let(:child_group_one) { groups(:bottom_group_one_one) }
+    let(:child_person) { child_role.person.reload }
+    let(:child_role) do
+      Fabricate(Group::BottomGroup::Leader.name, group: child_group_one,
+        start_on: 1.year.ago)
+    end
+
+    before do
+      role.update_column(:end_on, 1.day.ago)
+      child_role.update_column(:end_on, 1.day.ago)
+    end
+
+    it "finds the group of the given deleted person, not some other deleted person" do
+      expect(Group::DeletedPeople.group_for_deleted(person)).to eq(group)
+      expect(Group::DeletedPeople.group_for_deleted(child_person)).to eq(child_group_one)
+    end
+  end
+
   context "when roles are deleted in different series" do
     let(:group) { groups(:top_layer) }
     let(:bottom_group) { groups(:bottom_layer_one) }


### PR DESCRIPTION
Follow-up from #4210

Deleted people of one's layers are findable in the global search (https://github.com/hitobito/hitobito_sww/issues/80).
But after #4210 and before this fix, when clicking on the search result, you would get the access denied message, instead of opening the person in the context of the root group to display the contact data that is also shown in the deleted_people table.

The issue was a missing constraint by person in group_for_deleted. Without this constraint, for any person, some random group of the (unrelated) first deleted person would be found.

Verified locally using a production data dump.