### PR TITLE
Fix NoAttachmentsValidator (#4409)

### DIFF
--- a/app/domain/no_attachments_validator.rb
+++ b/app/domain/no_attachments_validator.rb
@@ -1,7 +1,14 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020-2026, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
 class NoAttachmentsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if value&.body&.attachments&.any?
-      record.errors[attribute] << I18n.t("errors.messages.attachments_not_allowed")
+      record.errors.add(attribute, I18n.t("errors.messages.attachments_not_allowed"))
     end
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -24,9 +24,17 @@ const imagePath = (name) => images(name, true);
 // Action Text
 require("trix")
 require("@rails/actiontext")
-// prevent adding attachments via drag and drop
+
+// prevent attaching files via drag and drop if the trix editor is nested below an element with class "no-attachments"
 document.addEventListener('trix-file-accept', function(event) {
-  if(event.target.parentNode.parentNode.classList.contains('no-attachments')) {
+  if (event.target.closest('.no-attachments')) {
     event.preventDefault();
+  }
+});
+
+// prevent attaching files via pasting if the trix editor is nested below an element with class "no-attachments"
+document.addEventListener('trix-attachment-add', function(event) {
+  if (event.target.closest('.no-attachments')) {
+    event.attachment.remove();
   }
 });

--- a/spec/models/custom_content_spec.rb
+++ b/spec/models/custom_content_spec.rb
@@ -1,7 +1,10 @@
-#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2026, Puzzle ITC. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
-#  https://github.com/hitobito/hitobito.
+#  https://github.com/hitobito/hitobito
+
 require "spec_helper"
 
 describe CustomContent do
@@ -111,6 +114,13 @@ describe CustomContent do
       subject.subject_fr = "Placeholders missing"
 
       is_expected.not_to be_valid
+    end
+
+    it "is invalid with attachments" do
+      subject.body = "<div>Some content</div>" \
+        '<action-text-attachment sgid="invalid" content-type="image/png"></action-text-attachment>'
+      expect(subject).not_to be_valid
+      expect(subject.errors[:body]).to include(I18n.t("errors.messages.attachments_not_allowed"))
     end
   end
 

--- a/spec/models/help_text_spec.rb
+++ b/spec/models/help_text_spec.rb
@@ -1,3 +1,10 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2019-2026, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
 require "spec_helper"
 
 describe HelpText do
@@ -27,5 +34,15 @@ describe HelpText do
     HelpText.where.not(id: [first.id, second.id, third.id]).destroy_all
 
     expect(HelpText.list).to eq [third, first, second]
+  end
+
+  context "validations" do
+    it "is invalid with attachments" do
+      ht = help_texts(:events_action_index)
+      ht.body = "<div>Some content</div>" \
+        '<action-text-attachment sgid="invalid" content-type="image/png"></action-text-attachment>'
+      expect(ht).not_to be_valid
+      expect(ht.errors[:body]).to include(I18n.t("errors.messages.attachments_not_allowed"))
+    end
   end
 end


### PR DESCRIPTION
- **Fix NoAttachmentsValidator for compatibility with rails >=7**
    
    The validator detected attachments correctly, but used the legacy
    record.errors[attribute] << message pattern which is not supported
    anymore since rails 7.


  Use record.errors.add instead so the validation actually fails.

- **Fix javascript handling of editors with disabled attachments**

  * Fix preventing attachments via drag&drop
  * Add preventing attachments via pasting

Fixes #4409