### PR TITLE
Match UI permissions when reading event participants in the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Umgebungsspezifische Meta Tags können über die Settings konfigurativ hinzugefügt werden (#4405)
 - Anlass E-Mails verwenden die E-Mail der Kontaktperson als Reply-To (opt-in) (#2881)
-- Rechungen können nach Herkunft (Einzel, Rechnungslauf, Sammelrechnung) gefiltert werden (hitobito/hitobito_sww#296)
+- Rechungen können nach Herkunft (Einzel, Rechnungslauf, Sammelrechnung) gefiltert werden (sww#296)
+- In der JSON:API können die gleichen Personendaten von Eventteilnehmern abgerufen werden wie im UI (pbs#466)
 
 ## Version 2.10
 

--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ gem "sentry-delayed_job"
 
 # load after others because dependencies
 gem "kaminari"
-gem "graphiti-openapi", github: "puzzle/graphiti-openapi", tag: "standalone/0.6.7"
+gem "graphiti-openapi", github: "puzzle/graphiti-openapi", tag: "standalone/0.6.8"
 
 gem "active_storage_validations" # validate filesize, dimensions and content-type of uploads
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/puzzle/graphiti-openapi.git
-  revision: f4ee80f5eb26b05c0033805d6e4f4e2407a49c61
-  tag: standalone/0.6.7
+  revision: 8bf9aa028fb05f0eaf8c46501ac7c7ecc8477da8
+  tag: standalone/0.6.8
   specs:
     graphiti-openapi (0.6.6)
       activemodel

--- a/app/abilities/ability_dsl/user_context.rb
+++ b/app/abilities/ability_dsl/user_context.rb
@@ -57,6 +57,11 @@ module AbilityDsl
       @course_offerers ||= Group.course_offerers.pluck(:id)
     end
 
+    def participation_details_person_ids
+      @participation_details_person_ids ||=
+        participation_details_participations.distinct.pluck(:participant_id).to_set
+    end
+
     private
 
     def init_permission_lookup_tables
@@ -148,6 +153,12 @@ module AbilityDsl
     def find_events_with_permission(permission)
       participations.select { |p| p.roles.any? { |r| r.class.permissions.include?(permission) } }
         .collect(&:event_id)
+    end
+
+    def participation_details_participations
+      ::Event::Participation
+        .accessible_by(JsonApi::EventParticipationDetailsAbility.new(user))
+        .where(participant_type: ::Person.sti_name)
     end
   end
 end

--- a/app/abilities/ability_dsl/user_context.rb
+++ b/app/abilities/ability_dsl/user_context.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -57,9 +57,15 @@ module AbilityDsl
       @course_offerers ||= Group.course_offerers.pluck(:id)
     end
 
+    # In hitobito/hitobito_pbs#466, cbe and ama found no easy better place to put this.
+    # It is a complex calculation which needs to be cached in the request context,
+    # similar to course_offerers which we already have here.
+    def participation_details_people
+      ::Person.where(id: participation_details_participations.select(:participant_id))
+    end
+
     def participation_details_person_ids
-      @participation_details_person_ids ||=
-        participation_details_participations.distinct.pluck(:participant_id).to_set
+      @participation_details_person_ids ||= participation_details_people.pluck(:id).to_set
     end
 
     private

--- a/app/abilities/json_api/contact_account_ability.rb
+++ b/app/abilities/json_api/contact_account_ability.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2023, Schweizer Wanderwege. This file is part of
+#  Copyright (c) 2023-2026, Schweizer Wanderwege. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -8,6 +8,8 @@
 module JsonApi
   class ContactAccountAbility
     include CanCan::Ability
+
+    delegate :participation_details_people, to: :user_context
 
     CONTACT_ACCOUNT_MODELS = [
       AdditionalEmail,
@@ -19,32 +21,28 @@ module JsonApi
     def initialize(user)
       @user = user
 
-      # Person ContactAccounts
-      # allow reading public contacts of people on which the user has :show permission
-      can :read, CONTACT_ACCOUNT_MODELS,
-        public: true, contactable: readable_people
+      # Allow access to all public contact accounts, since we don't have endpoints to list all
+      can :read, CONTACT_ACCOUNT_MODELS, public: true
       # allow reading all contacts of people on which the user has :show_details permissions
       can :read, CONTACT_ACCOUNT_MODELS, contactable: details_readable_people
+      # allow reading all contacts of people whose participation details are readable
+      can :read, CONTACT_ACCOUNT_MODELS, contactable: participation_details_people
+      # allow reading all contacts of groups on which the user has :show_details permissions
+      can :read, CONTACT_ACCOUNT_MODELS, contactable: details_readable_groups
 
       can :create, CONTACT_ACCOUNT_MODELS, contactable: details_writable_people
 
       can :update, CONTACT_ACCOUNT_MODELS, contactable: details_writable_people
 
       can :destroy, CONTACT_ACCOUNT_MODELS, contactable: details_writable_people
-
-      # Group ContactAccounts
-      can :read, CONTACT_ACCOUNT_MODELS, public: true, contactable: readable_groups
-
-      can :read, CONTACT_ACCOUNT_MODELS, contactable: details_readable_groups
     end
 
     private
 
     attr_reader :user
 
-    def readable_people
-      Person.accessible_by(PersonReadables.new(user))
-        .unscope(:select)
+    def user_context
+      @user_context ||= AbilityDsl::UserContext.new(user)
     end
 
     def details_readable_people
@@ -56,10 +54,6 @@ module JsonApi
       details_readable_people
         .accessible_by(PersonWritables.new(user))
         .unscope(:select)
-    end
-
-    def readable_groups
-      Group.accessible_by(GroupReadables.new(user))
     end
 
     def details_readable_groups

--- a/app/abilities/json_api/event_participation_ability.rb
+++ b/app/abilities/json_api/event_participation_ability.rb
@@ -21,7 +21,8 @@ module JsonApi
     def initialize(user)
       @user_context = AbilityDsl::UserContext.new(user)
 
-      define_abilities_from_person
+      define_abilities_from_person if user.id
+      define_abilities_from_service_token_or_person
     end
 
     private
@@ -32,18 +33,18 @@ module JsonApi
       :permission_layer_ids, :permission_group_ids, to: :user_context
 
     def define_abilities_from_person # rubocop:disable Metrics/AbcSize
-      if user.id
-        # herself
-        can_read_if(participant_type: "Person", participant_id: user.id)
+      # herself
+      can_read_if(participant_type: "Person", participant_id: user.id)
 
-        # guests
-        can_read_if(participant_type: "Event::Guest", participant_id: guests_for_user.select(:id))
+      # guests
+      can_read_if(participant_type: "Event::Guest", participant_id: guests_for_user.select(:id))
 
-        # managers
-        can_read_if(participant_type: "Person",
-          participant_id: user.people_manageds.select(:managed_id))
-      end
+      # managers
+      can_read_if(participant_type: "Person",
+        participant_id: user.people_manageds.select(:managed_id))
+    end
 
+    def define_abilities_from_service_token_or_person
       # from event roles and event.participations_visible
       can_read_if(event_id: participation_read_events)
 

--- a/app/abilities/json_api/event_participation_ability.rb
+++ b/app/abilities/json_api/event_participation_ability.rb
@@ -9,6 +9,15 @@ module JsonApi
   class EventParticipationAbility
     include CanCan::Ability
 
+    class_attribute :event_role_permissions, default: [:participations_read,
+      :participations_read_details, :participations_full, :event_full]
+    class_attribute :layer_and_below_permissions, default: [:layer_and_below_read]
+    class_attribute :group_and_below_permissions, default: [:group_and_below_read]
+    class_attribute :layer_permissions, default: [:layer_read]
+    class_attribute :group_permissions, default: [:group_read]
+    class_attribute :include_visible_participations, default: true
+    class_attribute :include_pending_applications, default: true
+
     def initialize(user)
       @user_context = AbilityDsl::UserContext.new(user)
 
@@ -38,17 +47,18 @@ module JsonApi
       # from event roles and event.participations_visible
       can_read_if(event_id: participation_read_events)
 
-      # from layer_and_below_read and group_and_below roles (subtree)
+      # from layer_and_below_* and group_and_below_* roles
       can_read_if(event: {groups: {lft: self_and_below_lft_ranges}})
 
-      # from layer_read (within_layer)
-      can_read_if(event: {groups: {layer_group_id: permission_layer_ids(:layer_read)}})
+      # from layer_* roles (within_layer)
+      can_read_if(event: {groups: {layer_group_id: permission_layer_ids(*layer_permissions)}})
 
-      # from group_read
-      can_read_if(event: {groups: {id: permission_group_ids(:group_read)}})
+      # from group_* roles
+      can_read_if(event: {groups: {id: permission_group_ids(*group_permissions)}})
 
       # from pending applications
-      if (permission_layer_ids(:layer_read, :layer_and_below_read) & course_offerers).any?
+      if include_pending_applications &&
+          (permission_layer_ids(:layer_read, :layer_and_below_read) & course_offerers).any?
         can_read_if(active: false, application_id: pending_applications.select(:id))
       end
     end
@@ -62,12 +72,16 @@ module JsonApi
     def pending_applications = ::Event::Application
       .where("waiting_list IS true OR priority_2_id IS NOT NULL OR priority_3_id IS NOT NULL")
 
-    def participation_read_events =
-      @participation_read_events ||=
-        active_participations.where(events: {participations_visible: true}).pluck(:event_id) +
-        events_with_permission(:participations_read) +
-        events_with_permission(:participations_full) +
-        events_with_permission(:event_full).uniq
+    def participation_read_events
+      @participation_read_events ||= (visible_participation_events +
+        event_role_permissions.flat_map { |permission| events_with_permission(permission) }).uniq
+    end
+
+    def visible_participation_events
+      return [] unless include_visible_participations
+
+      active_participations.where(events: {participations_visible: true}).pluck(:event_id)
+    end
 
     def active_participations = user.event_participations.active.joins(:event)
 
@@ -75,9 +89,13 @@ module JsonApi
       permissions.flat_map { |permission| user_context.permission_layer_ids(permission) }
     end
 
+    def permission_group_ids(*permissions)
+      permissions.flat_map { |permission| user_context.permission_group_ids(permission) }
+    end
+
     def self_and_below_lft_ranges
-      group_ids = permission_layer_ids(:layer_and_below_read) +
-        permission_group_ids(:group_and_below_read)
+      group_ids = permission_layer_ids(*layer_and_below_permissions) +
+        permission_group_ids(*group_and_below_permissions)
 
       Group
         .where(id: group_ids)

--- a/app/abilities/json_api/event_participation_details_ability.rb
+++ b/app/abilities/json_api/event_participation_details_ability.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
+module JsonApi
+  class EventParticipationDetailsAbility < EventParticipationAbility
+    self.event_role_permissions = [:participations_read_details, :participations_full]
+    self.layer_and_below_permissions = [:layer_and_below_full]
+    self.group_and_below_permissions = [:group_and_below_full]
+    self.layer_permissions = [:layer_full]
+    self.group_permissions = [:group_full]
+    self.include_visible_participations = false
+    self.include_pending_applications = false
+  end
+end

--- a/app/resources/event/participation_resource.rb
+++ b/app/resources/event/participation_resource.rb
@@ -28,7 +28,8 @@ class Event::ParticipationResource < ApplicationResource
   belongs_to :event
   polymorphic_belongs_to :participant do
     group_by(:participant_type) do
-      on(:Person)
+      on(:Person).belongs_to :person, resource: PersonResource,
+        base_scope: ::Person.all # hitobito/hitobito_pbs#466
       on(:"Event::Guest")
     end
   end

--- a/app/resources/event_resource.rb
+++ b/app/resources/event_resource.rb
@@ -40,7 +40,8 @@ class EventResource < ApplicationResource
     attribute :updated_at, :datetime, filterable: true
   end
 
-  belongs_to :contact, resource: PersonResource, writable: false
+  belongs_to :contact, resource: PersonResource, writable: false,
+    base_scope: ::Person.all # hitobito/hitobito_pbs#466
   belongs_to :kind, resource: Event::KindResource, writable: false
   has_many :dates, resource: Event::DateResource, writable: false
   has_many :participations, resource: Event::ParticipationResource, writable: false

--- a/app/resources/person_resource.rb
+++ b/app/resources/person_resource.rb
@@ -43,7 +43,7 @@ class PersonResource < ApplicationResource
     @object.decorate.picture_full_url
   end
   attribute :updated_at, :datetime
-  attribute :additional_information, :string
+  attribute :additional_information, :string, readable: :show_details?
 
   belongs_to :primary_group, resource: GroupResource, writable: false
 
@@ -75,12 +75,11 @@ class PersonResource < ApplicationResource
   private
 
   def show_details?(model_instance)
-    can?(:show_details, model_instance)
+    can?(:show_details, model_instance) ||
+      current_ability.user_context.participation_details_person_ids.include?(model_instance.id)
   end
 
   def write_details?
-    # no model_instance method argument is given when writable is called,
-    # so we have to access current entry by controller context
     can?(:show_details, context.entry) && can?(:update, context.entry)
   end
 end

--- a/app/resources/person_resource.rb
+++ b/app/resources/person_resource.rb
@@ -11,13 +11,14 @@ class PersonResource < ApplicationResource
 
   primary_endpoint "people", [:index, :show, :update]
 
-  def authorize_update(model)
-    if (model.changed_attribute_names_to_save & ["gender", "birthday"]).present?
-      # show_details ability is required additionally for updating gender, birthday
-      update_ability.authorize!(:show_details, model)
-    end
+  DETAIL_ATTRS = %w[gender birthday additional_information].freeze
 
-    super
+  def authorize_update(model)
+    changed_details = model.changed_attribute_names_to_save & DETAIL_ATTRS
+
+    super do |ability, model_from_db|
+      ability.authorize!(:show_details, model_from_db) if changed_details.present?
+    end
   end
 
   attribute :first_name, :string
@@ -43,7 +44,7 @@ class PersonResource < ApplicationResource
     @object.decorate.picture_full_url
   end
   attribute :updated_at, :datetime
-  attribute :additional_information, :string, readable: :show_details?
+  attribute :additional_information, :string, readable: :show_details?, writable: :write_details?
 
   belongs_to :primary_group, resource: GroupResource, writable: false
 
@@ -80,6 +81,8 @@ class PersonResource < ApplicationResource
   end
 
   def write_details?
-    can?(:show_details, context.entry) && can?(:update, context.entry)
+    # The actual permission check happens per model in #authorize_update.
+    # This method is only here so the OpenAPI schema shows writable: "guarded" instead of true.
+    true
   end
 end

--- a/spec/abilities/json_api/contact_account_ability_spec.rb
+++ b/spec/abilities/json_api/contact_account_ability_spec.rb
@@ -66,9 +66,26 @@ describe JsonApi::ContactAccountAbility do
         is_expected.not_to be_able_to(:read, phone_number)
       end
 
-      it "may not read public phone_numbers" do
+      it "may read public phone_numbers" do
         phone_number.public = true
-        is_expected.not_to be_able_to(:read, phone_number)
+        is_expected.to be_able_to(:read, phone_number)
+      end
+    end
+
+    context "when the details of a participation of the contactable are readable" do
+      let(:event) { events(:top_course) }
+      let!(:participation) do
+        Fabricate(:event_participation, event: event, participant: person, active: true)
+      end
+
+      before do
+        Fabricate(Group::TopGroup::Leader.name.to_sym, group: groups(:top_group), person: user)
+        expect(Ability.new(user)).to be_able_to(:show_details, participation)
+      end
+
+      it "may read non-public phone_numbers" do
+        phone_number.public = false
+        is_expected.to be_able_to(:read, phone_number)
       end
     end
   end
@@ -108,7 +125,7 @@ describe JsonApi::ContactAccountAbility do
         is_expected.to be_able_to(:read, contact_account)
       end
 
-      it "may not read non-public phone_numbers" do
+      it "may read non-public phone_numbers" do
         contact_account.public = false
         is_expected.to be_able_to(:read, contact_account)
       end
@@ -119,9 +136,9 @@ describe JsonApi::ContactAccountAbility do
         expect(main_ability).not_to be_able_to(:read, group)
       end
 
-      it "may not read public phone_numbers" do
+      it "may read public phone_numbers" do
         contact_account.public = true
-        is_expected.not_to be_able_to(:read, contact_account)
+        is_expected.to be_able_to(:read, contact_account)
       end
 
       it "may not read non-public phone_numbers" do

--- a/spec/abilities/json_api/event_participation_details_ability_spec.rb
+++ b/spec/abilities/json_api/event_participation_details_ability_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
+require "spec_helper"
+
+describe JsonApi::EventParticipationDetailsAbility do
+  let(:participation) { event_participations(:top) } # bottom_member in top_course
+  let(:event) { participation.event } # in top_layer
+
+  def accessible_by(person)
+    person = people(person) unless person.is_a?(Person)
+    Event::Participation.all.accessible_by(described_class.new(person))
+  end
+
+  def person_with_role(role_type, group)
+    Fabricate(role_type.sti_name, group: groups(group)).person
+  end
+
+  describe "layer and group permissions" do
+    it "may read with layer_and_below_full" do
+      expect(accessible_by(:top_leader)).to eq [participation]
+    end
+
+    it "may not read with layer_and_below_read only" do
+      event.update!(groups: [groups(:bottom_layer_one)])
+      person = person_with_role(Group::BottomLayer::Member, :bottom_layer_one)
+      expect(accessible_by(person)).to be_empty
+    end
+
+    it "may read with layer_full" do
+      person = person_with_role(Group::TopGroup::LocalGuide, :top_group)
+      expect(accessible_by(person)).to eq [participation]
+    end
+
+    it "may not read with layer_read only" do
+      person = person_with_role(Group::TopGroup::LocalSecretary, :top_group)
+      expect(accessible_by(person)).to be_empty
+    end
+
+    it "may read with group_and_below_full" do
+      event.update!(groups: [groups(:top_group)])
+      person = person_with_role(Group::TopGroup::GroupManager, :top_group)
+      expect(accessible_by(person)).to eq [participation]
+    end
+
+    it "may read with group_full" do
+      event.update!(groups: [groups(:top_group)])
+      person = person_with_role(Group::TopGroup::Secretary, :top_group)
+      expect(accessible_by(person)).to eq [participation]
+    end
+
+    it "may not read with group_and_below_read only" do
+      event.update!(groups: [groups(:top_group)])
+      person = person_with_role(Group::TopGroup::Member, :top_group)
+      expect(accessible_by(person)).to be_empty
+    end
+  end
+
+  describe "event roles" do
+    let!(:other) { Fabricate(:event_participation, event: event, active: true) }
+    let(:participant) { participation.participant }
+
+    it "may read with participations_full" do
+      expect(event_roles(:top_leader).class.permissions).to include :participations_full
+      expect(accessible_by(participant)).to match_array [participation, other]
+    end
+
+    it "may read with participations_read_details" do
+      event_roles(:top_leader).update!(type: Event::Role::Helper.sti_name)
+      expect(Event::Role::Helper.permissions).to eq [:participations_read_details]
+      expect(accessible_by(participant)).to match_array [participation, other]
+    end
+
+    it "may not read others with participations_read only" do
+      event_roles(:top_leader).update!(type: Event::Role::Speaker.sti_name)
+      expect(Event::Role::Speaker.permissions).to eq [:participations_read]
+      # her own participation stays readable
+      expect(accessible_by(participant)).to eq [participation]
+    end
+
+    it "may not read others of an event with visible participations" do
+      event_roles(:top_leader).update!(type: Event::Role::Participant.sti_name)
+      event.update!(participations_visible: true)
+      expect(accessible_by(participant)).to eq [participation]
+    end
+  end
+
+  describe "pending applications" do
+    # leader of top_course, but only layer_and_below_read in bottom_layer_one
+    let(:person) { participation.participant }
+    let!(:other_course) { Fabricate(:course, groups: [groups(:bottom_layer_two)]) }
+    let!(:other_participation) do
+      Fabricate(:event_participation, event: other_course,
+        application: Fabricate(:event_application))
+    end
+
+    it "may not read applicants from outside of the own layers" do
+      expect(other_participation).not_to be_active
+      expect(accessible_by(person)).to eq [participation]
+    end
+  end
+end

--- a/spec/api/event_participations/participant_spec.rb
+++ b/spec/api/event_participations/participant_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
+require "rails_helper"
+
+# The participant of a readable participation is exposed even if the person may not be read
+# otherwise. As this is a property of the relationship and not of a single endpoint, it is
+# asserted through every endpoint leading to it.
+describe "event_participations participant", type: :request do
+  it_behaves_like "jsonapi authorized requests", required_scopes: [:event_participations] do
+    subject(:make_request) do
+      jsonapi_get "/api/event_participations", params: {include: "participant"}
+    end
+
+    let(:event) { events(:top_course) }
+    let(:participant) { Fabricate(:person, additional_information: "internal note") }
+    let!(:participation) do
+      Fabricate(:event_participation, event: event, participant: participant, active: true)
+    end
+
+    def included_people
+      json["included"].to_a.select { |inc| inc["type"] == "people" }
+    end
+
+    def included_additional_information
+      included_people.find { |inc| inc["id"] == participant.id.to_s }
+        .dig("attributes", "additional_information")
+    end
+
+    def get_participations(includes: "participant", headers: {})
+      jsonapi_get "/api/event_participations",
+        params: {include: includes, filter: {event_id: event.id}}, headers: headers
+      expect(response.status).to eq(200), response.body
+    end
+
+    describe "participant without any role" do
+      it "is not readable through the people endpoint" do
+        jsonapi_get "/api/people"
+        expect(response.status).to eq(200), response.body
+        expect(d.map(&:id)).not_to include(participant.id)
+      end
+
+      it "is exposed from the participations endpoint" do
+        get_participations
+        expect(included_people.pluck("id")).to include(participant.id.to_s)
+      end
+
+      it "is exposed from the events endpoint" do
+        jsonapi_get "/api/events",
+          params: {include: "participations.participant", filter: {id: event.id}}
+        expect(response.status).to eq(200), response.body
+        expect(included_people.pluck("id")).to include(participant.id.to_s)
+      end
+
+      it "is exposed without roles" do
+        get_participations(includes: "participant.roles")
+
+        person = included_people.find { |inc| inc["id"] == participant.id.to_s }
+        expect(person["attributes"]["first_name"]).to eq participant.first_name
+        expect(person["relationships"]["roles"]["data"]).to be_empty
+      end
+
+      it "does not cache the service token's permissions across requests" do
+        read_only_token = Fabricate(:service_token, layer: groups(:top_layer),
+          name: "ReadOnly", token: "ReadOnly", permission: :layer_and_below_read,
+          people: true, events: true, event_participations: true)
+
+        get_participations
+        expect(included_additional_information).to eq "internal note"
+
+        get_participations(headers: {"X-TOKEN" => read_only_token.token})
+        expect(included_additional_information).to be_nil
+      end
+
+      context "with participation details permission" do
+        it "is exposed with details" do
+          get_participations
+
+          person = included_people.find { |inc| inc["id"] == participant.id.to_s }
+          expect(person["attributes"]["additional_information"]).to eq "internal note"
+          expect(person["attributes"]).to have_key("birthday")
+        end
+
+        it "is exposed with all phone numbers" do
+          public_number = Fabricate(:phone_number, contactable: participant, public: true)
+          private_number = Fabricate(:phone_number, contactable: participant, public: false)
+
+          get_participations(includes: "participant.phone_numbers")
+
+          numbers = json["included"].to_a.select { |inc| inc["type"] == "phone_numbers" }
+          expect(numbers.pluck("id"))
+            .to match_array [public_number.id.to_s, private_number.id.to_s]
+        end
+      end
+
+      context "without participation details permission" do
+        # layer_and_below_read grants :show on the participation, but not :show_details
+        before { service_token.update!(permission: :layer_and_below_read) }
+
+        it "is exposed without details" do
+          get_participations
+
+          person = included_people.find { |inc| inc["id"] == participant.id.to_s }
+          expect(person["attributes"]["first_name"]).to eq participant.first_name
+          expect(person["attributes"]).not_to have_key("additional_information")
+          expect(person["attributes"]).not_to have_key("birthday")
+        end
+
+        it "is exposed with public phone numbers only" do
+          public_number = Fabricate(:phone_number, contactable: participant, public: true)
+          Fabricate(:phone_number, contactable: participant, public: false)
+
+          get_participations(includes: "participant.phone_numbers")
+
+          numbers = json["included"].to_a.select { |inc| inc["type"] == "phone_numbers" }
+          expect(numbers.pluck("id")).to eq [public_number.id.to_s]
+        end
+      end
+    end
+  end
+end

--- a/spec/api/events/index_spec.rb
+++ b/spec/api/events/index_spec.rb
@@ -75,15 +75,18 @@ RSpec.describe "events#index", type: :request do
       let(:event) { Event.first }
       let(:params) { {include: "contact"} }
 
-      it "returns nothing without people scope" do
+      it "returns the contact even without people scope" do
         event.update_attribute(:contact_id, people(:bottom_member).id)
 
         make_request
 
         expect(response.status).to eq(200)
         data = json["data"]
-        expect(data[0]["relationships"]["contact"]["data"]).to be_nil
-        expect(json["included"]).to be_nil
+        contact_id = data[0]["relationships"]["contact"]["data"]["id"]
+        contact = json["included"].first { |inc| inc["type"] == "person" && inc.id == contact_id }
+        expect(contact["attributes"]["first_name"]).to eq("Bottom")
+        expect(contact["attributes"]["last_name"]).to eq("Member")
+        expect(contact["attributes"]["email"]).to eq(people(:bottom_member).email)
       end
 
       describe "with people scope" do
@@ -175,12 +178,14 @@ RSpec.describe "events#index", type: :request do
           expect(guest_data["attributes"]["email"]).to eq guest.email
         end
 
-        it "may not see included person if token has no permission" do
+        it "may see included person even if token has no general people permission" do
           service_token.update(people: false)
           make_request
           expect(response.status).to eq(200), response.body
           expect(json["data"][0]["relationships"]["participations"]["data"].size).to eq(1)
-          expect(json["included"][0]["relationships"]["participant"]["data"]).to be_nil
+          expect(json["included"][0]["relationships"]["participant"]["data"]["type"]).to eq "people"
+          expect(json["included"][0]["relationships"]["participant"]["data"]["id"]).to eq bottom_member.id.to_s
+          expect(json["included"].last["id"]).to eq bottom_member.id.to_s
         end
       end
     end

--- a/spec/api/events/show_spec.rb
+++ b/spec/api/events/show_spec.rb
@@ -61,16 +61,18 @@ RSpec.describe "events#show", type: :request do
       describe "without people scope" do
         before { service_token.update!(people: false) }
 
-        it "does not return the event contact, only the leader" do
+        it "still returns the event contact" do
           event.update_attribute(:contact_id, people(:bottom_member).id)
 
           make_request
 
           expect(response.status).to eq(200)
           data = json["data"]
-          expect(data["relationships"]["contact"]["data"]).to be_nil
-          expect(data["relationships"]["leaders"]["data"].size).to eq(1)
-          expect(json["included"].first["type"]).to eq("person-name")
+          contact_id = data["relationships"]["contact"]["data"]["id"]
+          contact = json["included"].first { |inc| inc["type"] == "person" && inc.id == contact_id }
+          expect(contact["attributes"]["first_name"]).to eq("Bottom")
+          expect(contact["attributes"]["last_name"]).to eq("Member")
+          expect(contact["attributes"]["email"]).to eq(people(:bottom_member).email)
         end
       end
     end

--- a/spec/api/people/index_spec.rb
+++ b/spec/api/people/index_spec.rb
@@ -63,5 +63,15 @@ RSpec.describe "people#index", type: :request do
       expect(response.status).to eq(200), response.body
       expect(response_body.dig(:included, 0, :type)).to eq "event_participations"
     end
+
+    it "does not return the public contacts of people which are not readable" do
+      other = Fabricate(:person)
+      phone_number = Fabricate(:phone_number, contactable: other, public: true)
+
+      jsonapi_get "/api/people", params: {include: "phone_numbers"}
+      expect(response.status).to eq(200), response.body
+      expect(d.map(&:id)).not_to include(other.id)
+      expect(json["included"].to_a.pluck("id")).not_to include(phone_number.id.to_s)
+    end
   end
 end

--- a/spec/controllers/json_api/people_controller_spec.rb
+++ b/spec/controllers/json_api/people_controller_spec.rb
@@ -1232,7 +1232,7 @@ describe JsonApi::PeopleController, type: [:request] do
 
           jsonapi_patch "/api/people/#{@person_id}", params
 
-          expect(response).to have_http_status(400)
+          expect(response).to have_http_status(403)
 
           person.reload
 

--- a/spec/resources/additional_email/reads_spec.rb
+++ b/spec/resources/additional_email/reads_spec.rb
@@ -14,7 +14,7 @@ describe AdditionalEmailResource, type: :resource do
   describe "serialization" do
     let(:role) { roles(:bottom_member) }
     let!(:person) { role.person }
-    let!(:additional_email) { Fabricate(:additional_email, contactable: person) }
+    let!(:additional_email) { Fabricate(:additional_email, contactable: person, public: false) }
 
     context "without appropriate permission" do
       let(:user) { Fabricate(:person) }

--- a/spec/resources/invoice/writes_spec.rb
+++ b/spec/resources/invoice/writes_spec.rb
@@ -89,6 +89,50 @@ describe InvoiceResource, type: :resource do
           expect(instance.update_attributes).to eq(true)
         }.to change { invoice.invoice_items.count }.by(1)
       end
+
+      describe "recipient detail attributes" do
+        # the acting person is the recipient, so they may see their own details
+        let(:invoice) { Fabricate(:invoice, group: groups(:bottom_layer_one), recipient: person) }
+
+        let(:attrs) do
+          payload.deep_merge(
+            data: {
+              relationships: {
+                recipient: {
+                  data: {
+                    id: person.id.to_s,
+                    type: "people",
+                    method: "update"
+                  }
+                }
+              }
+            },
+            included: [{
+              id: person.id.to_s,
+              type: "people",
+              attributes: {
+                additional_information: "Allergies"
+              }
+            }]
+          )
+        end
+
+        it "can be updated with show_details permission" do
+          instance = InvoiceResource.find(attrs)
+          expect {
+            expect(instance.update_attributes).to eq(true), instance.errors.full_messages.to_sentence
+          }.to change { person.reload.additional_information }.to("Allergies")
+        end
+
+        it "cannot be updated without show_details permission" do
+          allow(ability).to receive(:can?).and_call_original
+          allow(ability).to receive(:can?).with(:show_details, person).and_return(false)
+
+          instance = InvoiceResource.find(attrs)
+          expect { instance.update_attributes }.to raise_error(CanCan::AccessDenied)
+          expect(person.reload.additional_information).to be_blank
+        end
+      end
     end
   end
 end

--- a/spec/resources/person/writes_spec.rb
+++ b/spec/resources/person/writes_spec.rb
@@ -60,10 +60,6 @@ describe PersonResource, type: :resource do
       PersonResource.find(payload)
     end
 
-    before do
-      allow(context).to receive(:entry).and_return(person)
-    end
-
     it "works" do
       expect {
         expect(instance.update_attributes).to eq(true)
@@ -112,18 +108,20 @@ describe PersonResource, type: :resource do
         new_birthday = Time.zone.today
         payload[:data][:attributes][:gender] = "w"
         payload[:data][:attributes][:birthday] = new_birthday.to_json
+        payload[:data][:attributes][:additional_information] = "Allergies"
 
-        allow(context).to receive(:entry).and_return(person)
         expect {
           expect(instance.update_attributes).to eq(true)
         }.to change { person.reload.updated_at }
           .and change { person.gender }.to("w")
           .and change { person.birthday }.to(new_birthday)
+          .and change { person.additional_information }.to("Allergies")
       end
     end
 
     context "without show_details permission, it" do
       before do
+        allow(ability).to receive(:can?).and_call_original
         allow(ability).to receive(:can?).with(:show_details, person).and_return(false)
       end
 
@@ -132,7 +130,15 @@ describe PersonResource, type: :resource do
         payload[:data][:attributes][:gender] = "w"
         payload[:data][:attributes][:birthday] = new_birthday.to_json
 
-        expect { instance.update_attributes }.to raise_error(Graphiti::Errors::InvalidRequest)
+        expect { instance.update_attributes }.to raise_error(CanCan::AccessDenied)
+        expect(person.reload.gender).to eq "m"
+      end
+
+      it "does not update additional_information" do
+        payload[:data][:attributes][:additional_information] = "Allergies"
+
+        expect { instance.update_attributes }.to raise_error(CanCan::AccessDenied)
+        expect(person.reload.additional_information).to be_blank
       end
     end
 

--- a/spec/resources/phone_number/reads_spec.rb
+++ b/spec/resources/phone_number/reads_spec.rb
@@ -14,7 +14,7 @@ describe PhoneNumberResource, type: :resource do
   describe "serialization" do
     let(:role) { roles(:bottom_member) }
     let!(:person) { role.person }
-    let!(:phone_number) { Fabricate(:phone_number, contactable: person) }
+    let!(:phone_number) { Fabricate(:phone_number, contactable: person, public: false) }
 
     context "without appropriate permission" do
       let(:user) { Fabricate(:person) }

--- a/spec/resources/social_account/reads_spec.rb
+++ b/spec/resources/social_account/reads_spec.rb
@@ -14,7 +14,7 @@ describe SocialAccountResource, type: :resource do
   describe "serialization" do
     let(:role) { roles(:bottom_member) }
     let!(:person) { role.person }
-    let!(:social_account) { Fabricate(:social_account, contactable: person, label: "Webseite") }
+    let!(:social_account) { Fabricate(:social_account, contactable: person, label: "Webseite", public: false) }
 
     context "without appropriate permission" do
       let(:user) { Fabricate(:person) }

--- a/spec/support/graphiti/schema.json
+++ b/spec/support/graphiti/schema.json
@@ -2790,7 +2790,7 @@
         },
         "additional_information": {
           "type": "string",
-          "readable": true,
+          "readable": "guarded",
           "writable": true,
           "description": null
         }

--- a/spec/support/graphiti/schema.json
+++ b/spec/support/graphiti/schema.json
@@ -2791,7 +2791,7 @@
         "additional_information": {
           "type": "string",
           "readable": "guarded",
-          "writable": true,
+          "writable": "guarded",
           "description": null
         }
       },


### PR DESCRIPTION
Fixes hitobito/hitobito_pbs#466
Closes #3726 

- Adds base_scope customization on the relations Participation#participant and Event#contact so that during sideloading, these are accessible
- Allows to see the same Person attributes which would be visible in the UI
- Refactors JsonApi::ContactAccountAbility to always allow viewing public contact accounts, and extend it so the same contact accounts are accessible as they would be through the participants UI