### PR TITLE
bug/4348 set payment person attributes when paying manually

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -105,6 +105,18 @@ class PaymentsController < CrudController
   def assign_attributes
     super
     entry.status = :manually_created
+    payee_attributes = build_payee_attributes
+    entry.payee_attributes = payee_attributes if payee_attributes
+  end
+
+  def build_payee_attributes
+    if parent.is_a?(Invoice) && parent.recipient.is_a?(Person)
+      person_address = parent.recipient_address_values_without_name
+      person_name = (parent.recipient_address_values - person_address)[0]
+      {
+        person_id: parent.recipient_id, person_name:, person_address: person_address.join("\n")
+      }
+    end
   end
 
   def list_entries

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -44,6 +44,31 @@ describe PaymentsController do
       expect(assigns(:payment)).to be_invalid
       expect(response).to redirect_to(group_invoice_path(group, invoice))
     end
+
+    context "payee attributes" do
+      it "sets payee attributes from the person recipient" do
+        invoice.update!(state: :sent)
+        post :create, params: {group_id: group.id, invoice_id: invoice.id, payment: {amount: invoice.total}}
+
+        payee = assigns(:payment).payee
+        expect(payee.person_id).to eq invoice.recipient_id
+        expect(payee.person_name).to eq "Top Leader"
+        expect(payee.person_address).to eq "Greatstreet 345\n3456 Greattown"
+      end
+
+      it "does not set payee attributes when the invoice recipient is a group" do
+        sign_in(people(:top_leader))
+        group_invoice = invoices(:group_invoice)
+        group_invoice.update_columns(state: :sent)
+
+        expect do
+          post :create, params: {group_id: groups(:top_group).id, invoice_id: group_invoice.id,
+                                 payment: {amount: group_invoice.total}}
+        end.to change { group_invoice.payments.count }.by(1)
+
+        expect(assigns(:payment).payee).to be_nil
+      end
+    end
   end
 
   describe "GET#index" do


### PR DESCRIPTION
Persist person payee attributes when manually creating payment (https://github.com/hitobito/hitobito/issues/4348)

- does this need to be adapted for groups as invoice recipient
- do we really need this payee model? check with @nilsrauch

According with @ThomasEllenberger no migration of existing data is needed