### PR TITLE
Add feature toggle for invoice list filtering based on finance permission (hitobito/hitobito_ejv#76)

### DIFF
--- a/app/controllers/contactables/invoices_controller.rb
+++ b/app/controllers/contactables/invoices_controller.rb
@@ -19,26 +19,28 @@ class Contactables::InvoicesController < ListController
   private
 
   def list_entries
-    Invoice::Filter.new(params).apply(scope.page(params[:page]).per(50))
+    Invoice::Filter.new(params).apply(super.page(params[:page]).per(50))
   end
 
-  def scope
-    return base_scope if self_or_managed?
+  def model_scope
+    scope = filter_by_finance_layer? ? filter_by_finance_layer(super) : super
 
-    base_scope
-      .joins(group: :layer_group)
-      .where(layer_group: {id: current_ability.user_finance_layer_ids})
+    scope.preload(:group)
   end
 
-  def base_scope
-    method(:list_entries).super_method.call
-      .list
-      .includes(:group)
-      .where(search_conditions)
+  def filter_by_finance_layer?
+    FeatureGate.enabled?("invoices.filter_by_finance_layer") &&
+      !self_or_managed?
   end
 
   def self_or_managed?
     contactable == current_person || current_person.manageds.include?(contactable)
+  end
+
+  def filter_by_finance_layer(scope)
+    scope
+      .joins(group: :layer_group)
+      .where(layer_group: {id: current_ability.user_finance_layer_ids})
   end
 
   def contactable

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -306,6 +306,13 @@ groups:
 hitobito_log:
   recipient_emails:
 
+invoices:
+  filter_by_finance_layer:
+    # When enabled, the receiver invoices on a person's invoice tab are filtered
+    # to only show invoices from finance layers the current user has access to.
+    # When disabled, the pre-#4277 behavior is used and all invoices are shown.
+    enabled: true
+
 wallets:
   sync_interval: <%= ENV['HITOBITO_WALLETS_SYNC_SECONDS'].presence || 3.minutes %>
 

--- a/spec/controllers/contactables/invoices_controller_spec.rb
+++ b/spec/controllers/contactables/invoices_controller_spec.rb
@@ -62,6 +62,12 @@ describe Contactables::InvoicesController do
           get :index, params: {group_id: group.id, person_id: top_leader.id}
           expect(assigns(:invoices)).to be_empty
         end
+
+        it "may list invoices if filter_by_finance_layer=false" do
+          allow(Settings.invoices.filter_by_finance_layer).to receive(:enabled).and_return(false)
+          get :index, params: {group_id: group.id, person_id: top_leader.id}
+          expect(assigns(:invoices)).to match_array invoices(:invoice, :sent)
+        end
       end
     end
 


### PR DESCRIPTION
With #4277 we fixed the invoice listing to respect the finance
permission so that the user does not see invoices from groups where it
does not have finance permission.
This change is undesirable by EJV (and possibly others). We introduce
a feature gate, so now we can restore the old behaviour on demand.
