### PR TITLE
Align info tooltip icons to helptext icons

### DIFF
--- a/app/helpers/contactable_helper.rb
+++ b/app/helpers/contactable_helper.rb
@@ -40,7 +40,7 @@ module ContactableHelper
       title: t("contactable.public_check_box.tooltip")) do
       safe_join([
         t("activerecord.attributes.social_account.public"),
-        icon(:info, class: "ms-1")
+        icon(:"info-circle", class: "ms-1 text-secondary")
       ], " ")
     end
   end

--- a/app/views/contactable/_additional_email_fields.html.haml
+++ b/app/views/contactable/_additional_email_fields.html.haml
@@ -14,10 +14,10 @@
       = f.check_box(:mailings)
       %span{'data-bs-toggle': 'tooltip', title: t('.tooltip_mailings')}
         = t(:"activerecord.attributes.additional_emails.mailings")
-        %i.fas.fa-info
+        %i.fas.fa-info-circle.text-secondary
   = f.label(:invoices, class: 'checkbox me-3') do
     = f.check_box(:invoices)
     %span{'data-bs-toggle': 'tooltip', title: t('.tooltip_invoices')}
       = t(:"activerecord.attributes.additional_emails.invoices")
-      %i.fas.fa-info
+      %i.fas.fa-info-circle.text-secondary
   = render 'contactable/public_check_box', f: f


### PR DESCRIPTION
Auf der Bearbeiten Seite werden für Hilfetexte und Info-Tooltips unterschiedliche Icons verwendet, obwohl für den User kein wesentlicher Unterschied besteht. Um Irritation vorzubeugen und die Tooltips besser erkennbar zu machen wird vorgeschlagen, diese den Hilfetexten anzugleichen.

Vorher:
<img width="1236" height="552" alt="grafik" src="https://github.com/user-attachments/assets/b56124f6-9b58-47db-b927-6f909449f245" />

Mit Alignment:
<img width="1662" height="320" alt="grafik" src="https://github.com/user-attachments/assets/623072f2-1d7d-4323-ae42-5194448cf246" />
