### PR TITLE
Improve application renaming for DE translation

### DIFF
--- a/app/controllers/mailchimp_synchronizations_controller.rb
+++ b/app/controllers/mailchimp_synchronizations_controller.rb
@@ -12,7 +12,8 @@ class MailchimpSynchronizationsController < ApplicationController
     MailchimpSynchronizationJob.new(mailing_list.id).enqueue!
     flash[:notice] = translate(
       ".wait_for_synchronization",
-      overview_link: helpers.link_to(t("job_observations.index.title"), job_observations_path)
+      overview_link: helpers.link_to(t("job_observations.index.title"), job_observations_path),
+      application_name: Settings.application.name
     )
 
     redirect_to(action: :index, controller: :subscriptions)

--- a/app/helpers/navigation_helper/item.rb
+++ b/app/helpers/navigation_helper/item.rb
@@ -28,7 +28,9 @@ module NavigationHelper
     end
 
     def label(view)
-      label_key ? view.t(label_key) : model.model_name.human(count: 2)
+      return model.model_name.human(count: 2) unless label_key
+
+      view.t(label_key, application_name: Settings.application.name)
     end
 
     def url(view)

--- a/app/helpers/roles_helper.rb
+++ b/app/helpers/roles_helper.rb
@@ -51,7 +51,8 @@ module RolesHelper
     return role.label if role.permissions.blank?
 
     permissions = role.permissions.map do |p|
-      t(p, scope: "activerecord.attributes.role.class.permission.description").chomp(".")
+      t(p, scope: "activerecord.attributes.role.class.permission.description",
+        application_name: Settings.application.name).chomp(".")
     end
     "#{role.label} (#{permissions.join(", ")})"
   end

--- a/app/views/changelog/index.html.haml
+++ b/app/views/changelog/index.html.haml
@@ -4,7 +4,7 @@
 -#  https://github.com/hitobito/hitobito.
 
 - content_for(:head) do
-  %meta{name: "description", content: t(".meta_description")}
+  %meta{name: "description", content: t(".meta_description", application_name: Settings.application.name)}
 
 - title 'Changelog'
 

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -5,4 +5,4 @@
 %p= link_to t('.body.link_text', email: @email), confirmation_url(@resource, confirmation_token: @token)
 
 %br
-%p= t('.body.footer')
+%p= t('.body.footer', application_name: Settings.application.name)

--- a/app/views/devise/mailer/unlock_instructions.html.haml
+++ b/app/views/devise/mailer/unlock_instructions.html.haml
@@ -5,4 +5,4 @@
 %p= link_to t('.body.link_text'), unlock_url(@resource, unlock_token: @token)
 
 %br
-%p= t('.body.footer')
+%p= t('.body.footer', application_name: Settings.application.name)

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -5,7 +5,7 @@
 
 - prefix = 'devise.registrations.edit'
 - content_for(:head) do
-  %meta{name: "description", content: t("#{prefix}.meta_description")}
+  %meta{name: "description", content: t("#{prefix}.meta_description", application_name: Settings.application.name)}
 
 -title t("#{prefix}.change_password")
 

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -4,7 +4,7 @@
 -#  https://github.com/hitobito/hitobito.
 
 - content_for(:head) do
-  %meta{name: "description", content: t(".meta_description")}
+  %meta{name: "description", content: t(".meta_description", application_name: Settings.application.name)}
 
 -title t('layouts.unauthorized.forgot_password')
 

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -4,7 +4,7 @@
 -#  https://github.com/hitobito/hitobito.
 
 - content_for(:head) do
-  %meta{name: "description", content: t(".meta_description")}
+  %meta{name: "description", content: t(".meta_description", application_name: Settings.application.name)}
 
 -title t('.sign_in')
 

--- a/app/views/groups/self_registration/show.html.haml
+++ b/app/views/groups/self_registration/show.html.haml
@@ -3,7 +3,7 @@
 -#  or at https://github.com/hitobito/hitobito.
 
 - content_for(:head) do
-  %meta{name: "description", content: t(".meta_description")}
+  %meta{name: "description", content: t(".meta_description", application_name: Settings.application.name)}
 
 - title render_self_registration_title(group)
 

--- a/app/views/list/index.html.haml
+++ b/app/views/list/index.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-- title ti(:title, :models => models_label, :default => models_label)
+- title ti(:title, :models => models_label, :default => models_label, :application_name => Settings.application.name)
 
 - content_for(:toolbar, render('actions_index'))
 

--- a/app/views/people/_actions_show.html.haml
+++ b/app/views/people/_actions_show.html.haml
@@ -27,4 +27,4 @@
                   group_person_impersonate_path(parent, entry),
                   nil,
                   data: { method: :post },
-                  title: t('.impersonate_user_tooltip'))
+                  title: t('.impersonate_user_tooltip', application_name: Settings.application.name))

--- a/app/views/public_events/show.html.haml
+++ b/app/views/public_events/show.html.haml
@@ -4,7 +4,7 @@
 -#  https://github.com/hitobito/hitobito.
 
 - content_for(:head) do
-  %meta{name: "description", content: t(".meta_description")}
+  %meta{name: "description", content: t(".meta_description", application_name: Settings.application.name)}
 
 - title entry.to_s
 

--- a/app/views/roles/_info.html.haml
+++ b/app/views/roles/_info.html.haml
@@ -13,7 +13,7 @@
       %br/
       %ul.ms-3
         - @type.permissions.each do |perm|
-          %li= t("activerecord.attributes.role.class.permission.description.#{perm}")
+          %li= t("activerecord.attributes.role.class.permission.description.#{perm}", application_name: Settings.application.name)
     - else
       = t('.role_only_public', role: @type.label, group: @group)
 

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -1079,7 +1079,7 @@ de:
               approve_applications: Bestätigen der Kursanmeldungen für Personen dieser Ebene.
               finance: Erstellen und Verwalten von Rechnungen.
               layer_and_below_finance: Erstellen und Verwalten von Rechnungen auf dieser Ebene und allen darunter liegenden Ebenen.
-              impersonation: Hitobito als andere Person bedienen.
+              impersonation: "%{application_name} als andere Person bedienen."
               see_invisible_from_above: Sieht zusätzlich Personen, welche sonst von höheren Ebenen nicht eingesehen werden dürfen.
               manual_deletion: Löschen von Personen ohne Rollen
           kind:

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -147,7 +147,7 @@ de:
 
   changelog:
     index:
-      meta_description: Hitobito Changelog Seite
+      meta_description: "%{application_name} Changelog Seite"
   contactable:
     address_or_email: "%{address} oder %{email}"
     fields:
@@ -313,7 +313,7 @@ de:
       signed_out: "Du bist jetzt abgemeldet."
       new:
         sign_in: Anmelden
-        meta_description: Anmeldeseite für Hitobito
+        meta_description: "Anmeldeseite für %{application_name}"
       form:
         login_identity: Haupt-E-Mail
         sign_in: Anmelden
@@ -329,7 +329,7 @@ de:
       no_token: "Du kannst diese Seite nicht aufrufen, wenn Du nicht von einem Passwort Zurücksetzen E-Mail kommst. Falls Du von einem solchen E-Mail kommst, bitte überprüfe, dass Du die vollständige URL verwendest."
       new:
         reset_password_button: "Passwort zurücksetzen"
-        meta_description: Hitobito Passwort zurücksetzen Seite
+        meta_description: "%{application_name} Passwort zurücksetzen Seite"
     confirmations:
       new:
         resend_confirmation_instructions: "E-Mail-Adresse bestätigen"
@@ -359,7 +359,7 @@ de:
         old_password: "Altes Passwort"
         new_password: "Neues Passwort"
         new_password_confirmation: "Neues Passwort bestätigen"
-        meta_description: "Hitobito Passwort ändern Seite"
+        meta_description: "%{application_name} Passwort ändern Seite"
       person:
         updated: "Dein Passwort wurde aktualisiert."
 
@@ -370,7 +370,7 @@ de:
           greeting: "Hallo %{name}!"
           information_html: "Du kannst deine E-Mail-Adresse mit dem folgenden Link bestätigen:"
           link_text: "%{email} bestätigen"
-          footer: "Diese E-Mail wurde von Hitobito gesendet"
+          footer: "Diese E-Mail wurde von %{application_name} gesendet"
       reset_password_instructions:
         subject: "Anleitung für das Setzen Deines Passworts"
         body:
@@ -385,7 +385,7 @@ de:
           greeting: "Hallo %{name}!"
           information_html: "Dein Account wurde aufgrund von zu vielen Fehlversuchen beim Login gesperrt.<br>Klicke auf den folgenden Link um Deinen Account zu entsperren:"
           link_text: "Meinen Account entsperren"
-          footer: "Diese E-Mail wurde von Hitobito gesendet"
+          footer: "Diese E-Mail wurde von %{application_name} gesendet"
 
   errors:
     link_to_main: "Hauptseite"
@@ -1002,7 +1002,7 @@ de:
       alert:
         not_active: Die Selbstregistrierung ist in dieser Gruppe nicht möglich.
       show:
-        meta_description: Selbstregistrierungsseite für Hitobito
+        meta_description: "Selbstregistrierungsseite für %{application_name}"
       form:
         privacy_policy_caption: "Ich erkläre mich mit den folgenden Bestimmungen einverstanden:"
         submit: Registrieren
@@ -1082,7 +1082,7 @@ de:
     tabs:
       all: Alle
     index:
-      title: Hitobito Log
+      title: "Hitobito Log"
     list:
       from: Von
       to: Bis
@@ -1365,7 +1365,7 @@ de:
       end: "Imitation beenden"
 
   mailchimp_synchronizations:
-    wait_for_synchronization: "Ihre Daten werden aktuell an MailChimp gesendet. Dies kann einen Moment dauern. Danach wird die ausgewählte Liste mit den Kontakten aus hitobito aktualisiert sein. Der Status der Synchronisation ist auf der Jobübersicht zu sehen: %{overview_link}"
+    wait_for_synchronization: "Ihre Daten werden aktuell an MailChimp gesendet. Dies kann einen Moment dauern. Danach wird die ausgewählte Liste mit den Kontakten aus %{application_name} aktualisiert sein. Der Status der Synchronisation ist auf der Jobübersicht zu sehen: %{overview_link}"
 
   mailing_lists:
     subscriber_lists:
@@ -1634,7 +1634,7 @@ de:
       xml_file: "XML Datei"
   public_events:
     show:
-      meta_description: Öffentliche Kursanmeldeseite für Hitobito
+      meta_description: "Öffentliche Kursanmeldeseite für %{application_name}"
 
   qualifications:
     in_years: "%{years} Jahre"
@@ -1929,7 +1929,7 @@ de:
         reset: Person hat ein Login.<br><br>Diese Aktion sendet ihr einen Link, damit sie ihr Passwort neu setzen kann.
 
       impersonate_user: Imitieren
-      impersonate_user_tooltip: Du kannst hitobito so bedienen, als wärst du als diese Person eingeloggt.
+      impersonate_user_tooltip: "Du kannst %{application_name} so bedienen, als wärst du als diese Person eingeloggt."
       impersonate_user_tooltip_disabled: Diese Person kann erst imitiert werden, nachdem die E-Mail Adresse bestätigt wurde.
 
     actions_index:

--- a/spec/helpers/navigation_helper/item_spec.rb
+++ b/spec/helpers/navigation_helper/item_spec.rb
@@ -58,7 +58,9 @@ describe NavigationHelper::Item do
 
   describe "#label" do
     it "translates the :label key when given" do
-      allow(view).to receive(:t).with("json_api").and_return("JSON API")
+      allow(view).to receive(:t)
+        .with("json_api", application_name: Settings.application.name)
+        .and_return("JSON API")
       item = described_class.new(label: "json_api", path: :api_path)
 
       expect(item.label(view)).to eq("JSON API")


### PR DESCRIPTION
Im Rahmen von den Branding Arbeiten am BdP Wagon ist aufgefallen, dass einige Übersetzungen den Anwendungsnamen hard-kodieren während andere die Systemvariable nutzen. Dieser PR soll die Konsistenz erhöhen und stellt dazu weitere Translation-Keys auf die Nutzung der Systemvariable um.