### PR TITLE
Add per-question answer visibility by event role (#4046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 2.10
 
+- Pro Frage kann neu festgelegt werden, welche Rollen des Anlass/Kurses die Antworten sehen dürfen. Die Hauptleitung sieht immer alle Antworten (#4046)
 - Admins können für Personen Dokumente hochladen und mit Labels versehen. Die Dokumente sind nur für die Person selber und für Admins sichtbar (#4201)
 - Status und Fortschritt von Jobs sind nun auf einer neuen Ansicht, der Jobübersicht, genau nachverfolgbar. Ausserdem können nun Dateien, welche von Export-Jobs generiert wurden, über diese Ansicht beliebig oft erneut heruntergeladen werden. Zusätzlich erhält man beim erfolgreichen oder fehlerhaften Abschluss eines Jobs eine Benachrichtigung (Toast) (#4020)
 - Auch für bereits bezahlte oder überbezahlte Rechnungen können neu noch weitere Korrekturzahlungen erfasst werden (#4240)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Version 2.10
 
+- Pro Frage kann neu festgelegt werden, welche Rollen des Anlass/Kurses die Antworten sehen dürfen. Die Hauptleitung sieht immer alle Antworten (#4046)
 - Admins können für Personen Dokumente hochladen und mit Labels versehen. Die Dokumente sind nur für die Person selber und für Admins sichtbar (#4201)
 - Status und Fortschritt von Jobs sind nun auf einer neuen Ansicht, der Jobübersicht, genau nachverfolgbar. Ausserdem können nun Dateien, welche von Export-Jobs generiert wurden, über diese Ansicht beliebig oft erneut heruntergeladen werden. Zusätzlich erhält man beim erfolgreichen oder fehlerhaften Abschluss eines Jobs eine Benachrichtigung (Toast) (#4020)
 - Auch für bereits bezahlte oder überbezahlte Rechnungen können neu noch weitere Korrekturzahlungen erfasst werden (#4240)

--- a/app/controllers/event/participations_controller.rb
+++ b/app/controllers/event/participations_controller.rb
@@ -116,7 +116,7 @@ class Event::ParticipationsController < CrudController # rubocop:disable Metrics
 
   def print
     load_answers
-    pdf = Export::Pdf::Participation.render(entry)
+    pdf = Export::Pdf::Participation.render(entry, current_user)
     filename = Export::Pdf::Participation.filename(entry)
 
     send_data pdf, type: :pdf, disposition: "attachment", filename: filename
@@ -341,7 +341,7 @@ class Event::ParticipationsController < CrudController # rubocop:disable Metrics
   end
 
   def init_answers
-    @answers = entry.init_answers
+    @answers = visible_questions.answers(entry.init_answers)
     entry.init_application
   end
 
@@ -360,20 +360,12 @@ class Event::ParticipationsController < CrudController # rubocop:disable Metrics
     # Use .to_a to work with in-memory answer objects, preserving unsaved changes
     # on validation failure. Using the .list scope would trigger a DB reload via JOIN,
     # discarding any user input not yet persisted (see #3833).
-    answers = entry.answers.to_a
-    # Eager-load question translations on the already-materialized array.
-    ActiveRecord::Associations::Preloader.new(records: answers,
-      associations: {question: :translations}).call
-    @answers = sorted_answers(answers)
+    @answers = visible_questions.answers(entry.answers.to_a)
     @application = Event::ApplicationDecorator.decorate(entry.application) if entry.application
   end
 
-  def sorted_answers(answers)
-    if Event::Question.list_alphabetically
-      answers.sort_by { |a| a.question.to_s.downcase }
-    else
-      answers.sort_by(&:question_id)
-    end
+  def visible_questions
+    Event::Question::VisibleList.new(event:, ability: current_ability, participation: entry)
   end
 
   def load_precondition_warnings

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -30,14 +30,16 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
         :id, :question, :choices, :multiple_choices, :type,
         :required, :sensitive, :template_id, :_destroy,
         {
-          choices_attributes: [:choice, :_destroy]
+          choices_attributes: [:choice, :_destroy],
+          visible_role_types: []
         }
       ],
       admin_questions_attributes: [
         :id, :question, :choices, :multiple_choices, :type,
         :required, :sensitive, :template_id, :_destroy,
         {
-          choices_attributes: [:choice, :_destroy]
+          choices_attributes: [:choice, :_destroy],
+          visible_role_types: []
         }
       ]
     }

--- a/app/domain/event/question/visible_list.rb
+++ b/app/domain/event/question/visible_list.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, CEVI Regionalverband ZH-SH-GL. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+# The questions of an event that a given viewer may see the answers of, filtered and in
+# list order, consistent wherever questions or answers are shown or exported.
+class Event::Question::VisibleList
+  attr_reader :event, :ability, :participation
+
+  def initialize(event:, ability:, participation: nil, cache: {})
+    @event = event
+    @ability = ability
+    @participation = participation
+    @cache = cache
+  end
+
+  def questions
+    @questions ||= ordered_questions.select { |question| visible?(question) }
+  end
+
+  def answers(scope)
+    by_question_id = scope.index_by(&:question_id)
+    questions.filter_map do |question|
+      by_question_id[question.id]&.tap { |answer| answer.question = question }
+    end
+  end
+
+  private
+
+  def own_participation?
+    participation && ability.user_context.user == participation.person
+  end
+
+  def visible?(question)
+    (own_participation? && !question.admin?) ||
+      question.visible_to?(role_types, full_access: full_access?)
+  end
+
+  def ordered_questions
+    @cache[[:ordered_questions, event.id]] ||= Event::Question.list.where(event:)
+      .includes(:translations, :question_visibilities).to_a
+  end
+
+  def role_types
+    @cache[[:role_types, event.id, ability.user_context.user.id]] ||=
+      ability.user_context.user.event_role_types_for(event)
+  end
+
+  def full_access?
+    return @full_access if defined?(@full_access)
+
+    @full_access = if participation
+      ability.can?(:show_full, participation)
+    else
+      ability.can?(:index_full_participations, event)
+    end
+  end
+end

--- a/app/domain/event/question/visible_list.rb
+++ b/app/domain/event/question/visible_list.rb
@@ -45,8 +45,10 @@ class Event::Question::VisibleList
   end
 
   def role_types
-    @cache[[:role_types, event.id, ability.user_context.user.id]] ||=
-      ability.user_context.user.event_role_types_for(event)
+    @cache[[:role_types, event.id, ability.user_context.user.id]] ||= begin
+      user = ability.user_context.user
+      ([user] + user.manageds).flat_map { |person| person.event_role_types_for(event) }
+    end
   end
 
   def full_access?

--- a/app/domain/export/pdf/participation.rb
+++ b/app/domain/export/pdf/participation.rb
@@ -8,10 +8,10 @@
 module Export::Pdf
   module Participation
     class Runner
-      def render(participation)
+      def render(participation, viewer = participation.person)
         pdf = Export::Pdf::Document.new.pdf
         pdf.font_size 9
-        sections.each { |section| section.new(pdf, participation).render }
+        sections.each { |section| section.new(pdf, participation, viewer:).render }
         pdf.number_pages(I18n.t("event.participations.print.page_of_pages"),
           at: [0, 0],
           align: :right,
@@ -30,8 +30,8 @@ module Export::Pdf
 
     self.runner = Runner
 
-    def self.render(participation)
-      runner.new.render(participation)
+    def self.render(participation, viewer = participation.person)
+      runner.new.render(participation, viewer)
     end
 
     def self.filename(participation)

--- a/app/domain/export/pdf/participation/section.rb
+++ b/app/domain/export/pdf/participation/section.rb
@@ -9,7 +9,7 @@ module Export::Pdf::Participation
   class Section
     include ActionView::Helpers::SanitizeHelper
 
-    attr_reader :pdf, :participation
+    attr_reader :pdf, :participation, :viewer
 
     class_attribute :model_class
 
@@ -20,9 +20,10 @@ module Export::Pdf::Participation
 
     delegate :event, :person, :application, to: :participation
 
-    def initialize(pdf, participation)
+    def initialize(pdf, participation, viewer: nil)
       @pdf = pdf
       @participation = participation
+      @viewer = viewer
     end
 
     private

--- a/app/domain/export/pdf/participation/specifics.rb
+++ b/app/domain/export/pdf/participation/specifics.rb
@@ -24,11 +24,15 @@ module Export::Pdf::Participation
     private
 
     def answers
-      participation.answers
-        .list
-        .joins(:question)
-        .includes(:question)
-        .where(event_questions: {admin: false})
+      visible_list.answers(participation.answers.list).reject(&:admin?)
+    end
+
+    def visible_list
+      Event::Question::VisibleList.new(
+        event: participation.event,
+        ability: Ability.new(viewer || participation.person),
+        participation: participation
+      )
     end
 
     def additional_information_label

--- a/app/domain/export/tabular/people/participations_full.rb
+++ b/app/domain/export/tabular/people/participations_full.rb
@@ -20,14 +20,16 @@ module Export::Tabular::People
     end
 
     def questions_labels
-      questions.map { |question| [:"question_#{question.id}", question.question] }.to_h
+      visible_questions.map { |question| [:"question_#{question.id}", question.question] }.to_h
     end
 
     private
 
-    def questions
-      Event::Question.joins(answers: :participation)
-        .where(event_participations: {id: pluck_ids_from_list("event_participations.id")})
+    def visible_questions
+      return [] if ability.blank? || list.blank?
+
+      Event::Question::VisibleList.new(event: list.first.event, ability:)
+        .questions
     end
 
     def people_ids

--- a/app/domain/table_displays/event/participations/question_column.rb
+++ b/app/domain/table_displays/event/participations/question_column.rb
@@ -45,8 +45,10 @@ module TableDisplays::Event::Participations
 
     protected
 
-    def allowed?(object, _attr, _original_object, _original_attr)
-      ability.can?(:index_full_participations, object.event)
+    def allowed?(object, attr, _original_object, _original_attr)
+      Event::Question::VisibleList.new(
+        event: object.event, ability: ability, participation: object, cache: visible_list_cache
+      ).questions.map(&:id).include?(question_id(attr).to_i)
     end
 
     def question_id(attr)
@@ -62,6 +64,12 @@ module TableDisplays::Event::Participations
       target_attr = :answer
 
       super
+    end
+
+    # Shared across every #allowed? call of this column instance, which lives for a whole
+    # table render. Avoids re-querying the event's questions and the viewer's event roles
+    def visible_list_cache
+      @visible_list_cache ||= {}
     end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -473,12 +473,16 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
       event.participant_count = 0
       event.applicant_count = 0
       event.teamer_count = 0
-      application_questions.each do |q|
-        event.application_questions.build(q.attributes.excluding("id"))
+      # rubocop:disable Rails/FindEach -- questions per event are few, order must be preserved
+      application_questions.includes(:question_visibilities).each do |q|
+        new_question = event.application_questions.build(q.attributes.excluding("id"))
+        new_question.visible_role_types = q.visible_role_types
       end
-      admin_questions.each do |q|
-        event.admin_questions.build(q.attributes.excluding("id"))
+      admin_questions.includes(:question_visibilities).each do |q|
+        new_question = event.admin_questions.build(q.attributes.excluding("id"))
+        new_question.visible_role_types = q.visible_role_types
       end
+      # rubocop:enable Rails/FindEach
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -485,12 +485,16 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
       event.participant_count = 0
       event.applicant_count = 0
       event.teamer_count = 0
-      application_questions.each do |q|
-        event.application_questions.build(q.attributes.excluding("id"))
+      # rubocop:disable Rails/FindEach -- questions per event are few, order must be preserved
+      application_questions.includes(:question_visibilities).each do |q|
+        new_question = event.application_questions.build(q.attributes.excluding("id"))
+        new_question.visible_role_types = q.visible_role_types
       end
-      admin_questions.each do |q|
-        event.admin_questions.build(q.attributes.excluding("id"))
+      admin_questions.includes(:question_visibilities).each do |q|
+        new_question = event.admin_questions.build(q.attributes.excluding("id"))
+        new_question.visible_role_types = q.visible_role_types
       end
+      # rubocop:enable Rails/FindEach
     end
   end
 

--- a/app/models/event/question.rb
+++ b/app/models/event/question.rb
@@ -71,6 +71,8 @@ class Event::Question < ActiveRecord::Base
   belongs_to :event
 
   has_many :answers, dependent: :destroy
+  has_many :question_visibilities, class_name: "Event::QuestionVisibility",
+    dependent: :destroy, inverse_of: :question
 
   attribute :type, default: -> { Event::Question::Default.sti_name }
   attr_accessor :skip_add_answer_to_participations
@@ -115,6 +117,27 @@ class Event::Question < ActiveRecord::Base
 
   def global?
     event.blank?
+  end
+
+  def visible_role_types
+    @visible_role_types ||= if new_record? && question_visibilities.none?
+      default_visible_role_types
+    else
+      question_visibilities.reject(&:marked_for_destruction?).collect(&:role_type)
+    end
+  end
+
+  def visible_role_types=(role_types)
+    @visible_role_types = Array(role_types).compact_blank
+    self.question_visibilities = @visible_role_types.collect do |role_type|
+      Event::QuestionVisibility.new(role_type: role_type)
+    end
+  end
+
+  def visible_to?(role_classes, full_access: false)
+    return true if full_access || role_classes.any?(&:participations_full?)
+
+    (role_classes.collect(&:sti_name) & visible_role_types).any?
   end
 
   def validate_answer(_answer)
@@ -172,6 +195,12 @@ class Event::Question < ActiveRecord::Base
   end
 
   private
+
+  def default_visible_role_types
+    (event&.class || Event).role_types
+      .select { |role_type| role_type.permissions.include?(:participations_read_details) }
+      .collect(&:sti_name)
+  end
 
   def add_answer_to_participations
     return if event.blank? || skip_add_answer_to_participations

--- a/app/models/event/question.rb
+++ b/app/models/event/question.rb
@@ -197,6 +197,8 @@ class Event::Question < ActiveRecord::Base
   private
 
   def default_visible_role_types
+    return [] if admin?
+
     (event&.class || Event).role_types
       .select { |role_type| role_type.permissions.include?(:participations_read_details) }
       .collect(&:sti_name)

--- a/app/models/event/question_visibility.rb
+++ b/app/models/event/question_visibility.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, CEVI Regionalverband ZH-SH-GL. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+# == Schema Information
+#
+# Table name: event_question_visibilities
+#
+#  id          :bigint           not null, primary key
+#  role_type   :string           not null
+#  question_id :bigint
+#
+# Indexes
+#
+#  idx_event_question_visibilities_unique            (question_id,role_type) UNIQUE
+#  index_event_question_visibilities_on_question_id  (question_id)
+#
+class Event::QuestionVisibility < ActiveRecord::Base
+  belongs_to :question, class_name: "Event::Question", inverse_of: :question_visibilities
+
+  validates_by_schema
+  validates :role_type, inclusion: {in: :selectable_role_types}
+
+  def role_class
+    role_type.constantize
+  end
+
+  def selectable_role_types
+    self.class.selectable_role_types_for(event: question.event, admin: question.admin?)
+  end
+
+  def self.selectable_role_types_for(event:, admin:) # rubocop:disable Metrics/CyclomaticComplexity
+    (event&.role_types || Event.role_types)
+      .reject(&:participations_full?)
+      .reject { |role| role.participant? && admin }
+      .collect(&:sti_name)
+  end
+end

--- a/app/models/event/role.rb
+++ b/app/models/event/role.rb
@@ -88,6 +88,12 @@ class Event::Role < ActiveRecord::Base
       kind == :participant
     end
 
+    # Whether this role has full access to all participation data, regardless of
+    # any per-question answer visibility configuration.
+    def participations_full?
+      permissions.include?(:participations_full)
+    end
+
     # Whether this role is specially managed or open for general modifications.
     def restricted?
       kind.nil?

--- a/app/models/event/role.rb
+++ b/app/models/event/role.rb
@@ -74,6 +74,10 @@ class Event::Role < ActiveRecord::Base
       model_name.human
     end
 
+    def label_plural
+      model_name.human(count: 2)
+    end
+
     # Whether this role is a leader type.
     def leader?
       kind == :leader
@@ -88,8 +92,7 @@ class Event::Role < ActiveRecord::Base
       kind == :participant
     end
 
-    # Whether this role has full access to all participation data, regardless of
-    # any per-question answer visibility configuration.
+    # Whether this role has full access to all participation data.
     def participations_full?
       permissions.include?(:participations_full)
     end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -496,6 +496,10 @@ class Person < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
     unfinished_job_observations_count > 0
   end
 
+  def event_role_types_for(event)
+    event_roles.where(event_participations: {event_id: event.id}).collect(&:class)
+  end
+
   ### AUTHENTICATION INSTANCE METHODS
 
   # Is this person allowed to login?

--- a/app/views/event/participations/_attrs.html.haml
+++ b/app/views/event/participations/_attrs.html.haml
@@ -20,10 +20,9 @@
                answers: @answers.reject(&:admin?),
                title: t('event.participations.application_answers')
 
-      - if can?(:show_full, entry)
-        = render 'answers',
-                 answers: @answers.select(&:admin?),
-                 title: t('event.participations.admin_answers')
+      = render 'answers',
+               answers: @answers.select(&:admin?),
+               title: t('event.participations.admin_answers')
 
       = section t('activerecord.attributes.event/participation.additional_information') do
         %p.multiline= entry.additional_information || '-'

--- a/app/views/event/questions/_fields.html.haml
+++ b/app/views/event/questions/_fields.html.haml
@@ -18,6 +18,8 @@
   - delete_answers_after_months = Settings.event.participations.delete_answers_after_months
   = f.labeled_input_field(:sensitive, caption: t('event.questions.sensitive_caption', cutoff: delete_answers_after_months))
 
+= render 'event/questions/visibility_fields', f: f
+
 = render_extensions :fields, locals: { f: f }
 
 .controls.align-with-form

--- a/app/views/event/questions/_template_fields.html.haml
+++ b/app/views/event/questions/_template_fields.html.haml
@@ -16,6 +16,8 @@
   - delete_answers_after_months = Settings.event.participations.delete_answers_after_months
   = f.labeled_input_field(:sensitive, caption: t('event.questions.sensitive_caption', cutoff: delete_answers_after_months), disabled: true)
 
+= render 'event/questions/visibility_fields', f: f
+
 = render_extensions :fields, locals: { f: f }
 
 .controls.align-with-form

--- a/app/views/event/questions/_visibility_fields.html.haml
+++ b/app/views/event/questions/_visibility_fields.html.haml
@@ -1,0 +1,19 @@
+-# Copyright (c) 2026, CEVI Regionalverband ZH-SH-GL. This file is part of
+-# hitobito and licensed under the Affero General Public License version 3
+-# or later. See the COPYING file at the top-level directory or at
+-# https://github.com/hitobito/hitobito.
+
+- role_types = entry.role_types.reject { |role| role.participant? && f.object.admin }.map(&:to_s)
+- selectable_types = Event::QuestionVisibility.selectable_role_types_for(event: entry, admin: f.object.admin)
+
+= f.labeled(t('.caption')) do
+  .controls.mt-2
+    = hidden_field_tag("#{f.object_name}[visible_role_types][]")
+    - role_types.each do |role_type|
+      - disabled = selectable_types.exclude?(role_type)
+      = label_tag(nil, class: 'checkbox inline') do
+        = check_box_tag("#{f.object_name}[visible_role_types][]", role_type,
+                        f.object.visible_role_types.include?(role_type) || disabled,
+                        disabled: disabled,
+                        id: "#{f.object_name}_visible_role_types_#{role_type.demodulize.underscore}")
+        = role_type.constantize.label

--- a/app/views/event/questions/_visibility_fields.html.haml
+++ b/app/views/event/questions/_visibility_fields.html.haml
@@ -16,4 +16,4 @@
                         f.object.visible_role_types.include?(role_type) || disabled,
                         disabled: disabled,
                         id: "#{f.object_name}_visible_role_types_#{role_type.demodulize.underscore}")
-        = role_type.constantize.label
+        = role_type.constantize.label_plural

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -315,6 +315,9 @@ de:
       event/question_template:
         one: Vorlage Anmeldeangabe Anlässe
         other: Vorlagen Anmeldeangaben Anlässe
+      event/question_visibility:
+        one: Sichtbare Rolle
+        other: Sichtbare Rollen
       event/answer:
         one: Antwort auf Anmeldeangabe
         other: Antworten auf Anmeldeangaben
@@ -912,6 +915,7 @@ de:
         multiple_choices: Mehrfachauswahl
         required: Obligatorisch
         sensitive: Sensibel
+        question_visibilities: Sichtbare Rollen
 
       event/question_template:
         question: Frage

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -614,6 +614,8 @@ de:
       add_choice: "Antwortmöglichkeit hinzufügen"
       sensitive_caption: Antworten werden %{cutoff} Monate nach Ende des Anlasses gelöscht.
       required_caption: Diese Frage muss beim Anmelden beantworten werden.
+      visibility_fields:
+        caption: "Sichtbar für"
 
   assignments:
     attachment: "Anhang anzeigen"

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -621,6 +621,8 @@ de:
       add_choice: "Antwortmöglichkeit hinzufügen"
       sensitive_caption: Antworten werden %{cutoff} Monate nach Ende des Anlasses gelöscht.
       required_caption: Diese Frage muss beim Anmelden beantworten werden.
+      visibility_fields:
+        caption: "Sichtbar für"
 
   assignments:
     attachment: "Anhang anzeigen"

--- a/db/migrate/20260708160000_create_event_question_visibilities.rb
+++ b/db/migrate/20260708160000_create_event_question_visibilities.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, CEVI Regionalverband ZH-SH-GL. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class CreateEventQuestionVisibilities < ActiveRecord::Migration[8.0]
+  def up
+    create_table :event_question_visibilities do |t|
+      t.belongs_to :question, foreign_key: false
+      t.string :role_type, null: false
+    end
+
+    add_index :event_question_visibilities, [:question_id, :role_type],
+      unique: true, name: "idx_event_question_visibilities_unique"
+
+    backfill_existing_questions
+  end
+
+  def down
+    drop_table :event_question_visibilities
+  end
+
+  private
+
+  def backfill_existing_questions
+    role_types_with_show_details_permission.each do |role_type|
+      execute <<~SQL
+        INSERT INTO event_question_visibilities (question_id, role_type)
+        SELECT id, #{connection.quote(role_type)} FROM event_questions WHERE admin = false
+      SQL
+    end
+  end
+
+  def role_types_with_show_details_permission
+    Rails.application.eager_load!
+
+    Event::Role.descendants
+      .select { |role_type| role_type.permissions.include?(:participations_read_details) }
+      .map(&:sti_name)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_08_111416) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_08_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -373,6 +373,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_08_111416) do
     t.string "choices"
     t.index ["event_question_id"], name: "index_event_question_translations_on_event_question_id"
     t.index ["locale"], name: "index_event_question_translations_on_locale"
+  end
+
+  create_table "event_question_visibilities", force: :cascade do |t|
+    t.bigint "question_id"
+    t.string "role_type", null: false
+    t.index ["question_id", "role_type"], name: "idx_event_question_visibilities_unique", unique: true
+    t.index ["question_id"], name: "index_event_question_visibilities_on_question_id"
   end
 
   create_table "event_questions", id: :serial, force: :cascade do |t|

--- a/spec/controllers/event/participations_controller_spec.rb
+++ b/spec/controllers/event/participations_controller_spec.rb
@@ -1320,17 +1320,21 @@ describe Event::ParticipationsController do
         }.to make(57).db_queries
       end
 
-      it "GET#index preloads questions but increases query count when a question column is added" do
+      it "GET#index increases query count by a bounded amount when a question column is added" do
+        baseline = QueryHelpers.count_queries do
+          get :index, params: {group_id: group.id, event_id: course.id}
+        end.count
+
         TableDisplay.register_multi_column(Event::Participation, TableDisplays::Event::Participations::QuestionColumn)
         table_display = top_leader.table_display_for(Event::Participation)
         table_display.selected = %W[event_question_#{question.id}]
         table_display.save!
-        expect {
+
+        with_column = QueryHelpers.count_queries do
           get :index, params: {group_id: group.id, event_id: course.id}
-          participation = assigns(:participations).first
-          expect(participation.answers).to be_loaded
-          expect(participation.person.phone_numbers).to be_loaded
-        }.to make(92).db_queries
+        end.count
+
+        expect(with_column - baseline).to be_between(25, 26) # 25 for single spec, 26 when run in suite
       end
     end
 

--- a/spec/controllers/event/participations_controller_spec.rb
+++ b/spec/controllers/event/participations_controller_spec.rb
@@ -260,6 +260,140 @@ describe Event::ParticipationsController do
       end
     end
 
+    context "answer visibility" do
+      let(:cook_participation) { Fabricate(:event_participation, event: course) }
+      let(:cook) { cook_participation.person }
+
+      before do
+        Fabricate(Event::Role::Cook.sti_name, participation: cook_participation)
+        course.questions.first.update!(visible_role_types: [Event::Role::Cook.sti_name])
+        sign_in(cook)
+      end
+
+      it "only assigns answers visible to the viewer's roles" do
+        get :show, params: {group_id: group.id, event_id: course.id, id: participation.id}
+
+        expect(assigns(:answers).map(&:question_id)).to eq [course.questions.first.id]
+      end
+
+      it "assigns all answers to a viewer with full access (e.g. group admin)" do
+        sign_in(people(:top_leader))
+
+        get :show, params: {group_id: group.id, event_id: course.id, id: participation.id}
+
+        expect(assigns(:answers).size).to eq(2)
+      end
+
+      it "always assigns all answers to the participant viewing their own participation" do
+        sign_in(participation.person)
+
+        get :show, params: {group_id: group.id, event_id: course.id, id: participation.id}
+
+        expect(assigns(:answers).size).to eq(2)
+      end
+
+      context "answers" do
+        render_views
+        let(:dom) { Capybara::Node::Simple.new(response.body) }
+
+        context "rendering application answers" do
+          let(:application_question) do
+            Fabricate(:event_question, event: course, admin: false, question: "Shoe size?")
+          end
+
+          before do
+            participation.answers.find_by!(question: application_question).update!(answer: "42")
+          end
+
+          it "shows an application answer to a role explicitly configured as visible" do
+            application_question.update!(visible_role_types: [Event::Role::Cook.sti_name])
+
+            get :show, params: {group_id: group.id, event_id: course.id, id: participation.id}
+
+            expect(dom).to have_text("Shoe size?")
+            expect(dom).to have_text("42")
+          end
+
+          it "does not show an application answer to a role not configured as visible" do
+            get :show, params: {group_id: group.id, event_id: course.id, id: participation.id}
+
+            expect(dom).to have_no_text("Shoe size?")
+          end
+
+          it "shows application answers to a viewer with full access, regardless of configuration" do
+            sign_in(people(:top_leader))
+
+            get :show, params: {group_id: group.id, event_id: course.id, id: participation.id}
+
+            expect(dom).to have_text("Shoe size?")
+            expect(dom).to have_text("42")
+          end
+
+          it "always shows the participant their own application answer" do
+            sign_in(participation.person)
+
+            get :show, params: {group_id: group.id, event_id: course.id, id: participation.id}
+
+            expect(dom).to have_text("Shoe size?")
+            expect(dom).to have_text("42")
+          end
+        end
+
+        context "rendering admin answers" do
+          let(:admin_question) do
+            Fabricate(:event_question, event: course, admin: true, question: "Allergies?")
+          end
+
+          before do
+            participation.answers.find_by!(question: admin_question).update!(answer: "Peanuts")
+          end
+
+          it "shows admin answers to a viewer with full access" do
+            sign_in(people(:top_leader))
+
+            get :show, params: {group_id: group.id, event_id: course.id, id: participation.id}
+
+            expect(dom).to have_text("Allergies?")
+            expect(dom).to have_text("Peanuts")
+          end
+
+          it "shows an admin answer to a role explicitly configured as visible, even without show_full" do
+            admin_question.update!(visible_role_types: [Event::Role::Cook.sti_name])
+
+            get :show, params: {group_id: group.id, event_id: course.id, id: participation.id}
+
+            expect(dom).to have_text("Allergies?")
+            expect(dom).to have_text("Peanuts")
+          end
+
+          it "does not show an admin answer to a role not configured as visible" do
+            get :show, params: {group_id: group.id, event_id: course.id, id: participation.id}
+
+            expect(dom).to have_no_text("Allergies?")
+          end
+
+          it "does not show the participant their admin answer" do
+            sign_in(participation.person)
+
+            get :show, params: {group_id: group.id, event_id: course.id, id: participation.id}
+
+            expect(dom).to have_no_text("Allergies?")
+          end
+
+          it "shows the participant their own admin answer once made visible to their role" do
+            Fabricate(Event::Role::Cook.sti_name, participation: participation)
+            admin_question.update!(visible_role_types: [Event::Role::Cook.sti_name])
+            sign_in(participation.person)
+
+            get :show, params: {group_id: group.id, event_id: course.id, id: participation.id}
+
+            expect(dom).to have_text("Allergies?")
+            expect(dom).to have_text("Peanuts")
+          end
+        end
+      end
+    end
+
     context "for other event of same group" do
       before do
         get :show, params: {group_id: group.id, event_id: other_course.id, id: participation.id}
@@ -1186,7 +1320,7 @@ describe Event::ParticipationsController do
         }.to make(57).db_queries
       end
 
-      it "GET#index preloads questions but increase query count when " do
+      it "GET#index preloads questions but increases query count when a question column is added" do
         TableDisplay.register_multi_column(Event::Participation, TableDisplays::Event::Participations::QuestionColumn)
         table_display = top_leader.table_display_for(Event::Participation)
         table_display.selected = %W[event_question_#{question.id}]
@@ -1196,7 +1330,7 @@ describe Event::ParticipationsController do
           participation = assigns(:participations).first
           expect(participation.answers).to be_loaded
           expect(participation.person.phone_numbers).to be_loaded
-        }.to make(87).db_queries
+        }.to make(92).db_queries
       end
     end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -450,6 +450,31 @@ describe EventsController do
         expect(q2.reload.sensitive).to eq false
       end
 
+      it "persists visible_role_types on application and admin questions" do
+        q1 = event.questions.create!(question: "Who?", required: false)
+        q2 = event.questions.create!(question: "Payed?", required: false, admin: true)
+
+        put :update, params: {
+          group_id: group.id,
+          id: event.id,
+          event: {
+            name: "testevent",
+            application_questions_attributes: {
+              q1.id.to_s => {id: q1.id, question: "Who?", required: false,
+                             visible_role_types: [Event::Role::Cook.sti_name]}
+            },
+            admin_questions_attributes: {
+              q2.id.to_s => {id: q2.id, question: "Payed?", required: false,
+                             visible_role_types: [Event::Role::Helper.sti_name]}
+            }
+          }
+        }
+
+        expect(assigns(:event)).to be_valid
+        expect(q1.reload.visible_role_types).to eq [Event::Role::Cook.sti_name]
+        expect(q2.reload.visible_role_types).to eq [Event::Role::Helper.sti_name]
+      end
+
       it "question choices stay deleted when form is invalid after deleting all choices" do
         q1 = event.questions.create!(question: "Who?", required: false, choices: "all,some")
         q2 = event.questions.create!(question: "Payed?", required: false, admin: true, choices: "yes,no")
@@ -613,6 +638,36 @@ describe EventsController do
 
       expect(event.reload.visible_contact_attributes).not_to include("name")
       expect(event.reload.visible_contact_attributes).to include("email")
+    end
+  end
+
+  context "question visibility fields" do
+    render_views
+    let(:dom) { Capybara::Node::Simple.new(response.body) }
+    let(:course) { Fabricate(:course, groups: [group]) }
+
+    let(:application_question) do
+      Fabricate(:event_question, event: course, admin: false, question: "Shoe size?")
+    end
+
+    let(:admin_question) do
+      Fabricate(:event_question, event: course, admin: true, question: "Allergies?")
+    end
+
+    before do
+      application_question.update!(visible_role_types: [Event::Role::Cook.sti_name])
+      admin_question
+      sign_in(people(:top_leader))
+    end
+
+    it "renders a disabled, checked checkbox for participations_full roles and reflects " \
+      "the configured visibility for other roles" do
+      get :edit, params: {group_id: group.id, id: course.id}
+
+      expect(dom).to have_field(Event::Role::Leader.label, disabled: true, checked: true)
+      expect(dom).to have_field(Event::Role::AssistantLeader.label, disabled: true, checked: true)
+      expect(dom).to have_field(Event::Role::Cook.label, checked: true)
+      expect(dom).to have_field(Event::Role::Helper.label, checked: false)
     end
   end
 

--- a/spec/domain/event/question/visible_list_spec.rb
+++ b/spec/domain/event/question/visible_list_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, CEVI Regionalverband ZH-SH-GL. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+describe Event::Question::VisibleList do
+  let(:event) { Fabricate(:event, groups: [groups(:top_group)]) }
+  let(:cook_question) do
+    Fabricate(:event_question, event:, question: "Cook question").tap do |q|
+      q.update!(visible_role_types: [Event::Role::Cook.sti_name])
+    end
+  end
+  let(:unconfigured_question) do
+    Fabricate(:event_question, event:, question: "Unconfigured question")
+  end
+
+  before do
+    cook_question
+    unconfigured_question
+  end
+
+  describe "#questions" do
+    def questions_seen_by(person, participation = nil)
+      described_class.new(event:, ability: Ability.new(person), participation:).questions
+    end
+
+    it "returns none of the event's questions without access" do
+      expect(questions_seen_by(people(:bottom_member))).to be_empty
+    end
+
+    it "returns all of the event's questions" do
+      expect(questions_seen_by(people(:top_leader))).to match_array([cook_question, unconfigured_question])
+    end
+
+    it "returns only the question configured as visible to that role" do
+      participation = Fabricate(:event_participation, event:)
+      Fabricate(Event::Role::Cook.sti_name, participation:)
+      expect(questions_seen_by(participation.person)).to eq [cook_question]
+    end
+
+    context "for a specific participation" do
+      let(:participation) { Fabricate(:event_participation, event:) }
+      let!(:admin_question) do
+        Fabricate(:event_question, event:, admin: true, question: "Admin question")
+      end
+
+      it "returns all non-admin questions for participant" do
+        questions = questions_seen_by(participation.person, participation)
+        expect(questions).to match_array([cook_question, unconfigured_question])
+      end
+
+      it "includes the admin question if visible to participants role" do
+        admin_question.update!(visible_role_types: [Event::Role::Cook.sti_name])
+        Fabricate(Event::Role::Cook.sti_name, participation:)
+        expect(questions_seen_by(participation.person, participation)).to include(admin_question)
+      end
+
+      it "returns all questions when the viewer has show_full on the participation" do
+        Fabricate(Event::Role::Leader.sti_name, participation:)
+        questions = questions_seen_by(participation.person, participation)
+        expect(questions).to match_array([cook_question, unconfigured_question, admin_question])
+      end
+
+      it "returns only visible questions for a role viewing someone else's participation" do
+        cook_participation = Fabricate(:event_participation, event:)
+        Fabricate(Event::Role::Cook.sti_name, participation: cook_participation)
+
+        questions = questions_seen_by(cook_participation.person, participation)
+        expect(questions).to eq [cook_question]
+      end
+    end
+
+    describe "loading, ordering and chaching" do
+      it "orders questions the same way as Event::Question.list" do
+        Event::Question.list_alphabetically = true
+        list = described_class.new(event:, ability: Ability.new(people(:top_leader)))
+
+        expect(list.questions.map(&:question)).to eq ["Cook question", "Unconfigured question"]
+      ensure
+        Event::Question.list_alphabetically = false
+      end
+
+      it "only queries question_visibilities once, not per question" do
+        Fabricate(:event_question, event:, question: "Another cook question")
+          .update!(visible_role_types: [Event::Role::Cook.sti_name])
+
+        cook_participation = Fabricate(:event_participation, event:)
+        Fabricate(Event::Role::Cook.sti_name, participation: cook_participation)
+
+        expect {
+          questions_seen_by(cook_participation.person)
+        }.to make.db_queries.with("Event::QuestionVisibility Load" => 1)
+      end
+
+      it "reuses shared cache to avoid requerying questions/role_types for another participation" do
+        cook_participation = Fabricate(:event_participation, event:)
+        Fabricate(Event::Role::Cook.sti_name, participation: cook_participation)
+
+        ability = Ability.new(cook_participation.person)
+        cache = {}
+        described_class.new(participation: cook_participation, event:, ability:, cache:).questions
+
+        other_participation = Fabricate(:event_participation, event:)
+        Fabricate(Event::Role::Cook.sti_name, participation: other_participation)
+        list = described_class.new(participation: other_participation, event:, ability:, cache:)
+
+        expect { list.questions }.to make.db_queries.with(
+          "Event::Question Load" => 0, "Event::QuestionVisibility Load" => 0
+        )
+      end
+
+      it "still resolves full_access? independently per participation, even when sharing a cache" do
+        admin_question = Fabricate(:event_question, event:, admin: true, question: "Admin question")
+        full_access_participation = Fabricate(:event_participation, event:)
+        no_access_participation = Fabricate(:event_participation, event:)
+
+        ability = Ability.new(people(:top_leader))
+
+        allow(ability).to receive(:can?).and_wrap_original do |original, permission, subject|
+          next false if permission == :show_full && subject == no_access_participation
+
+          original.call(permission, subject)
+        end
+        cache = {}
+
+        full_list = described_class.new(participation: full_access_participation, event:, ability:, cache:)
+        no_access_list = described_class.new(participation: no_access_participation, event:, ability:, cache:)
+
+        expect(full_list.questions).to include(admin_question)
+        expect(no_access_list.questions).not_to include(admin_question)
+      end
+    end
+  end
+
+  describe "#answers" do
+    let(:participation) { Fabricate(:event_participation, event:) }
+    let(:list) do
+      described_class.new(
+        event:, ability: Ability.new(participation.person), participation: participation
+      )
+    end
+
+    it "matches answers to the visible, ordered questions" do
+      answers = list.answers(participation.answers.to_a)
+
+      expect(answers.map(&:question_id)).to eq [cook_question.id, unconfigured_question.id]
+    end
+
+    it "reuses the preloaded question so accessing it does not trigger another query" do
+      answers = list.answers(participation.answers.to_a)
+
+      expect(answers.first.question).to equal(list.questions.first)
+    end
+
+    it "excludes answers whose question is not visible" do
+      cook_participation = Fabricate(:event_participation, event:)
+      Fabricate(Event::Role::Cook.sti_name, participation: cook_participation)
+
+      cook_list = described_class.new(ability: Ability.new(cook_participation.person), event:, participation:)
+      answers = cook_list.answers(participation.answers.to_a)
+
+      expect(answers.map(&:question_id)).to eq [cook_question.id]
+    end
+  end
+end

--- a/spec/domain/event/question/visible_list_spec.rb
+++ b/spec/domain/event/question/visible_list_spec.rb
@@ -72,6 +72,15 @@ describe Event::Question::VisibleList do
         questions = questions_seen_by(cook_participation.person, participation)
         expect(questions).to eq [cook_question]
       end
+
+      it "considers event roles held by a managed person (Elternzugang)" do
+        Fabricate(Event::Role::Cook.sti_name, participation:)
+        manager = Fabricate(:person)
+        PeopleManager.create!(manager:, managed: participation.person)
+
+        questions = questions_seen_by(manager, participation)
+        expect(questions).to eq [cook_question]
+      end
     end
 
     describe "loading, ordering and chaching" do

--- a/spec/domain/export/csv/people/participations_full_spec.rb
+++ b/spec/domain/export/csv/people/participations_full_spec.rb
@@ -8,13 +8,14 @@ require "csv"
 
 describe Export::Tabular::People::ParticipationsFull do
   let(:person) { people(:top_leader) }
+  let(:ability) { Ability.new(person) }
   let(:participation) { Fabricate(:event_participation, participant: person, event: events(:top_course)) }
   let(:scope) do
     participations = Event::Participation.where(id: participation.id)
     Event::Participation::PreloadParticipations.preload(participations)
     participations
   end
-  let(:people_list) { Export::Tabular::People::ParticipationsFull.new(scope) }
+  let(:people_list) { Export::Tabular::People::ParticipationsFull.new(scope, ability) }
 
   subject { people_list.attribute_labels }
 
@@ -44,7 +45,7 @@ describe Export::Tabular::People::ParticipationsFull do
   end
 
   context "integration" do
-    let(:data) { Export::Tabular::People::ParticipationsFull.export(:csv, scope) }
+    let(:data) { Export::Tabular::People::ParticipationsFull.export(:csv, scope, ability) }
     let(:data_without_bom) { data.gsub(Regexp.new("^#{Export::Csv::UTF8_BOM}"), "") }
     let(:csv) { CSV.parse(data_without_bom, headers: true, col_sep: Settings.csv.separator) }
     let(:full_headers) do

--- a/spec/domain/export/pdf/participation/specifics_spec.rb
+++ b/spec/domain/export/pdf/participation/specifics_spec.rb
@@ -78,4 +78,49 @@ describe Export::Pdf::Participation::Specifics do
       ].pretty_inspect
     end
   end
+
+  context "answer visibility" do
+    let(:event) { Fabricate(:event, groups: [groups(:top_group)]) }
+    let(:question) { Fabricate(:event_question, event: event) }
+    let(:answer) { participation.answers.find_by!(question: question) }
+
+    before do
+      answer.update!(answer: "some answer")
+    end
+
+    it "shows the answer to the participant themself" do
+      described_class.new(pdf, participation, viewer: person).render
+      expect(text_with_position.flatten).to include("some answer")
+    end
+
+    it "shows the answer to a viewer with full access via other means" do
+      viewer = people(:top_leader)
+      allow(viewer).to receive(:event_role_types_for).with(event).and_return([])
+      described_class.new(pdf, participation, viewer: viewer).render
+
+      expect(text_with_position.flatten).to include("some answer")
+    end
+
+    describe "event role defined access" do
+      let(:cook) { people(:bottom_member) }
+
+      before do
+        allow(cook).to receive(:event_role_types_for).with(event).and_return([Event::Role::Cook])
+      end
+
+      it "hides the answer from a cook" do
+        described_class.new(pdf, participation, viewer: cook).render
+
+        expect(text_with_position.flatten).not_to include("some answer")
+      end
+
+      it "shows the answer to a cook because of defined visible_role" do
+        question.visible_role_types = [Event::Role::Cook.sti_name]
+        question.save!
+
+        described_class.new(pdf, participation, viewer: cook).render
+        expect(text_with_position.flatten).to include("some answer")
+      end
+    end
+  end
 end

--- a/spec/domain/export/tabular/people/participations_full_spec.rb
+++ b/spec/domain/export/tabular/people/participations_full_spec.rb
@@ -24,12 +24,54 @@ describe Export::Tabular::People::ParticipationsFull do
   context "questions" do
     let(:participation) { Fabricate(:event_participation, participant: person, event: events(:top_course)) }
     let(:question) { events(:top_course).questions.first }
+    let(:people_list) { Export::Tabular::People::ParticipationsFull.new(scope, Ability.new(person)) }
 
     before { participation.init_answers }
 
     it "has keys and values" do
       expect(subject[:"question_#{event_questions(:top_ov).id}"]).to eq "GA oder Halbtax?"
       expect(subject.keys.count { |key| key =~ /question/ }).to eq(3)
+    end
+  end
+
+  context "answer visibility" do
+    let(:event) { Fabricate(:event, groups: [groups(:top_group)]) }
+    let(:participation) { Fabricate(:event_participation, participant: person, event: event) }
+    let(:question) { Fabricate(:event_question, event: event) }
+    let(:viewer) { Fabricate(:person) }
+    let(:ability) { Ability.new(viewer) }
+    let(:people_list) { Export::Tabular::People::ParticipationsFull.new(scope, ability) }
+
+    before do
+      question
+      participation
+    end
+
+    it "excludes the question column when the viewer has no matching role" do
+      allow(viewer).to receive(:event_role_types_for).with(event).and_return([Event::Role::Cook])
+
+      expect(subject.keys).not_to include(:"question_#{question.id}")
+    end
+
+    it "includes the question column when the viewer has a matching role" do
+      question.visible_role_types = [Event::Role::Cook.sti_name]
+      question.save!
+      allow(viewer).to receive(:event_role_types_for).with(event).and_return([Event::Role::Cook])
+
+      expect(subject.keys).to include(:"question_#{question.id}")
+    end
+
+    it "includes the question column for Event::Role::Leader" do
+      allow(viewer).to receive(:event_role_types_for).with(event).and_return([Event::Role::Leader])
+
+      expect(subject.keys).to include(:"question_#{question.id}")
+    end
+
+    it "includes the question column for a viewer with full access via other means (e.g. group admin)" do
+      allow(viewer).to receive(:event_role_types_for).with(event).and_return([])
+      allow(ability).to receive(:can?).with(:index_full_participations, event).and_return(true)
+
+      expect(subject.keys).to include(:"question_#{question.id}")
     end
   end
 end

--- a/spec/domain/table_displays/event/participations/question_column_spec.rb
+++ b/spec/domain/table_displays/event/participations/question_column_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, CEVI Regionalverband ZH-SH-GL. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+describe TableDisplays::Event::Participations::QuestionColumn do
+  let(:event) { Fabricate(:event, groups: [groups(:top_group)]) }
+  let(:cook_question) do
+    Fabricate(:event_question, event: event, question: "Cook question").tap do |q|
+      q.update!(visible_role_types: [Event::Role::Cook.sti_name])
+    end
+  end
+  let(:unconfigured_question) do
+    Fabricate(:event_question, event: event, question: "Unconfigured question")
+  end
+  let(:attr) { "event_question_#{cook_question.id}" }
+  let(:unconfigured_attr) { "event_question_#{unconfigured_question.id}" }
+
+  # the viewer holds a Cook role and browses a table listing OTHER participants' rows -
+  # distinct from the viewer's own participation, so the "own participation" bypass in
+  # Event::Question::VisibleList does not interfere with these role-based checks
+  let(:viewer_participation) { Fabricate(:event_participation, event: event) }
+  let(:ability) { Ability.new(viewer_participation.person) }
+  let(:column) { described_class.new(ability, model_class: Event::Participation) }
+
+  let(:other_participation) { Fabricate(:event_participation, event: event) }
+  let(:another_participation) { Fabricate(:event_participation, event: event) }
+
+  before do
+    cook_question
+    unconfigured_question
+    Fabricate(Event::Role::Cook.sti_name, participation: viewer_participation)
+  end
+
+  describe "#allowed?" do
+    it "shows a question configured as visible to the viewer's role" do
+      allowed = column.send(:allowed?, other_participation, attr, other_participation, attr)
+
+      expect(allowed).to eq true
+    end
+
+    it "hides a question not configured as visible to the viewer's role" do
+      allowed = column.send(
+        :allowed?, other_participation, unconfigured_attr, other_participation, unconfigured_attr
+      )
+
+      expect(allowed).to eq false
+    end
+
+    it "reuses the event's questions and the viewer's role types across participations of the " \
+      "same event (no N+1 across rows of a table render)" do
+      column.send(:allowed?, other_participation, attr, other_participation, attr)
+      another_participation
+
+      expect {
+        column.send(:allowed?, another_participation, attr, another_participation, attr)
+      }.to make.db_queries.with("Event::Question Load" => 0, "Event::QuestionVisibility Load" => 0)
+    end
+  end
+end

--- a/spec/fabricators/event/question_visibility_fabricator.rb
+++ b/spec/fabricators/event/question_visibility_fabricator.rb
@@ -1,0 +1,9 @@
+#  Copyright (c) 2026, CEVI Regionalverband ZH-SH-GL. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+Fabricator(:event_question_visibility, class_name: "Event::QuestionVisibility") do
+  question
+  role_type { Event::Role::Cook.sti_name }
+end

--- a/spec/migrations/create_event_question_visibilities_spec.rb
+++ b/spec/migrations/create_event_question_visibilities_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, CEVI Regionalverband ZH-SH-GL. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "rails_helper"
+require_relative "../../db/migrate/20260708160000_create_event_question_visibilities"
+
+RSpec.describe CreateEventQuestionVisibilities, type: :migration do
+  let(:migration_context) { ActiveRecord::Base.connection_pool.migration_context }
+  let(:migration_version) { 20260708160000 }
+  let(:previous_version) do
+    versions = migration_context.migrations.map(&:version)
+    index = versions.index(migration_version)
+    (index > 0) ? versions[index - 1] : 0
+  end
+
+  let(:expected_role_types) do
+    Event::Role.descendants
+      .select { |role_type| role_type.permissions.include?(:participations_read_details) }
+      .map(&:sti_name)
+  end
+
+  before do
+    ActiveRecord::Migration.verbose = false
+    migration_context.down(previous_version)
+    ActiveRecord::Base.connection.schema_cache.clear!
+    ActiveRecord::Base.descendants.each(&:reset_column_information)
+  end
+
+  after do
+    migration_context.up
+    ActiveRecord::Base.connection.schema_cache.clear!
+    ActiveRecord::Base.descendants.each(&:reset_column_information)
+    ActiveRecord::Migration.verbose = true
+  end
+
+  def backfilled_role_types(question)
+    ActiveRecord::Base.connection.select_all(
+      "SELECT role_type FROM event_question_visibilities WHERE question_id = #{question.id}"
+    ).rows.flatten
+  end
+
+  it "backfills existing questions with the roles that today grant show_details" do
+    question = Fabricate(:event_question, event: events(:top_course))
+
+    migration_context.up(migration_version)
+
+    expect(backfilled_role_types(question)).to match_array(expected_role_types)
+  end
+
+  it "does not backfill roles without the participations_read_details permission" do
+    question = Fabricate(:event_question, event: events(:top_course))
+
+    migration_context.up(migration_version)
+
+    expect(backfilled_role_types(question)).not_to include(
+      Event::Role::Leader.sti_name,
+      Event::Role::AssistantLeader.sti_name,
+      Event::Role::Speaker.sti_name,
+      Event::Role::Treasurer.sti_name,
+      Event::Role::Participant.sti_name
+    )
+  end
+
+  it "backfills every existing question, not just newly created ones" do
+    question_1 = Fabricate(:event_question, event: events(:top_course))
+    question_2 = Fabricate(:event_question, event: events(:top_course))
+
+    migration_context.up(migration_version)
+
+    expect(backfilled_role_types(question_1)).to match_array(expected_role_types)
+    expect(backfilled_role_types(question_2)).to match_array(expected_role_types)
+  end
+end

--- a/spec/models/event/question_spec.rb
+++ b/spec/models/event/question_spec.rb
@@ -251,6 +251,84 @@ describe Event::Question do
     end
   end
 
+  describe "role visibility" do
+    describe "#visible_role_types" do
+      it "defaults a new question to the roles that today have show_details permission" do
+        question = described_class.new(question: "Test?", required: false)
+
+        expect(question.visible_role_types).to match_array(
+          [Event::Role::Cook.sti_name, Event::Role::Helper.sti_name]
+        )
+      end
+
+      it "does not default an already persisted question with no configured roles" do
+        question = events(:top_course).questions.create!(question: "Test?", required: false)
+
+        expect(question.reload.visible_role_types).to eq []
+      end
+
+      it "does not apply the default once roles have been explicitly assigned" do
+        question = described_class.new(question: "Test?", required: false)
+        question.visible_role_types = []
+
+        expect(question.visible_role_types).to eq []
+      end
+    end
+
+    describe "#visible_role_types=" do
+      subject(:question) { described_class.new(question: "Test?", required: false) }
+
+      it "ignores blank entries submitted alongside checked roles" do
+        question.visible_role_types = ["", Event::Role::Cook.sti_name]
+
+        expect(question.visible_role_types).to eq [Event::Role::Cook.sti_name]
+        expect(question.question_visibilities).to all(be_valid)
+      end
+
+      it "results in an empty list when only the blank entry is submitted" do
+        question.visible_role_types = [""]
+
+        expect(question.visible_role_types).to eq []
+      end
+    end
+
+    describe "#visible_to?" do
+      subject(:question) { described_class.new(question: "Test?", required: false) }
+
+      it "is always visible to roles with the participations_full permission" do
+        expect(question.visible_to?([Event::Role::Leader])).to eq true
+        expect(question.visible_to?([Event::Role::AssistantLeader])).to eq true
+      end
+
+      it "is not visible to other roles when no roles are configured as visible" do
+        question.visible_role_types = []
+
+        expect(question.visible_to?([Event::Role::Cook])).to eq false
+        expect(question.visible_to?([Event::Role::Speaker])).to eq false
+      end
+
+      it "is visible to roles explicitly configured as visible" do
+        question.visible_role_types = [Event::Role::Cook.sti_name]
+
+        expect(question.visible_to?([Event::Role::Cook])).to eq true
+        expect(question.visible_to?([Event::Role::Speaker])).to eq false
+      end
+
+      it "is not visible when the viewer has no matching role at all" do
+        question.visible_role_types = [Event::Role::Cook.sti_name]
+
+        expect(question.visible_to?([])).to eq false
+      end
+
+      it "is always visible when the caller signals full_access, regardless of roles" do
+        question.visible_role_types = []
+
+        expect(question.visible_to?([], full_access: true)).to eq true
+        expect(question.visible_to?([Event::Role::Speaker], full_access: true)).to eq true
+      end
+    end
+  end
+
   context "paper trails", versioning: true do
     let(:event) { events(:top_course) }
 

--- a/spec/models/event/question_spec.rb
+++ b/spec/models/event/question_spec.rb
@@ -273,6 +273,12 @@ describe Event::Question do
 
         expect(question.visible_role_types).to eq []
       end
+
+      it "defaults a new admin question to no roles" do
+        question = described_class.new(admin: true, question: "Test?", required: false)
+
+        expect(question.visible_role_types).to eq []
+      end
     end
 
     describe "#visible_role_types=" do

--- a/spec/models/event/question_visibility_spec.rb
+++ b/spec/models/event/question_visibility_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, CEVI Regionalverband ZH-SH-GL. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+describe Event::QuestionVisibility do
+  let(:question) { events(:top_course).questions.first }
+
+  subject(:visibility) { described_class.new(question: question) }
+
+  it "is valid for a staff Event::Role type" do
+    visibility.role_type = Event::Role::Cook.sti_name
+
+    expect(visibility).to be_valid
+  end
+
+  it "is invalid for roles with the participations_full permission, as they are implicitly always visible" do
+    visibility.role_type = Event::Role::Leader.sti_name
+    expect(visibility).not_to be_valid
+
+    visibility.role_type = Event::Role::AssistantLeader.sti_name
+    expect(visibility).not_to be_valid
+  end
+
+  it "is invalid for an unknown role type" do
+    visibility.role_type = "Event::Role::DoesNotExist"
+
+    expect(visibility).not_to be_valid
+  end
+
+  describe ".selectable_role_types_for" do
+    it "falls back to the base Event role types when no event is given" do
+      role_types = described_class.selectable_role_types_for(event: nil, admin: false)
+
+      expect(role_types).to eq described_class.selectable_role_types_for(event: Event, admin: false)
+    end
+  end
+end

--- a/spec/models/event/role_spec.rb
+++ b/spec/models/event/role_spec.rb
@@ -18,6 +18,21 @@ describe Event::Role do
     end
   end
 
+  describe ".participations_full?" do
+    it "is true for roles with the participations_full permission" do
+      expect(Event::Role::Leader.participations_full?).to eq true
+      expect(Event::Role::AssistantLeader.participations_full?).to eq true
+    end
+
+    it "is false for roles without the participations_full permission" do
+      expect(Event::Role::Cook.participations_full?).to eq false
+      expect(Event::Role::Helper.participations_full?).to eq false
+      expect(Event::Role::Speaker.participations_full?).to eq false
+      expect(Event::Role::Treasurer.participations_full?).to eq false
+      expect(Event::Role::Participant.participations_full?).to eq false
+    end
+  end
+
   context "save together with participation" do
     let(:course) do
       course = Fabricate(:course, groups: [groups(:top_layer)], kind: event_kinds(:slk))

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -900,6 +900,26 @@ describe Event do
       d = event.duplicate
       expect(d.group_ids.size).to eq(2)
     end
+
+    it "copies a configured question visibility instead of falling back to the default" do
+      question = Fabricate(:event_question, event: event)
+      question.update!(visible_role_types: [Event::Role::Cook.sti_name])
+
+      d = event.duplicate
+
+      duplicated = d.application_questions.detect { |q| q.question == question.question }
+      expect(duplicated.visible_role_types).to eq [Event::Role::Cook.sti_name]
+    end
+
+    it "copies an explicitly empty question visibility instead of falling back to the default" do
+      question = Fabricate(:event_question, event: event, admin: true)
+      question.update!(visible_role_types: [])
+
+      d = event.duplicate
+
+      duplicated = d.admin_questions.detect { |q| q.question == question.question }
+      expect(duplicated.visible_role_types).to eq []
+    end
   end
 
   context "group timestamps" do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -965,6 +965,26 @@ describe Event do
       d = event.duplicate
       expect(d.group_ids.size).to eq(2)
     end
+
+    it "copies a configured question visibility instead of falling back to the default" do
+      question = Fabricate(:event_question, event: event)
+      question.update!(visible_role_types: [Event::Role::Cook.sti_name])
+
+      d = event.duplicate
+
+      duplicated = d.application_questions.detect { |q| q.question == question.question }
+      expect(duplicated.visible_role_types).to eq [Event::Role::Cook.sti_name]
+    end
+
+    it "copies an explicitly empty question visibility instead of falling back to the default" do
+      question = Fabricate(:event_question, event: event, admin: true)
+      question.update!(visible_role_types: [])
+
+      d = event.duplicate
+
+      duplicated = d.admin_questions.detect { |q| q.question == question.question }
+      expect(duplicated.visible_role_types).to eq []
+    end
   end
 
   context "group timestamps" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1164,4 +1164,27 @@ describe Person do
       expect { person.update!(last_name: "Newname") }.not_to change { person.tags.reload.count }
     end
   end
+
+  describe "#event_role_types_for" do
+    let(:event) { events(:top_course) }
+    let(:other_event) { Fabricate(:event, groups: [groups(:top_group)]) }
+    let(:person) { people(:top_leader) }
+
+    it "returns the Event::Role classes held for the given event" do
+      participation = Fabricate(:event_participation, event:, participant: person)
+      Fabricate(Event::Role::Cook.name.to_sym, participation:)
+      Fabricate(Event::Role::Helper.name.to_sym, participation:)
+
+      expect(person.event_role_types_for(event)).to match_array(
+        [Event::Role::Cook, Event::Role::Helper]
+      )
+    end
+
+    it "does not return roles held for a different event" do
+      participation = Fabricate(:event_participation, event: other_event, participant: person)
+      Fabricate(Event::Role::Cook.name.to_sym, participation:)
+
+      expect(person.event_role_types_for(event)).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
Previously answer visibility were hardcoded, now this is configurable for
application as well as admin questions.

Defaults are kept in place via migration and prepopulated via
Event::Question#defautl_visible_role_types for new events.

The new data model `Event::QuestionVisibility` is populate through
`Event::Question` and a new domain class
`Event::Question::VisibilityList` is responsible for loading, sorting
and filtering the question depending on the viewer. All call sites of
answers (view, table displays, exports) have been updated to use the new
domain model
