### PR TITLE
Clean up see_invisible_from_above permission logic

### DIFF
--- a/app/abilities/ability_dsl/base.rb
+++ b/app/abilities/ability_dsl/base.rb
@@ -137,21 +137,11 @@ module AbilityDsl
     end
 
     def user_group_ids
-      case permission
-      when :see_invisible_from_above
-        user.groups_with_permission(:see_invisible_from_above).to_a.collect(&:id)
-      else
-        user_context.permission_group_ids(permission) || []
-      end
+      user_context.permission_group_ids(permission) || []
     end
 
     def user_layer_ids
-      case permission
-      when :see_invisible_from_above
-        user_context.layer_ids(user.groups_with_permission(:see_invisible_from_above).to_a)
-      else
-        user_context.permission_layer_ids(permission) || []
-      end
+      user_context.permission_layer_ids(permission) || []
     end
 
     def user_finance_layer_ids

--- a/app/abilities/ability_dsl/base.rb
+++ b/app/abilities/ability_dsl/base.rb
@@ -158,6 +158,10 @@ module AbilityDsl
       user_context.permission_layer_ids(:finance)
     end
 
+    def user_see_invisible_layer_ids
+      user_context.permission_layer_ids(:see_invisible_from_above)
+    end
+
     # Are any items of the existing list present in the list of required items?
     def contains_any?(required, existing)
       (required & existing).present?

--- a/app/abilities/ability_dsl/constraints/person.rb
+++ b/app/abilities/ability_dsl/constraints/person.rb
@@ -71,12 +71,12 @@ module AbilityDsl::Constraints
     end
 
     def non_restricted_in_same_layer_or_visible_below
-      non_restricted_in_same_layer || visible_below || can_see_invisible_in_layer_or_above
+      non_restricted_in_same_layer || visible_below ||
+        (in_same_layer_or_below && can_see_invisible_in_layer_or_above)
     end
 
     def can_see_invisible_in_layer_or_above
-      contains_any?(person.groups_hierarchy_ids,
-        user_context.permission_layer_ids(:see_invisible_from_above))
+      contains_any?(person.groups_hierarchy_ids, user_see_invisible_layer_ids)
     end
 
     def local_hiearchy_ids(groups)

--- a/app/abilities/ability_dsl/constraints/person.rb
+++ b/app/abilities/ability_dsl/constraints/person.rb
@@ -71,7 +71,12 @@ module AbilityDsl::Constraints
     end
 
     def non_restricted_in_same_layer_or_visible_below
-      non_restricted_in_same_layer || visible_below
+      non_restricted_in_same_layer || visible_below || can_see_invisible_in_layer_or_above
+    end
+
+    def can_see_invisible_in_layer_or_above
+      contains_any?(person.groups_hierarchy_ids,
+        user_context.permission_layer_ids(:see_invisible_from_above))
     end
 
     def local_hiearchy_ids(groups)

--- a/app/abilities/concerns/visible_from_above_condition.rb
+++ b/app/abilities/concerns/visible_from_above_condition.rb
@@ -1,47 +1,30 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Pfadibewegung Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
 module VisibleFromAboveCondition
   extend ActiveSupport::Concern
 
   def visible_from_above_condition(condition)
-    return if layer_groups_above.blank?
+    query = Group.in_subtrees_of(layer_groups_above)
+    return if query.nil?
 
-    visible_from_above_groups = OrCondition.new
-    collapse_groups_to_highest(layer_groups_above) do |layer_group|
-      visible_from_above_groups.or(Group.below_or_at_condition(layer_group.lft, layer_group.rgt))
-    end
-
-    query = "(#{visible_from_above_groups.to_a.first}) AND roles.type IN (?)"
-    args = visible_from_above_groups.to_a[1..] + [Role.visible_types.collect(&:sti_name)]
-    condition.or(query, *args)
+    condition.or("(#{query}) AND roles.type IN (?)", Role.visible_types.collect(&:sti_name))
   end
 
   def see_invisible_from_above_condition(condition)
-    return if layer_groups_see_invisible_from_above.blank?
+    query = Group.in_subtrees_of(layer_groups_see_invisible_from_above)
+    return if query.nil?
 
-    see_invisible_from_above_groups = OrCondition.new
-    collapse_groups_to_highest(layer_groups_see_invisible_from_above) do |layer_group|
-      see_invisible_from_above_groups.or(
-        Group.below_or_at_condition(layer_group.lft, layer_group.rgt)
-      )
-    end
-
-    condition.or(*see_invisible_from_above_groups.to_a)
+    condition.or(query)
   end
 
   def layer_groups_see_invisible_from_above
-    # rubocop:todo Layout/LineLength
-    @layer_groups_unconfined_below ||= Group.where(id: layer_group_ids_with_permissions(:see_invisible_from_above))
-    # rubocop:enable Layout/LineLength
-  end
-
-  private
-
-  # If group B is a child of group A, B is collapsed into A.
-  # e.g. input [A,B] -> output A
-  def collapse_groups_to_highest(layer_groups)
-    layer_groups.each do |group|
-      unless layer_groups.any? { |g| g.is_ancestor_of?(group) }
-        yield group
-      end
-    end
+    @layer_groups_unconfined_below ||= Group.where(
+      id: layer_group_ids_with_permissions(:see_invisible_from_above)
+    )
   end
 end

--- a/app/abilities/person_ability.rb
+++ b/app/abilities/person_ability.rb
@@ -71,6 +71,10 @@ class PersonAbility < AbilityDsl::Base
       .may(:show)
       .readable_in_same_layer_or_visible_below
 
+    permission(:see_invisible_from_above)
+      .may(:show, :show_full, :show_details, :history)
+      .in_same_layer_or_below
+
     permission(:layer_and_below_full)
       .may(:update, :primary_group, :send_password_instructions, :log, :approve_add_request,
         :show_tags, :create_tags, :assign_tags, :index_notes, :security)

--- a/app/abilities/person_layer_writables.rb
+++ b/app/abilities/person_layer_writables.rb
@@ -46,7 +46,7 @@ class PersonLayerWritables < GroupBasedFetchables
     OrCondition.new.tap do |condition|
       append_group_conditions(condition)
       visible_from_above_condition(condition)
-      see_invisible_from_above_condition(condition)
+      see_invisible_from_above_condition(condition) if layer_group_ids_above.present?
       condition.or(*manager_condition)
     end
   end

--- a/app/abilities/person_layer_writables.rb
+++ b/app/abilities/person_layer_writables.rb
@@ -46,9 +46,17 @@ class PersonLayerWritables < GroupBasedFetchables
     OrCondition.new.tap do |condition|
       append_group_conditions(condition)
       visible_from_above_condition(condition)
-      see_invisible_from_above_condition(condition) if layer_group_ids_above.present?
+      write_invisible_from_above_condition(condition)
       condition.or(*manager_condition)
     end
+  end
+
+  def write_invisible_from_above_condition(condition)
+    see_invisible = Group.in_subtrees_of(layer_groups_see_invisible_from_above)
+    writable = Group.in_subtrees_of(layer_groups_above)
+    return if see_invisible.nil? || writable.nil?
+
+    condition.or("(#{see_invisible}) AND (#{writable})")
   end
 
   def manager_condition

--- a/app/abilities/role_ability.rb
+++ b/app/abilities/role_ability.rb
@@ -32,13 +32,11 @@ class RoleAbility < AbilityDsl::Base
   end
 
   def in_same_layer_or_visible_below
-    in_same_layer_if_active ||
-      (
-        subject.visible_from_above? &&
-        permission_in_layers?(group.layer_hierarchy.collect(&:id)) &&
-        in_active_group
-      ) ||
-      can_see_invisible_in_layer_or_above
+    return false unless in_active_group
+
+    in_same_layer ||
+      (in_same_layer_or_below &&
+        (subject.visible_from_above? || can_see_invisible_in_layer_or_above))
   end
 
   def non_restricted
@@ -57,10 +55,7 @@ class RoleAbility < AbilityDsl::Base
   end
 
   def can_see_invisible_in_layer_or_above
-    contains_any?(
-      subject.group.layer_hierarchy.collect(&:id),
-      user_context.permission_layer_ids(:see_invisible_from_above)
-    )
+    contains_any?(group.layer_hierarchy.collect(&:id), user_see_invisible_layer_ids)
   end
 
   def her_own

--- a/app/models/group/nested_set.rb
+++ b/app/models/group/nested_set.rb
@@ -153,6 +153,16 @@ module Group::NestedSet
         "#{quoted_tbl}.rgt <= #{sanitize_nested_set_bound(rgt)}"
     end
 
+    # Generates a SQL condition string for checking if groups are below or at any of the
+    # given groups, i.e. the union of their subtrees. Nil if no groups are given.
+    def in_subtrees_of(groups)
+      return if groups.blank?
+
+      collapse_groups_to_highest(groups)
+        .collect { |group| "(#{below_or_at_condition(group.lft, group.rgt)})" }
+        .join(" OR ")
+    end
+
     # Generates a SQL condition string for checking if groups are above or at given bounds.
     # Includes the group at the bounds itself plus all ancestors.
     # lft/rgt accept Integer values, hardcoded column references (e.g., "other_table.lft"),
@@ -165,6 +175,12 @@ module Group::NestedSet
     end
 
     private
+
+    # If group B is a child of group A, B is collapsed into A.
+    # e.g. input [A,B] -> output [A]
+    def collapse_groups_to_highest(groups)
+      groups.reject { |group| groups.any? { |other| other.is_ancestor_of?(group) } }
+    end
 
     # Validates a nested-set bound value against SQL injection.
     # Three forms are accepted:

--- a/spec/abilities/person_ability_spec.rb
+++ b/spec/abilities/person_ability_spec.rb
@@ -59,6 +59,12 @@ describe PersonAbility do
       is_expected.to be_able_to(:security, other.person)
     end
 
+    it "may modify roles which are invisible from above in the same layer" do
+      other = Fabricate(Role::External.name.to_sym, group: groups(:top_group))
+      expect(other).not_to be_visible_from_above
+      is_expected.to be_able_to(:update, other)
+    end
+
     it "may not update root email if in same group" do
       root = people(:root)
       Fabricate(Group::TopGroup::Member.name.to_sym, group: groups(:top_group), person: root)
@@ -373,6 +379,45 @@ describe PersonAbility do
         other = Fabricate(Role::External.name.to_sym, group: Fabricate(Group::TopLayer.name.to_sym))
         is_expected.not_to be_able_to(:show, other.person.reload)
         is_expected.not_to be_able_to(:update, other.person.reload)
+      end
+
+      it "may modify invisible roles below" do
+        is_expected.to be_able_to(:show, invisible)
+        is_expected.to be_able_to(:update, invisible)
+        is_expected.to be_able_to(:destroy, invisible)
+      end
+
+      it "may not modify invisible roles in an archived group" do
+        groups(:bottom_layer_one).archive!
+        is_expected.not_to be_able_to(:update, invisible.reload)
+        is_expected.not_to be_able_to(:destroy, invisible.reload)
+      end
+    end
+
+    context "combined with layer_and_below_full further down" do
+      let(:other) { Fabricate(Role::External.name.to_sym, group: groups(:bottom_layer_two)) }
+
+      before do
+        Fabricate(Group::BottomLayer::Leader.name.to_sym, group: groups(:bottom_layer_one),
+          person: role.person)
+      end
+
+      it "may update invisible people in the layer_and_below_full subtree" do
+        is_expected.to be_able_to(:update, invisible.person.reload)
+      end
+
+      it "may show but not update invisible people outside that subtree" do
+        is_expected.to be_able_to(:show, other.person.reload)
+        is_expected.not_to be_able_to(:update, other.person.reload)
+      end
+
+      it "may not change managers of invisible people outside that subtree" do
+        is_expected.not_to be_able_to(:change_managers, other.person.reload)
+      end
+
+      it "may not modify roles of invisible people outside that subtree" do
+        is_expected.not_to be_able_to(:update, other)
+        is_expected.not_to be_able_to(:destroy, other)
       end
     end
   end

--- a/spec/abilities/person_ability_spec.rb
+++ b/spec/abilities/person_ability_spec.rb
@@ -339,6 +339,44 @@ describe PersonAbility do
     end
   end
 
+  context :see_invisible_from_above do
+    let(:role) do
+      Fabricate(Group::TopGroup::InvisiblePeopleManager.name.to_sym, group: groups(:top_group))
+    end
+    let(:invisible) { Fabricate(Role::External.name.to_sym, group: groups(:bottom_layer_one)) }
+
+    it "does not grant write access on its own" do
+      expect(invisible).not_to be_visible_from_above
+      is_expected.to be_able_to(:show, invisible.person.reload)
+      is_expected.not_to be_able_to(:update, invisible.person.reload)
+    end
+
+    context "combined with layer_and_below_full" do
+      before do
+        Fabricate(Group::TopGroup::Leader.name.to_sym, group: groups(:top_group),
+          person: role.person)
+      end
+
+      it "may show invisible people below" do
+        is_expected.to be_able_to(:show, invisible.person.reload)
+      end
+
+      it "may update invisible people below" do
+        is_expected.to be_able_to(:update, invisible.person.reload)
+      end
+
+      it "may change managers of invisible people below" do
+        is_expected.to be_able_to(:change_managers, invisible.person.reload)
+      end
+
+      it "may not show or update invisible people outside the layer hierarchy" do
+        other = Fabricate(Role::External.name.to_sym, group: Fabricate(Group::TopLayer.name.to_sym))
+        is_expected.not_to be_able_to(:show, other.person.reload)
+        is_expected.not_to be_able_to(:update, other.person.reload)
+      end
+    end
+  end
+
   context :layer_and_below_read do
     # member with additional group_full role
     let(:role) { Fabricate(Group::TopGroup::Secretary.name.to_sym, group: groups(:top_group)) }

--- a/spec/abilities/person_writables_spec.rb
+++ b/spec/abilities/person_writables_spec.rb
@@ -142,5 +142,27 @@ describe PersonWritables do
         end
       end
     end
+
+    context "combined with layer_and_below_full further down" do
+      # Each permission applies downwards from its own role: :see_invisible_from_above from
+      # the top layer, :layer_and_below_full from bottom_layer_one. Writing a person needs
+      # both of them above her, so bottom_layer_two stays read only.
+      before do
+        Fabricate(Group::BottomLayer::Leader.name.to_sym, group: groups(:bottom_layer_one),
+          person: role.person)
+      end
+
+      it "returns invisible people in the layer_and_below_full subtree" do
+        other = Fabricate(Role::External.name.to_sym, group: groups(:bottom_layer_one))
+        is_expected.to include(other.person)
+      end
+
+      it "does not return people outside that subtree" do
+        visible = Fabricate(Group::BottomLayer::Leader.name.to_sym,
+          group: groups(:bottom_layer_two))
+        invisible = Fabricate(Role::External.name.to_sym, group: groups(:bottom_layer_two))
+        is_expected.not_to include(visible.person, invisible.person)
+      end
+    end
   end
 end

--- a/spec/abilities/person_writables_spec.rb
+++ b/spec/abilities/person_writables_spec.rb
@@ -99,35 +99,47 @@ describe PersonWritables do
       expect(role.permissions).to include(:see_invisible_from_above)
     end
 
-    context "own group" do
-      let(:group) { role.group }
-
-      it "may get people with visible_from_above=true" do
-        other = Fabricate(Group::TopGroup::Leader.name.to_sym, group: groups(:top_group))
-        expect(other).to be_visible_from_above
-        is_expected.to include(other.person)
-      end
-
-      it "may get people with visible_from_above=false" do
-        other = Fabricate(Role::External.name.to_sym, group: groups(:top_group))
-        expect(other).not_to be_visible_from_above
-        is_expected.to include(other.person)
-      end
+    it "does not return people, as the permission alone grants read access only" do
+      visible = Fabricate(Group::BottomLayer::Leader.name.to_sym, group: groups(:bottom_layer_one))
+      invisible = Fabricate(Role::External.name.to_sym, group: groups(:bottom_layer_one))
+      expect(visible).to be_visible_from_above
+      expect(invisible).not_to be_visible_from_above
+      is_expected.not_to include(visible.person, invisible.person)
     end
 
-    context "lower group" do
-      let(:group) { groups(:bottom_layer_one) }
-
-      it "ay get people with visible_from_above=true" do
-        other = Fabricate(Group::BottomLayer::Leader.name.to_sym, group: groups(:bottom_layer_one))
-        expect(other).to be_visible_from_above
-        is_expected.to include(other.person)
+    context "combined with layer_and_below_full" do
+      before do
+        Fabricate(Group::TopGroup::Leader.name.to_sym, group: groups(:top_group),
+          person: role.person)
       end
 
-      it "may get people with visible_from_above=false" do
-        other = Fabricate(Role::External.name.to_sym, group: groups(:bottom_layer_one))
-        expect(other).not_to be_visible_from_above
-        is_expected.to include(other.person)
+      context "own group" do
+        it "returns people with visible_from_above=true" do
+          other = Fabricate(Group::TopGroup::Leader.name.to_sym, group: groups(:top_group))
+          expect(other).to be_visible_from_above
+          is_expected.to include(other.person)
+        end
+
+        it "returns people with visible_from_above=false" do
+          other = Fabricate(Role::External.name.to_sym, group: groups(:top_group))
+          expect(other).not_to be_visible_from_above
+          is_expected.to include(other.person)
+        end
+      end
+
+      context "lower group" do
+        it "returns people with visible_from_above=true" do
+          other = Fabricate(Group::BottomLayer::Leader.name.to_sym,
+            group: groups(:bottom_layer_one))
+          expect(other).to be_visible_from_above
+          is_expected.to include(other.person)
+        end
+
+        it "returns people with visible_from_above=false" do
+          other = Fabricate(Role::External.name.to_sym, group: groups(:bottom_layer_one))
+          expect(other).not_to be_visible_from_above
+          is_expected.to include(other.person)
+        end
       end
     end
   end

--- a/spec/controllers/person/security_tools_controller_spec.rb
+++ b/spec/controllers/person/security_tools_controller_spec.rb
@@ -54,8 +54,11 @@ describe Person::SecurityToolsController do
                                                          Group::BottomLayer::Member.label],
                                                        deleted: false}
         expected_groups_and_roles[top_group.id] = {name: top_group.name,
-                                                    roles: [Group::TopGroup::Leader.label,
-                                                      Group::TopGroup::Secretary.label],
+                                                    roles: [
+                                                      Group::TopGroup::Leader.label,
+                                                      Group::TopGroup::Secretary.label,
+                                                      Group::TopGroup::InvisiblePeopleManager.label
+                                                    ],
                                                     deleted: false}
 
         expect(assigns(:groups_and_roles_that_see_me)).to eq(expected_groups_and_roles)


### PR DESCRIPTION
- Don't automatically grant write permission to see_invisible_from_above roles (they need layer_and_below_full for that)
- Consistently allow seeing invisible people in the PersonAbility, not just in the readables/writables classes.
- Only apply the effect of see_invisible_from_above downwards in the group tree, instead of globally
- Clean up obsolete special case in AbilityDsl::Base