### PR TITLE
JobObservation must be reused when rescheduling (hitobito/hitobito_sac_cas#2582)

### DIFF
--- a/app/jobs/concerns/observable_job.rb
+++ b/app/jobs/concerns/observable_job.rb
@@ -24,11 +24,7 @@ module ObservableJob
     return super unless enqueueing_person
 
     ActiveRecord::Base.transaction do
-      job_observation = JobObservation.create!(
-        person: enqueueing_person, job_class: self.class.name,
-        reports_progress:, filename: @options&.dig(:filename),
-        filetype: @format, max_attempts: try(:max_attempts)
-      )
+      job_observation = find_or_create_job_observation(enqueueing_person)
       @job_observation_id = job_observation.id
 
       delayed_job = super
@@ -66,5 +62,19 @@ module ObservableJob
 
   def job_observation
     @job_observation ||= JobObservation.find(@job_observation_id)
+  end
+
+  private
+
+  # Reuse the observation if this job instance was already enqueued once (e.g. rescheduled by
+  # BackgroundJobs::LimitConcurrentExecutions) instead of creating a duplicate.
+  def find_or_create_job_observation(enqueueing_person)
+    return JobObservation.find(@job_observation_id) if @job_observation_id
+
+    JobObservation.create!(
+      person: enqueueing_person, job_class: self.class.name,
+      reports_progress:, filename: @options&.dig(:filename),
+      filetype: @format, max_attempts: try(:max_attempts)
+    )
   end
 end

--- a/spec/features/job_observations_spec.rb
+++ b/spec/features/job_observations_spec.rb
@@ -81,9 +81,9 @@ describe :job_observations, js: true do
   it "should update pagination when jobs are enqueued" do
     allow(Kaminari.config).to receive(:default_per_page).and_return(2)
 
-    job = Test::SuccessfulObservableJob.new
+    job_class = Test::SuccessfulObservableJob
     2.times do
-      delayed_job = job.enqueue!
+      delayed_job = job_class.new.enqueue!
       JobObservation.where(delayed_job:).update!(job_class: "FirstJob")
     end
 
@@ -94,7 +94,7 @@ describe :job_observations, js: true do
       expect(page).to have_content("First job", count: 2)
       expect(page).not_to have_content("Letzte")
 
-      delayed_job = job.enqueue!
+      delayed_job = job_class.new.enqueue!
       JobObservation.where(delayed_job:).update!(job_class: "SecondJob")
 
       expect(page).to have_content("First job", count: 1)
@@ -107,7 +107,7 @@ describe :job_observations, js: true do
       expect(page).not_to have_content("Second job")
       expect(page).to have_content("Erste")
 
-      delayed_job = job.enqueue!
+      delayed_job = job_class.new.enqueue!
       JobObservation.where(delayed_job:).update!(job_class: "SecondJob")
 
       expect(page).to have_content("First job", count: 2)

--- a/spec/jobs/concerns/observable_job_spec.rb
+++ b/spec/jobs/concerns/observable_job_spec.rb
@@ -188,7 +188,7 @@ describe ObservableJob do
       allow(Auth).to receive(:current_person).and_return(person)
     end
 
-    it "creates a new observation if new job instance job is scheduled twice" do
+    it "creates a new observation for each enqueued job instance of the same job class" do
       expect { Test::SuccessfulObservableJob.new.enqueue! }.to change { JobObservation.count }.by(1)
       expect { Test::SuccessfulObservableJob.new.enqueue! }.to change { JobObservation.count }.by(1)
     end

--- a/spec/jobs/concerns/observable_job_spec.rb
+++ b/spec/jobs/concerns/observable_job_spec.rb
@@ -193,16 +193,32 @@ describe ObservableJob do
       expect { Test::SuccessfulObservableJob.new.enqueue! }.to change { JobObservation.count }.by(1)
     end
 
-    it "updates existing observation if same job instance is re-scheduled as done by LimitConcurrentExecutions" do
-      job = Test::SuccessfulObservableJob.new
-      job.enqueue!
-      observation = job.job_observation
+    context "when limited to single concurrent execution" do
+      before do
+        allow(Settings.delayed_jobs.concurrency).to receive(:jobs).and_return(%w[Test::SuccessfulObservableJob])
 
-      rescheduled_job = nil
-      expect { rescheduled_job = job.enqueue! }.not_to change { JobObservation.count }
+        locked = Test::SuccessfulObservableJob.new
+        locked_record = locked.enqueue!
+        locked_record.update!(locked_at: Time.zone.now, locked_by: "dummy-worker")
 
-      expect(job.job_observation).to eq observation
-      expect(observation.reload.delayed_job).to eq rescheduled_job
+        @blocked = Test::SuccessfulObservableJob.new
+        @blocked_record = @blocked.enqueue!
+
+        expect(locked.job_observation).not_to eq(@blocked.job_observation)
+      end
+
+      it "reschedules using existing observation" do
+        expect do
+          Delayed::Worker.new.work_off
+        end.to not_change { Delayed::Job.count }
+          .and not_change { JobObservation.count }
+
+        # the second blocked job gets destroyed and re-scheduled
+        expect { @blocked_record.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+        rescheduled = Delayed::Job.find_by("locked_at IS NULL and handler LIKE '%Test::SuccessfulObservableJob%'")
+        expect(rescheduled.payload_object.job_observation).to eq(@blocked.job_observation)
+      end
     end
   end
 

--- a/spec/jobs/concerns/observable_job_spec.rb
+++ b/spec/jobs/concerns/observable_job_spec.rb
@@ -183,6 +183,29 @@ describe ObservableJob do
     end
   end
 
+  context "re-enqueueing the same job instance" do
+    before do
+      allow(Auth).to receive(:current_person).and_return(person)
+    end
+
+    it "creates a new observation if new job instance job is scheduled twice" do
+      expect { Test::SuccessfulObservableJob.new.enqueue! }.to change { JobObservation.count }.by(1)
+      expect { Test::SuccessfulObservableJob.new.enqueue! }.to change { JobObservation.count }.by(1)
+    end
+
+    it "updates existing observation if same job instance is re-scheduled as done by LimitConcurrentExecutions" do
+      job = Test::SuccessfulObservableJob.new
+      job.enqueue!
+      observation = job.job_observation
+
+      rescheduled_job = nil
+      expect { rescheduled_job = job.enqueue! }.not_to change { JobObservation.count }
+
+      expect(job.job_observation).to eq observation
+      expect(observation.reload.delayed_job).to eq rescheduled_job
+    end
+  end
+
   context "job observation id" do
     it "has job_observation_id in the parameters array of all observable jobs", :aggregate_failures do
       Rails.autoloaders.main.eager_load_dir("app/jobs")


### PR DESCRIPTION
Gewisse Jobs werden rescheduled, solange noch ein job von diesem Typ läuft 

https://github.com/hitobito/hitobito/blob/34d21d5d3695ab37858b0cdf14e3fc193f5ac8f1/app/domain/background_jobs/limit_concurrent_executions.rb#L38

Das ist bei den Observations noch nicht berücksicht gewesen und hat dazu geführt, dass dafür immer neue Observations erstellt wurden.

Das wir hier enqueuen ist aber grundsätzlich richtig, da ein `update(run_at: next_run_at)` einem "erfoglreichen" Run entspricht und der job somit vom Worker gelöscht werden würde