### PR TITLE
Update to latest Node.js 16.x version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 ruby 3.2.6
-nodejs 16.15.0
+nodejs 16.20.2
 yarn 1.22.19

--- a/bin/active_wagon
+++ b/bin/active_wagon
@@ -12,7 +12,7 @@ require "pathname"
 # Allows switching wagons quickly (depends on https://direnv.net/)
 class Setup
   USED_RUBY_VERSION = "3.2.6"
-  USED_NODE_VERSION = "16.15.0"
+  USED_NODE_VERSION = "16.20.2"
   USED_YARN_VERSION = "1.22.19"
 
   YOUTH_DEPENDENT_WAGONS = %w[pbs cevi pro_natura jubla sjas jemk sac_cas dav].freeze


### PR DESCRIPTION
See #4407 

Production uses the latest 16.x version anyways, since the `Dockefile` just specifies `NODEJS_VERSION="16"`.