### PR TITLE
Update graphiti to 1.13.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "gibbon"
 gem "globalize"
 gem "googleauth" # Used for the google wallet integration
 gem "jwt" # Used for signing Google Wallet save URLs
-gem "graphiti"
+gem "graphiti", "1.13.3"
 gem "graphiti-rails"
 gem "haml"
 gem "http_accept_language"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,13 +339,14 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    graphiti (1.10.2)
+    graphiti (1.13.3)
       activesupport (>= 5.2)
       concurrent-ruby (>= 1.2, < 2.0)
       dry-types (>= 0.15.0, < 2.0)
       graphiti_errors (~> 1.1.0)
       jsonapi-renderer (~> 0.2, >= 0.2.2)
       jsonapi-serializable (~> 0.3.0)
+      ostruct (>= 0.5)
     graphiti-rails (0.4.1)
       graphiti (~> 1.2)
       railties (>= 5.0)
@@ -905,7 +906,7 @@ DEPENDENCIES
   gibbon
   globalize
   googleauth
-  graphiti
+  graphiti (= 1.13.3)
   graphiti-openapi!
   graphiti-rails
   graphiti_spec_helpers

--- a/spec/api/people/index_spec.rb
+++ b/spec/api/people/index_spec.rb
@@ -47,6 +47,33 @@ RSpec.describe "people#index", type: :request do
       end
     end
 
+    describe "nil filtering" do
+      before do
+        people(:top_leader).update!(nickname: "Toppy")
+        people(:bottom_member).update!(nickname: nil)
+      end
+
+      context "with an empty value" do
+        let(:params) { {filter: {nickname: ""}} }
+
+        it "returns the people without a value" do
+          make_request
+          expect(response.status).to eq(200), response.body
+          expect(d.map(&:id)).to match_array([people(:bottom_member).id])
+        end
+      end
+
+      context "with an empty value and the not_eq operator" do
+        let(:params) { {filter: {nickname: {not_eq: ""}}} }
+
+        it "returns the people with a value" do
+          make_request
+          expect(response.status).to eq(200), response.body
+          expect(d.map(&:id)).to match_array([people(:top_leader).id])
+        end
+      end
+    end
+
     describe "layer_group" do
       let(:params) { {include: "layer_group"} }
 


### PR DESCRIPTION
Fixes #3877

Semi-breaking: Nicht mehr supported in dieser Version ist eine `page` Zahl ohne `[number]`: `?page=2` geht nicht mehr, `?page[number]=2` geht weiterhin und ist auch so korrekt im JSON:API Standard. Könnte kaputt gehen wenn Anbindungen von Hand ausprogrammiert wurden.

