### PR TITLE
Move unusual bounces to Failed and notify Sentry

### DIFF
--- a/app/domain/mailing_lists/bulk_mail/bounce_handler.rb
+++ b/app/domain/mailing_lists/bulk_mail/bounce_handler.rb
@@ -40,13 +40,16 @@ module MailingLists::BulkMail
       when :block then block_bounce
       when :continue then true
       when :register then record_bounce
-      when :internal_error then notify_sentry(:internal_error)
+      when :internal_error then notify_sentry(:internal_error, action)
       else
         record_bounce
-        notify_sentry(:unknown_code)
+        notify_sentry(:unknown_code, action)
       end
 
       action
+    rescue NoBounceRecipientDetected
+      notify_sentry(:no_recipient, action)
+      :unknown
     end
 
     def analyze_diagnostic_code(code)
@@ -110,14 +113,17 @@ module MailingLists::BulkMail
       @bulk_mail_bounce.destroy!
     end
 
-    def notify_sentry(message_code)
+    def notify_sentry(message_code, determined_action)
       message = case message_code
       when :internal_error then "A Bounce had an internal error in its Diagnostic Code"
       when :unknown_code then "A Bounce had a previously unknown Diagnostic Code"
+      when :no_recipient then "A Bounce had an undetectable original recipient"
       end
 
       Sentry.capture_message(message, logger: "bounce_handler", extra: {
-        diagnostic_code: @imap_mail.diagnostic_code
+        diagnostic_code: @imap_mail.diagnostic_code,
+        message_id: @imap_mail.message_id,
+        determined_action: determined_action
       })
     end
   end

--- a/app/utils/imap/mail.rb
+++ b/app/utils/imap/mail.rb
@@ -98,11 +98,11 @@ class Imap::Mail
     @mail ||= ::Mail.read_from_string(@net_imap_mail.attr["RFC822"])
   end
 
-  private
-
   def bounce?
     mail.bounced? || mail.diagnostic_code.present?
   end
+
+  private
 
   def envelope
     @net_imap_mail.attr["ENVELOPE"]

--- a/app/utils/imap/mail.rb
+++ b/app/utils/imap/mail.rb
@@ -14,7 +14,7 @@ class Imap::Mail
   attr_accessor :net_imap_mail
 
   delegate :subject, :sender, to: :envelope
-  delegate :final_recipient, :diagnostic_code, to: :mail
+  delegate :message_id, :final_recipient, :diagnostic_code, to: :mail
 
   def self.build(net_imap_mail)
     entry = new

--- a/spec/domain/mailing_lists/bulk_mail/bounce_handler_spec.rb
+++ b/spec/domain/mailing_lists/bulk_mail/bounce_handler_spec.rb
@@ -118,17 +118,18 @@ describe MailingLists::BulkMail::BounceHandler do
       expect(last_bounce.email).to eql "nothing@example2.com"
     end
 
-    it "raises for unusual bounces" do
+    it "handles unusual bounces gracefully" do
       unusual_bounce = Mail.read_from_string(
         Rails.root.join("spec", "fixtures", "email", "list_bounce.eml")
         .read.gsub(/^.*nothing@example2.com.*$/, "")
       )
       allow(bounce_imap_mail).to receive(:mail).and_return(unusual_bounce)
 
+      expect(bounce_handler).to receive(:notify_sentry).with(:no_recipient, :unknown)
+
       expect do
         bounce_handler.process
-      end.to raise_error(MailingLists::BulkMail::NoBounceRecipientDetected)
-        .with_message(/Mail seems to be a bounce, but the original recipient could not be detected./)
+      end.to_not change(Bounce, :count)
     end
   end
 
@@ -163,7 +164,7 @@ describe MailingLists::BulkMail::BounceHandler do
 
     it "reports internal errors" do
       expect(bounce_handler).to receive(:analyze_diagnostic_code).and_return(:internal_error)
-      expect(bounce_handler).to receive(:notify_sentry).once
+      expect(bounce_handler).to receive(:notify_sentry).with(:internal_error, :internal_error).once
 
       expect(bounce_handler).to_not receive(:block_bounce)
       expect(bounce_handler).to_not receive(:record_bounce)
@@ -174,7 +175,7 @@ describe MailingLists::BulkMail::BounceHandler do
     it "records a bounces a reports an error for unknown codes" do
       expect(bounce_handler).to receive(:analyze_diagnostic_code).and_return(:unknown)
       expect(bounce_handler).to receive(:record_bounce).once
-      expect(bounce_handler).to receive(:notify_sentry).once
+      expect(bounce_handler).to receive(:notify_sentry).with(:unknown_code, :unknown).once
 
       expect(bounce_handler).to_not receive(:block_bounce)
 
@@ -184,7 +185,7 @@ describe MailingLists::BulkMail::BounceHandler do
     it "records a bounces a reports an error for other codes" do
       expect(bounce_handler).to receive(:analyze_diagnostic_code).and_return(:dunno_dont_care)
       expect(bounce_handler).to receive(:record_bounce).once
-      expect(bounce_handler).to receive(:notify_sentry).once
+      expect(bounce_handler).to receive(:notify_sentry).with(:unknown_code, :dunno_dont_care).once
 
       expect(bounce_handler).to_not receive(:block_bounce)
 

--- a/spec/utils/imap/mail_spec.rb
+++ b/spec/utils/imap/mail_spec.rb
@@ -18,11 +18,11 @@ describe Imap::Mail do
     end
 
     it "has assumptions" do
-      expect(bounce_imap_mail).to be_bounced
+      expect(bounce_imap_mail).to be_bounce
     end
 
     it "is a list-bounce if it is bounced and a hitobito message uid is present" do
-      expect(bounce_imap_mail).to be_bounced
+      expect(bounce_imap_mail).to be_bounce
       expect(bounce_imap_mail.bounce_hitobito_message_uid).to be_present
 
       expect(bounce_imap_mail).to be_list_bounce
@@ -32,7 +32,7 @@ describe Imap::Mail do
       body = bounce_mail.body.raw_source.gsub("X-Hitobito-Message-UID: a15816bbd204ba20", "")
       expect(bounce_mail.body).to receive(:raw_source).and_return(body)
 
-      expect(bounce_imap_mail).to be_bounced
+      expect(bounce_imap_mail).to be_bounce
       expect(bounce_imap_mail).not_to be_list_bounce
     end
 


### PR DESCRIPTION
Some Bounce-Mails do not have a detectable original recipient (from whom the mails bounced off of), this leads to an error and left the mail in place, which repeated the error. Also, the mail in question blocks further processing of the mails.

See https://glitchtip.puzzle.ch/hitobito/issues/17864?project=20