### PR TITLE
Add grouping overview-page for settings

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026-2026, Schweizer Alpen-Club. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class AdminsController < ApplicationController
+  skip_authorization_check only: :show
+  before_action :authorize_action, only: :show
+
+  def show
+  end
+
+  private
+
+  def authorize_action
+    authorize!(:update_settings, current_person)
+  end
+end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -40,9 +40,10 @@ module NavigationHelper
        invoice_runs?]},
 
     {label: :admin,
-     url: :label_formats_path,
+     url: :admin_path,
      icon_name: "cog",
-     active_for: %w[self_registration_reasons
+     active_for: %w[admin
+       self_registration_reasons
        label_formats
        custom_contents
        event_kinds
@@ -57,7 +58,7 @@ module NavigationHelper
        hitobito_log_entries
        mails/imap mails/bounces
        api],
-     if: ->(_) { can?(:index, LabelFormat) }}
+     if: ->(_) { can?(:update_settings, current_person) }}
   ]
 
   def render_main_nav

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -6,7 +6,7 @@
 #  https://github.com/hitobito/hitobito.
 
 module NavigationHelper
-  MAIN = [ # rubocop:disable Style/MutableConstant extended in wagons
+  MAIN = [
     {label: :groups,
      url: :groups_path,
      icon_name: "users",
@@ -46,7 +46,7 @@ module NavigationHelper
      if: ->(_) { can?(:update_settings, current_person) }}
   ]
 
-  ADMIN_GROUPS = { # rubocop:disable Style/MutableConstant extended in wagons
+  ADMIN_GROUPS = {
     main: {
       heading: "admins.show.main",
       items: [
@@ -58,12 +58,10 @@ module NavigationHelper
           path: :oauth_active_authorizations_path,
           if: ->(_) { current_user.oauth_applications.exists? }),
         Item.new(model: ActsAsTaggableOn::Tag, path: :tags_path),
-        Item.new(model: PersonalDocumentLabel,
-          path: :personal_document_labels_path,
-          if: ->(_) {
-            FeatureGate.enabled?("personal_documents") && can?(:index, PersonalDocumentLabel)
-          })
-      ]
+        FeatureGate.if("personal_documents") do
+          Item.new(model: PersonalDocumentLabel, path: :personal_document_labels_path)
+        end
+      ].compact_blank
     },
     info: {
       heading: "admins.show.info",

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -42,24 +42,82 @@ module NavigationHelper
     {label: :admin,
      url: :admin_path,
      icon_name: "cog",
-     active_for: %w[admin
-       self_registration_reasons
-       label_formats
-       custom_contents
-       event_kinds
-       event_kind_categories
-       qualification_kinds
-       oauth/applications
-       help_texts
-       oauth/active_authorizations
-       event_feed
-       tags
-       personal_document_labels
-       hitobito_log_entries
-       mails/imap mails/bounces
-       api],
+     active_for: ->(_) { admin_active_for_paths },
      if: ->(_) { can?(:update_settings, current_person) }}
   ]
+
+  ADMIN_GROUPS = { # rubocop:disable Style/MutableConstant extended in wagons
+    main: {
+      heading: "admins.show.main",
+      items: [
+        Item.new(model: LabelFormat, path: :label_formats_path),
+        Item.new(model: CustomContent, path: :custom_contents_path),
+        Item.new(model: HelpText, path: :help_texts_path),
+        Item.new(model: Oauth::Application, path: :oauth_applications_path),
+        Item.new(label: "navigation.admin/oauth_authorizations",
+          path: :oauth_active_authorizations_path,
+          if: ->(_) { current_user.oauth_applications.exists? }),
+        Item.new(model: ActsAsTaggableOn::Tag, path: :tags_path),
+        Item.new(model: PersonalDocumentLabel,
+          path: :personal_document_labels_path,
+          if: ->(_) {
+            FeatureGate.enabled?("personal_documents") && can?(:index, PersonalDocumentLabel)
+          })
+      ]
+    },
+    info: {
+      heading: "admins.show.info",
+      items: [
+        Item.new(label: "json_api", path: :api_path),
+        Item.new(label: "navigation.imap_mails",
+          path: ->(_) { imap_mails_path(mailbox: "inbox") },
+          active_for: "mails/imap",
+          if: ->(_) { can?(:manage, Imap::Mail) }),
+        Item.new(label: "navigation.admin/event_feed",
+          path: :event_feed_path,
+          if: ->(_) { can?(:update, current_user) }),
+        Item.new(label: "hitobito_log_entries.index.title",
+          path: :hitobito_log_entries_path,
+          if: ->(_) { can?(:index, HitobitoLogEntry) })
+      ]
+    },
+    events: {
+      heading: "admins.show.events",
+      items: [
+        Item.new(model: Event::Kind, path: :event_kinds_path),
+        Item.new(model: Event::KindCategory, path: :event_kind_categories_path),
+        Item.new(model: QualificationKind, path: :qualification_kinds_path)
+      ]
+    },
+    people: {
+      heading: "admins.show.people",
+      items: [
+        Item.new(model: SelfRegistrationReason, path: :self_registration_reasons_path)
+      ]
+    }
+  }
+
+  # Unfiltered by visibility on purpose as evaluated on every page and only affects highlighting
+  def admin_active_for_paths
+    ADMIN_GROUPS.values.flat_map { |group| group[:items] }
+      .map { |item| item.active_for(self) }
+  end
+
+  def admin_current_group_key
+    ADMIN_GROUPS.find do |_key, group|
+      group[:items].any? { |item| item.visible?(self) && item.current?(self) }
+    end&.first
+  end
+
+  def admin_groups_by_heading
+    ADMIN_GROUPS.sort_by { |_key, group| t(group[:heading]) }
+  end
+
+  # A group's visible items, sorted by their translated label.
+  def admin_group_items(group)
+    group[:items].select { |item| item.visible?(self) }
+      .sort_by { |item| item.label(self) }
+  end
 
   def render_main_nav
     content_tag_nested(:ul, MAIN, class: "nav-left-list") do |options|
@@ -71,13 +129,17 @@ module NavigationHelper
 
   def main_nav_section(options)
     url = send(options[:url])
-    active = section_active?(url, options[:active_for], options[:inactive_for])
+    active = section_active?(url, resolve_active_for(options[:active_for]), options[:inactive_for])
     classes = "nav-left-section"
     classes += " active" if active
     content_tag(:li, class: classes) do
       concat(link_to(icon(options[:icon_name]) + I18n.t("navigation.#{options[:label]}"), url))
       concat(sheet.render_left_nav) if active && sheet.left_nav?
     end
+  end
+
+  def resolve_active_for(active_for)
+    active_for.is_a?(Proc) ? instance_eval(&active_for) : active_for
   end
 
   def nav(label, url, active_for = [], inactive_for = [])

--- a/app/helpers/navigation_helper/item.rb
+++ b/app/helpers/navigation_helper/item.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
+module NavigationHelper
+  class Item
+    attr_reader :model, :label_key, :path, :condition, :active_for_override
+
+    def initialize(**attrs)
+      @model = attrs[:model]
+      @path = attrs.fetch(:path)
+      @label_key = attrs[:label]
+      @condition = attrs[:if]
+      @active_for_override = attrs[:active_for]
+    end
+
+    def visible?(view)
+      if condition
+        view.instance_eval(&condition)
+      elsif model
+        view.can?(:index, model)
+      else
+        true
+      end
+    end
+
+    def label(view)
+      label_key ? view.t(label_key) : model.model_name.human(count: 2)
+    end
+
+    def url(view)
+      path.is_a?(Proc) ? view.instance_eval(&path) : view.send(path)
+    end
+
+    def active_for(view)
+      active_for_override || url(view).delete_prefix("/").split("?").first
+    end
+
+    def current?(view)
+      view.send(:section_active?, url(view), [active_for(view)])
+    end
+  end
+end

--- a/app/helpers/sheet/admin.rb
+++ b/app/helpers/sheet/admin.rb
@@ -6,7 +6,7 @@
 module Sheet
   class Admin < Base
     def title
-      I18n.t("navigation.admin")
+      super.presence || I18n.t("navigation.admin")
     end
 
     def left_nav?

--- a/app/helpers/sheet/admin.rb
+++ b/app/helpers/sheet/admin.rb
@@ -5,6 +5,10 @@
 
 module Sheet
   class Admin < Base
+    def title
+      I18n.t("navigation.admin")
+    end
+
     def left_nav?
       true
     end

--- a/app/helpers/sheet/admin.rb
+++ b/app/helpers/sheet/admin.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.

--- a/app/javascript/stylesheets/hitobito/modules/_nav_left.scss
+++ b/app/javascript/stylesheets/hitobito/modules/_nav_left.scss
@@ -88,11 +88,8 @@
   .divider {
     display: block;
     color: $gray-darker;
-    text-transform: uppercase;
-    font-size: 0.7rem;
     padding-left: $nav-left-padding-full;
-    margin-top: 1rem;
-    margin-left: 3px;
+    margin-top: 0.2rem;
   }
 
   .nav-left-section-link~.divider,

--- a/app/views/admins/show.html.haml
+++ b/app/views/admins/show.html.haml
@@ -1,0 +1,69 @@
+.row
+  .col-xl-3.col-lg-4.col-md-6.col-sm-12
+    %h2= t(".main")
+    %ul.container
+      - if can?(:index, LabelFormat)
+        %li
+          = link_to LabelFormat.model_name.human(count: 2), label_formats_path
+      - if can?(:index, CustomContent)
+        %li
+          = link_to CustomContent.model_name.human(count: 2), custom_contents_path
+      - if can?(:index, HelpText)
+        %li
+          = link_to HelpText.model_name.human(count: 2), help_texts_path
+      - if can?(:index, Oauth::Application)
+        %li
+          = link_to Oauth::Application.model_name.human(count: 2), oauth_applications_path
+      - if current_user.oauth_applications.exists?
+        %li
+          = link_to t('navigation.admin/oauth_authorizations'), oauth_active_authorizations_path
+      - if can?(:index, ActsAsTaggableOn::Tag)
+        %li
+          = link_to ActsAsTaggableOn::Tag.model_name.human(count: 2), tags_path
+
+      = render_extensions(:admin_main)
+
+  .col-xl-3.col-lg-4.col-md-6.col-sm-12
+    %h2= t(".info")
+    %ul.container
+      %li
+        = link_to t('json_api'), api_path
+      - if can?(:manage, Imap::Mail)
+        %li
+          = link_to t('navigation.imap_mails'), imap_mails_path(mailbox: 'inbox')
+      - if can?(:update, current_user)
+        %li
+          = link_to t('navigation.admin/event_feed'), event_feed_path
+      - if can?(:index, HitobitoLogEntry)
+        %li
+          = link_to t('hitobito_log_entries.index.title'), hitobito_log_entries_path
+
+      = render_extensions(:admin_info)
+
+  .col-xl-3.col-lg-4.col-md-6.col-sm-12
+    %h2= t(".events")
+    %ul.container
+      = render_extensions(:admin_event)
+
+      - if can?(:index, Event::Kind)
+        %li
+          = link_to Event::Kind.model_name.human(count: 2), event_kinds_path
+      - if can?(:index, Event::KindCategory)
+        %li
+          = link_to Event::KindCategory.model_name.human(count: 2), event_kind_categories_path
+      - if can?(:index, QualificationKind)
+        %li
+          = link_to QualificationKind.model_name.human(count: 2), qualification_kinds_path
+
+      = render_extensions(:admin_kinds)
+
+  .col-xl-3.col-lg-4.col-md-6.col-sm-12
+    %h2= t(".people")
+    %ul.container
+      - if can?(:index, SelfRegistrationReason)
+        %li
+          = link_to SelfRegistrationReason.model_name.human(count: 2), self_registration_reasons_path
+
+      = render_extensions(:admin_people)
+
+  = render_extensions(:admin_setting_groups)

--- a/app/views/admins/show.html.haml
+++ b/app/views/admins/show.html.haml
@@ -1,69 +1,75 @@
-.row
-  .col-xl-3.col-lg-4.col-md-6.col-sm-12
-    %h2= t(".main")
-    %ul.container
-      - if can?(:index, LabelFormat)
-        %li
-          = link_to LabelFormat.model_name.human(count: 2), label_formats_path
-      - if can?(:index, CustomContent)
-        %li
-          = link_to CustomContent.model_name.human(count: 2), custom_contents_path
-      - if can?(:index, HelpText)
-        %li
-          = link_to HelpText.model_name.human(count: 2), help_texts_path
-      - if can?(:index, Oauth::Application)
-        %li
-          = link_to Oauth::Application.model_name.human(count: 2), oauth_applications_path
-      - if current_user.oauth_applications.exists?
-        %li
-          = link_to t('navigation.admin/oauth_authorizations'), oauth_active_authorizations_path
-      - if can?(:index, ActsAsTaggableOn::Tag)
-        %li
-          = link_to ActsAsTaggableOn::Tag.model_name.human(count: 2), tags_path
+-#  Copyright (c) 2026 Schweizer Alpen-Club SAC. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
 
-      = render_extensions(:admin_main)
+.container
+  .row.row-cols-1.row-cols-sm-2.row-cols-md-3.row-cols-lg-4
+    .col
+      %h2= t(".main")
+      %ul.container
+        - if can?(:index, LabelFormat)
+          %li
+            = link_to LabelFormat.model_name.human(count: 2), label_formats_path
+        - if can?(:index, CustomContent)
+          %li
+            = link_to CustomContent.model_name.human(count: 2), custom_contents_path
+        - if can?(:index, HelpText)
+          %li
+            = link_to HelpText.model_name.human(count: 2), help_texts_path
+        - if can?(:index, Oauth::Application)
+          %li
+            = link_to Oauth::Application.model_name.human(count: 2), oauth_applications_path
+        - if current_user.oauth_applications.exists?
+          %li
+            = link_to t('navigation.admin/oauth_authorizations'), oauth_active_authorizations_path
+        - if can?(:index, ActsAsTaggableOn::Tag)
+          %li
+            = link_to ActsAsTaggableOn::Tag.model_name.human(count: 2), tags_path
 
-  .col-xl-3.col-lg-4.col-md-6.col-sm-12
-    %h2= t(".info")
-    %ul.container
-      %li
-        = link_to t('json_api'), api_path
-      - if can?(:manage, Imap::Mail)
+        = render_extensions(:admin_main)
+
+    .col
+      %h2= t(".info")
+      %ul.container
         %li
-          = link_to t('navigation.imap_mails'), imap_mails_path(mailbox: 'inbox')
-      - if can?(:update, current_user)
-        %li
-          = link_to t('navigation.admin/event_feed'), event_feed_path
-      - if can?(:index, HitobitoLogEntry)
-        %li
-          = link_to t('hitobito_log_entries.index.title'), hitobito_log_entries_path
+          = link_to t('json_api'), api_path
+        - if can?(:manage, Imap::Mail)
+          %li
+            = link_to t('navigation.imap_mails'), imap_mails_path(mailbox: 'inbox')
+        - if can?(:update, current_user)
+          %li
+            = link_to t('navigation.admin/event_feed'), event_feed_path
+        - if can?(:index, HitobitoLogEntry)
+          %li
+            = link_to t('hitobito_log_entries.index.title'), hitobito_log_entries_path
 
-      = render_extensions(:admin_info)
+        = render_extensions(:admin_info)
 
-  .col-xl-3.col-lg-4.col-md-6.col-sm-12
-    %h2= t(".events")
-    %ul.container
-      = render_extensions(:admin_event)
+    .col
+      %h2= t(".events")
+      %ul.container
+        = render_extensions(:admin_event)
 
-      - if can?(:index, Event::Kind)
-        %li
-          = link_to Event::Kind.model_name.human(count: 2), event_kinds_path
-      - if can?(:index, Event::KindCategory)
-        %li
-          = link_to Event::KindCategory.model_name.human(count: 2), event_kind_categories_path
-      - if can?(:index, QualificationKind)
-        %li
-          = link_to QualificationKind.model_name.human(count: 2), qualification_kinds_path
+        - if can?(:index, Event::Kind)
+          %li
+            = link_to Event::Kind.model_name.human(count: 2), event_kinds_path
+        - if can?(:index, Event::KindCategory)
+          %li
+            = link_to Event::KindCategory.model_name.human(count: 2), event_kind_categories_path
+        - if can?(:index, QualificationKind)
+          %li
+            = link_to QualificationKind.model_name.human(count: 2), qualification_kinds_path
 
-      = render_extensions(:admin_kinds)
+        = render_extensions(:admin_kinds)
 
-  .col-xl-3.col-lg-4.col-md-6.col-sm-12
-    %h2= t(".people")
-    %ul.container
-      - if can?(:index, SelfRegistrationReason)
-        %li
-          = link_to SelfRegistrationReason.model_name.human(count: 2), self_registration_reasons_path
+    .col
+      %h2= t(".people")
+      %ul.container
+        - if can?(:index, SelfRegistrationReason)
+          %li
+            = link_to SelfRegistrationReason.model_name.human(count: 2), self_registration_reasons_path
 
-      = render_extensions(:admin_people)
+        = render_extensions(:admin_people)
 
-  = render_extensions(:admin_setting_groups)
+    = render_extensions(:admin_setting_groups)

--- a/app/views/admins/show.html.haml
+++ b/app/views/admins/show.html.haml
@@ -5,71 +5,11 @@
 
 .container
   .row.row-cols-1.row-cols-sm-2.row-cols-md-3.row-cols-lg-4
-    .col
-      %h2= t(".main")
-      %ul.container
-        - if can?(:index, LabelFormat)
-          %li
-            = link_to LabelFormat.model_name.human(count: 2), label_formats_path
-        - if can?(:index, CustomContent)
-          %li
-            = link_to CustomContent.model_name.human(count: 2), custom_contents_path
-        - if can?(:index, HelpText)
-          %li
-            = link_to HelpText.model_name.human(count: 2), help_texts_path
-        - if can?(:index, Oauth::Application)
-          %li
-            = link_to Oauth::Application.model_name.human(count: 2), oauth_applications_path
-        - if current_user.oauth_applications.exists?
-          %li
-            = link_to t('navigation.admin/oauth_authorizations'), oauth_active_authorizations_path
-        - if can?(:index, ActsAsTaggableOn::Tag)
-          %li
-            = link_to ActsAsTaggableOn::Tag.model_name.human(count: 2), tags_path
-
-        = render_extensions(:admin_main)
-
-    .col
-      %h2= t(".info")
-      %ul.container
-        %li
-          = link_to t('json_api'), api_path
-        - if can?(:manage, Imap::Mail)
-          %li
-            = link_to t('navigation.imap_mails'), imap_mails_path(mailbox: 'inbox')
-        - if can?(:update, current_user)
-          %li
-            = link_to t('navigation.admin/event_feed'), event_feed_path
-        - if can?(:index, HitobitoLogEntry)
-          %li
-            = link_to t('hitobito_log_entries.index.title'), hitobito_log_entries_path
-
-        = render_extensions(:admin_info)
-
-    .col
-      %h2= t(".events")
-      %ul.container
-        = render_extensions(:admin_event)
-
-        - if can?(:index, Event::Kind)
-          %li
-            = link_to Event::Kind.model_name.human(count: 2), event_kinds_path
-        - if can?(:index, Event::KindCategory)
-          %li
-            = link_to Event::KindCategory.model_name.human(count: 2), event_kind_categories_path
-        - if can?(:index, QualificationKind)
-          %li
-            = link_to QualificationKind.model_name.human(count: 2), qualification_kinds_path
-
-        = render_extensions(:admin_kinds)
-
-    .col
-      %h2= t(".people")
-      %ul.container
-        - if can?(:index, SelfRegistrationReason)
-          %li
-            = link_to SelfRegistrationReason.model_name.human(count: 2), self_registration_reasons_path
-
-        = render_extensions(:admin_people)
-
-    = render_extensions(:admin_setting_groups)
+    - admin_groups_by_heading.each do |_key, group|
+      - items = admin_group_items(group)
+      - next if items.empty?
+      .col
+        %h2= t(group[:heading])
+        %ul.container
+          - items.each do |item|
+            %li= link_to item.label(self), item.url(self)

--- a/app/views/admins/show.html.haml
+++ b/app/views/admins/show.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-.container
+.container{style: 'margin-left: 1rem'}
   .row.row-cols-1.row-cols-sm-2.row-cols-md-3.row-cols-lg-4
     - admin_groups_by_heading.each do |_key, group|
       - items = admin_group_items(group)

--- a/app/views/custom_contents/_actions_index.html.haml
+++ b/app/views/custom_contents/_actions_index.html.haml
@@ -2,4 +2,3 @@
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
-

--- a/app/views/shared/_admin_left_nav.html.haml
+++ b/app/views/shared/_admin_left_nav.html.haml
@@ -1,44 +1,18 @@
--#  Copyright (c) 2012-2019, Jungwacht Blauring Schweiz. This file is part of
+-#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
 %ul.nav-left-list
-  - if can?(:index, LabelFormat)
-    = nav LabelFormat.model_name.human(count: 2), label_formats_path, %w(label_formats)
-  - if can?(:update, current_user)
-    = nav t('navigation.admin/event_feed'), event_feed_path, %w(event_feed)
-  - if can?(:index, CustomContent)
-    = nav CustomContent.model_name.human(count: 2), custom_contents_path, %w(custom_contents)
-  - if can?(:index, HelpText)
-    = nav HelpText.model_name.human(count: 2), help_texts_path, %w(help_texts)
-  - if can?(:index, SelfRegistrationReason)
-    = nav SelfRegistrationReason.model_name.human(count: 2), self_registration_reasons_path, %w(self_registration_reasons)
-
-  = render_extensions(:admin_nav_main)
-
-  - if can?(:index, Event::Kind)
-    = nav Event::Kind.model_name.human(count: 2), event_kinds_path, %w(event_kinds)
-  - if can?(:index, Event::KindCategory)
-    = nav Event::KindCategory.model_name.human(count: 2), event_kind_categories_path, %w(event_kind_categories)
-  - if can?(:index, QualificationKind)
-    = nav QualificationKind.model_name.human(count: 2), qualification_kinds_path, %w(qualification_kinds)
-
-  = render_extensions(:admin_nav_event)
-
-  - if can?(:index, Oauth::Application)
-    = nav Oauth::Application.model_name.human(count: 2), oauth_applications_path, %w(oauth_applications)
-  - if current_user.oauth_applications.exists?
-    = nav t('navigation.admin/oauth_authorizations'), oauth_active_authorizations_path, %w(oauth_active_authorizations)
-  - if can?(:index, ActsAsTaggableOn::Tag)
-    = nav ActsAsTaggableOn::Tag.model_name.human(count: 2), tags_path, %w(tags)
-  - if FeatureGate.enabled?("personal_documents") && can?(:index, PersonalDocumentLabel)
-    = nav PersonalDocumentLabel.model_name.human(count: 2), personal_document_labels_path, %w(personal_document_labels)
-  - if can?(:manage, Imap::Mail)
-    = nav t('navigation.imap_mails'), imap_mails_path(mailbox: 'inbox'), %w(mails/imap_mails mails/bounces)
-  - if can?(:index, HitobitoLogEntry)
-    = nav t('hitobito_log_entries.index.title'), hitobito_log_entries_path
-
-  = render_extensions(:admin_nav_kinds)
-
-  = nav t('json_api'), api_path
+  - current_group_key = admin_current_group_key
+  - admin_groups_by_heading.each do |key, group|
+    - items = admin_group_items(group)
+    - next if items.empty?
+    - dom_id = "admin-nav-group-#{key}"
+    %li.divider
+      %a.inline{href: "##{dom_id}", data: {bs_toggle: :collapse}}
+        = t(group[:heading])
+    %li.collapse{id: dom_id, class: (key == current_group_key ? "show" : nil)}
+      %ul.nav-left-list
+        - items.each do |item|
+          = nav item.label(self), item.url(self), Array(item.active_for(self))

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -134,6 +134,13 @@ de:
         success: "%{model} wurde erfolgreich gelöscht."
         failure: "%{model} konnte nicht gelöscht werden."
 
+  admins:
+    show:
+      main: Allgemein
+      info: Information
+      events: Anlässe und Kurse
+      people: Mitgliederverwaltung
+
   blocked:
     index:
       title: Login gesperrt

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,8 @@ Hitobito::Application.routes.draw do
   end
 
   language_scope do
+    resource :admin, only: :show
+
     namespace :oauth do
       resource :profile, only: :show
       resources :applications do

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -14,6 +14,9 @@ auth:
 address_sync:
   enabled: true
 
+personal_documents:
+  enabled: true
+
 payment_providers:
   - name: postfinance-test
     url: https://isotest.postfinance.ch/ebicsweb/ebicsweb

--- a/spec/features/admin_left_nav_spec.rb
+++ b/spec/features/admin_left_nav_spec.rb
@@ -21,7 +21,8 @@ describe :admin_left_nav, js: true do
       it "is visible if self registration is enabled" do
         allow(FeatureGate).to receive(:enabled?).with(:self_registration_reason).and_return(true)
         visit path
-        expect(page.find("nav#page-navigation")).to have_link(href: self_registration_reasons_path)
+        expect(page.find("nav#page-navigation"))
+          .to have_link(href: self_registration_reasons_path, visible: :all)
       end
     end
 

--- a/spec/features/oauth_workflow_spec.rb
+++ b/spec/features/oauth_workflow_spec.rb
@@ -17,6 +17,7 @@ describe "OauthWorkflow", js: true do
     visit root_path
     within("#page-navigation") do
       click_link "Einstellungen"
+      click_link "Allgemein"
       click_link "OAuth Applikationen"
     end
     click_link "Erstellen"

--- a/spec/helpers/navigation_helper/item_spec.rb
+++ b/spec/helpers/navigation_helper/item_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
+require "spec_helper"
+
+describe NavigationHelper::Item do
+  let(:view) { double("view") }
+
+  describe "#initialize" do
+    it "requires a :path" do
+      expect { described_class.new(model: LabelFormat) }.to raise_error(KeyError)
+    end
+  end
+
+  describe "#visible?" do
+    context "with an :if condition" do
+      subject(:item) do
+        described_class.new(path: :imap_mails_path, if: ->(_) { can?(:manage, Imap::Mail) })
+      end
+
+      it "is visible when the condition evaluates to true in the view's context" do
+        allow(view).to receive(:can?).with(:manage, Imap::Mail).and_return(true)
+        expect(item.visible?(view)).to eq(true)
+      end
+
+      it "is hidden when the condition evaluates to false" do
+        allow(view).to receive(:can?).with(:manage, Imap::Mail).and_return(false)
+        expect(item.visible?(view)).to eq(false)
+      end
+    end
+
+    context "with a :model and no :if" do
+      subject(:item) { described_class.new(model: LabelFormat, path: :label_formats_path) }
+
+      it "defaults to can?(:index, model)" do
+        allow(view).to receive(:can?).with(:index, LabelFormat).and_return(true)
+        expect(item.visible?(view)).to eq(true)
+      end
+
+      it "is hidden when can?(:index, model) is false" do
+        allow(view).to receive(:can?).with(:index, LabelFormat).and_return(false)
+        expect(item.visible?(view)).to eq(false)
+      end
+    end
+
+    context "with neither :if nor :model" do
+      subject(:item) { described_class.new(label: "json_api", path: :api_path) }
+
+      it "is always visible" do
+        expect(item.visible?(view)).to eq(true)
+      end
+    end
+  end
+
+  describe "#label" do
+    it "translates the :label key when given" do
+      allow(view).to receive(:t).with("json_api").and_return("JSON API")
+      item = described_class.new(label: "json_api", path: :api_path)
+
+      expect(item.label(view)).to eq("JSON API")
+    end
+
+    it "falls back to the model's human name when no :label is given" do
+      item = described_class.new(model: LabelFormat, path: :label_formats_path)
+      expect(item.label(view)).to eq(LabelFormat.model_name.human(count: 2))
+    end
+  end
+
+  describe "#url" do
+    it "sends a symbol :path to the view" do
+      allow(view).to receive(:label_formats_path).and_return("/label_formats")
+      item = described_class.new(model: LabelFormat, path: :label_formats_path)
+
+      expect(item.url(view)).to eq("/label_formats")
+    end
+
+    it "evaluates a proc :path in the view's context" do
+      allow(view).to receive(:imap_mails_path)
+        .with(mailbox: "inbox").and_return("/mails/imap/inbox")
+      item = described_class.new(path: ->(_) { imap_mails_path(mailbox: "inbox") })
+
+      expect(item.url(view)).to eq("/mails/imap/inbox")
+    end
+  end
+
+  describe "#active_for" do
+    it "uses the explicit :active_for override when given" do
+      item = described_class.new(path: :imap_mails_path, active_for: "mails/imap")
+      expect(item.active_for(view)).to eq("mails/imap")
+    end
+
+    it "derives the fragment from the url otherwise" do
+      allow(view).to receive(:label_formats_path).and_return("/de/label_formats")
+      item = described_class.new(model: LabelFormat, path: :label_formats_path)
+
+      expect(item.active_for(view)).to eq("de/label_formats")
+    end
+
+    it "strips a query string from a derived url" do
+      allow(view).to receive(:api_path).and_return("/api?locale=de")
+      item = described_class.new(label: "json_api", path: :api_path)
+
+      expect(item.active_for(view)).to eq("api")
+    end
+  end
+
+  describe "#current?" do
+    it "delegates to the view's section_active? with the item's url and active_for" do
+      allow(view).to receive(:label_formats_path).and_return("/label_formats")
+      item = described_class.new(model: LabelFormat, path: :label_formats_path)
+
+      expect(view).to receive(:section_active?)
+        .with("/label_formats", ["label_formats"]).and_return(true)
+
+      expect(item.current?(view)).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
This adds a new overview-page with several extension-points. Most mirror the existing ones from the left navigation in the admin-section.

For new wagon-specific contexts, there is a generic extension-point to add more groups.

See hitobito/hitobito_sac_cas#2325