### PR TITLE
Preselect the correct label in translated dropdowns

### DIFF
--- a/app/helpers/contactable_helper.rb
+++ b/app/helpers/contactable_helper.rb
@@ -23,12 +23,16 @@ module ContactableHelper
   def contact_method_label_select(form)
     contact_method = form.object
     current_label = contact_method.label
+
     options = (contact_method.class.predefined_labels | [current_label].compact).map do |value|
       translated = contact_method.class.translate_label(value)
       OpenStruct.new(value: value, translated: translated)
     end
-    form.collection_select(:translated_label, options, :value, :translated, {},
-      class: "form-select form-select-sm")
+
+    form.collection_select(
+      :translated_label, options, :value, :translated, {selected: current_label},
+      class: "form-select form-select-sm"
+    )
   end
 
   def contactable_public_field_icon

--- a/spec/helpers/contactable_helper_spec.rb
+++ b/spec/helpers/contactable_helper_spec.rb
@@ -40,6 +40,16 @@ describe ContactableHelper, type: :helper do
         .to have_selector("option[value='#{standard_options.third}'][selected='selected']")
     end
 
+    it "the current value is selected in another language as well" do
+      I18n.with_locale(:fr) do
+        additional_email.label = standard_options.third
+        result = helper.contact_method_label_select(form)
+
+        expect(result)
+          .to have_selector("option[value='#{standard_options.third}'][selected='selected']")
+      end
+    end
+
     it "includes current value as option" do
       additional_email.label = "nonstandard_value"
       result = helper.contact_method_label_select(form)


### PR DESCRIPTION
The internal value is the german locale, so we need to use that for comparing. ActionViews built-in FormBuilder does not know about this speciality, so we need to use the provided API to help it along.

One example: https://help.puzzle.ch/#ticket/zoom/11497
