### PR TITLE
Add optional de_DE override language

### DIFF
--- a/.agents/skills/development/SKILL.md
+++ b/.agents/skills/development/SKILL.md
@@ -18,7 +18,7 @@ Default workflow for feature work or behavior changes. For resolving a defect, u
 1. State the reason for the change — the goal describing how the application should improve for the user.
 2. Write a spec first, defining the desired state. It must fail before any implementation exists.
 3. Implement the change.
-4. Do not touch locales other than `de`, not even `de_CH`.
+4. Do not touch locales other than `de`, not even german variants like `de_CH` or `de_DE`.
 5. Confirm the spec now passes.
 6. Run the specs for all touched classes to catch regressions.
 7. Update the copyright notice at the top of touched files to cover the current year.

--- a/.agents/skills/fixing-a-bug/SKILL.md
+++ b/.agents/skills/fixing-a-bug/SKILL.md
@@ -19,7 +19,7 @@ Any bugfix task: reproducing and resolving a defect. For new functionality, use 
 2. Verify `rubocop` and `brakeman` report no errors locally before starting.
 3. Write a spec that reproduces the bug BEFORE changing any other code. It must fail first.
 4. Implement the fix.
-5. Do not touch locales other than `de`, not even `de_CH`.
+5. Do not touch locales other than `de`, not even german variants like `de_CH` or `de_DE`.
 6. Confirm the spec now passes.
 7. Update the copyright notice at the top of touched files to cover the current year.
 8. Run `brakeman` — no new security findings.

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ RUN    bundle config set --local deployment 'true' \
     && bundle install \
     && bundle clean \
     && bundle exec bootsnap precompile --gemfile \
-    && bundle exec rails locales:patch_de
+    && RAILS_DB_ADAPTER=nulldb bundle exec rails locales:patch_de
 
 # only copy things needed for yarning
 # COPY package.json yarn.lock ./

--- a/config/locales/models.de_DE.yml
+++ b/config/locales/models.de_DE.yml
@@ -1,0 +1,6 @@
+#  Copyright (c) 2012-2026, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+de_DE:

--- a/config/locales/views.de_DE.yml
+++ b/config/locales/views.de_DE.yml
@@ -1,0 +1,6 @@
+#  Copyright (c) 2012-2026, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+de_DE:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,6 +42,8 @@ application:
     # first entry is considered the default language
     de: Deutsch
 
+  german_variant: de_CH
+
 <% mail_domain = ENV['RAILS_MAIL_DOMAIN'].presence ||
                  ENV['RAILS_HOST_NAME'].presence ||
                  'localhost'

--- a/doc/architecture/adr/011_deutsche-texte-auf-transifex-uebersetzbar.md
+++ b/doc/architecture/adr/011_deutsche-texte-auf-transifex-uebersetzbar.md
@@ -33,3 +33,10 @@ Entscheid: Deutsche Texte können in Transifex nach `de_XX` (z.B. `de_CH`) über
 ### di 2025-11-07
 
 Die 2. Variante benötigt keine Anpassungen der Applikation und ist somit weniger aufwendig umzusetzen.
+
+### cbe 2026-08-25
+
+Um sprachlich besser für Kunden ausserhalb der Schweiz kompatibel zu sein, gibt es neu neben `de_CH` im
+Core auch noch `de_DE`. Welche davon beim Build für `de` übernommen wird, kann pro Wagon über
+`application.german_variant` in settings.yml gewählt werden. Default im Core ist `de_CH`, somit
+rückwärtskompatibel.

--- a/doc/architecture/wagons/README.md
+++ b/doc/architecture/wagons/README.md
@@ -76,7 +76,8 @@ If the wagon is the main wagon for a new organization structure, you can additio
   * Create a project in [Transifex](https://www.transifex.com/) (e.g. hitobito_pbs)
   * Ensure that Settings > General > Project url is set correctly (e.g. app/transifex.com/hitobito/hitobito_pbs)
   * if the customer should have the option to define the german texts himself, then add a german variant locale to the
-    transifex project (e.g. `de_CH` for Switzerland)
+    transifex project (e.g. `de_CH` for Switzerland, `de_DE` for Germany) and set the same locale as
+    `application.german_variant` in the wagon's `config/settings.yml` (the core defaults to `de_CH`)
   * Rename customer specific locale files to generic `config/locales/wagon.xx.yml` format
   * Make sure there is all required locale files in the wagon's config/locales folder (all non default language files can be empty on init)
   * create .tx/config and add all files (you might copy it from

--- a/doc/developer/guidelines.md
+++ b/doc/developer/guidelines.md
@@ -101,8 +101,10 @@ einsprachig, wird Transifex nicht gebraucht.
 * Transifex Projekt Name muss gleich wie der Gem Name des Wagons sein.
 * Die Ursprungssprache ist Deutsch (diese kann über Transifex nicht bearbeitet werden)
 * Falls die deutschen Texte auch über Transifex angepasst werden sollen, dann muss im Transifex
-  Projekt eine Deutsch Variante wie `de_CH` hinzugefügt werden. Diese werden im build Prozess 
-  automatisch für die locale `de` übernommen.
+  Projekt eine Deutsch Variante wie `de_CH` (Schweiz) oder `de_DE` (Deutschland) hinzugefügt werden
+  und die gleiche Variante im `config/settings.yml` des Wagons unter `application.german_variant`
+  gesetzt werden (Default im Core: `de_CH`). Diese werden im Build-Prozess automatisch für die
+  locale `de` übernommen.
 * Damit Ein-/Mehrzahlformen in allen Sprachen angegeben werden können, müssen in den deutschen
 Localefiles immer die Keys `one` und `other` angegeben werden, auch wenn diese (im Deutschen)
 identisch sind.
@@ -138,8 +140,10 @@ der Texte und sollten bei den entsprechenden Teilen ebenfalls genau so übernomm
 öffnende Tag (`<b>`) muss zwingend ein entsprechendes schliessendes Tag mit Schrägstrich folgen
 (`</b>`).
 * Deutsche Texte können im Transifex angepasst werden, wenn im Projekt eine deutsch Variante locale
-  konfiguriert ist (z.B. `de_CH`). Diese werden im build Prozess automatisch für die locale
-  `de` übernommen. Dies geschieht mit dem rake Task `rails locales:patch_de`. Im development Environment
+  konfiguriert ist (z.B. `de_CH` oder `de_DE`). Welche Variante verwendet wird, bestimmt die Setting
+  `application.german_variant`, die pro Wagon überschrieben werden kann; im Core ist `de_CH` gesetzt.
+  Die Dateien dieser einen Variante werden im Build-Prozess automatisch für die locale `de`
+  übernommen. Dies geschieht mit dem rake Task `rails locales:patch_de`. Im development Environment
   können die deutschen Texte von transifex übernommen werden, indem der Task lokal ausgeführt wird.
 
 

--- a/lib/tasks/locales.rake
+++ b/lib/tasks/locales.rake
@@ -1,20 +1,32 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025-2026, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
 namespace :locales do
-  desc "Copy german variant locale files to 'de' locale if they exist (e.g., de_CH to de)"
-  task :patch_de do
+  desc "Copy the configured german variant locale files to the 'de' locale (e.g., de_CH to de)"
+  task patch_de: :environment do
+    variant = Settings.application.german_variant.presence
+
+    if variant.nil?
+      puts "No application.german_variant configured, nothing to patch"
+      next
+    end
+
     search_paths = [Rails.root] + Wagons.all.map(&:root)
 
     search_paths.each do |path|
       locale_dir = path.join("config", "locales")
 
-      # Find all YAML files for de locale variants (e.g., *.de_CH.yml)
-      locale_dir.glob("*.de_??.yml").each do |source_file|
-        source_locale = source_file.to_s[/(de_..)\.yml$/, 1]
-
+      # Find all YAML files for the configured de locale variant (e.g., *.de_CH.yml)
+      locale_dir.glob("*.#{variant}.yml").each do |source_file|
         # Read the source file and replace the locale key (e.g., 'de_CH:') with 'de:'
-        i18n_data = source_file.read.sub(/^#{source_locale}:/, "de:")
+        i18n_data = source_file.read.sub(/^#{variant}:/, "de:")
 
         # Write the modified content to the file with the 'de' locale suffix
-        target_file = source_file.to_s.sub(".#{source_locale}.yml", ".de.yml")
+        target_file = source_file.to_s.sub(".#{variant}.yml", ".de.yml")
         puts "Writing patched #{source_file} to #{target_file}"
         File.write(target_file, i18n_data)
       end

--- a/spec/tasks/locales_spec.rb
+++ b/spec/tasks/locales_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Puzzle ITC. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+require "rake"
+
+describe "locales:patch_de" do
+  # The task overwrites *.de.yml in place, so it must never run on the real config/locales.
+  # Instead the real locale files are copied into a temporary Rails.root.
+  let(:core_locales) { Rails.root.join("config", "locales") }
+  let(:tmp) { Pathname.new(Dir.mktmpdir) }
+  let(:locale_dir) { tmp.join("config", "locales") }
+
+  # rspec does not load rake tasks, and :environment is already booted by the spec_helper
+  Rake::Task.define_task(:environment)
+  Rake.application.rake_require("tasks/locales", [Rails.root.join("lib").to_s])
+
+  subject(:task) { Rake::Task["locales:patch_de"] }
+
+  before do
+    task.reenable
+
+    locale_dir.mkpath
+    FileUtils.cp_r("#{core_locales}/.", locale_dir)
+    locale_dir.glob("*.de_??.yml").each(&:delete) # variants are added per example
+
+    allow(Rails).to receive(:root).and_return(tmp)
+    allow(Wagons).to receive(:all).and_return([])
+    allow(Settings.application).to receive(:german_variant).and_return("de_DE")
+  end
+
+  after { tmp.rmtree }
+
+  def write_variant(locale, text)
+    locale_dir.join("views.#{locale}.yml")
+      .write("# comment header\n\n#{locale}:\n  global:\n    add: #{text}\n")
+  end
+
+  it "patches the de locale with the configured variant only" do
+    write_variant("de_CH", "Hinzufügen")
+    write_variant("de_DE", "Hinzufuegen")
+
+    expect { task.invoke }.to change { locale_dir.join("views.de.yml").read }
+      .to("# comment header\n\nde:\n  global:\n    add: Hinzufuegen\n")
+  end
+
+  it "does not touch the other locales" do
+    write_variant("de_DE", "Hinzufuegen")
+    others = locale_dir.glob("*.{fr,it,en}.yml") + [locale_dir.join("models.de.yml")]
+
+    expect { task.invoke }.not_to change { others.map(&:read) }
+  end
+
+  it "does nothing if no file for the configured variant exists" do
+    write_variant("de_CH", "Hinzufügen")
+
+    expect { task.invoke }.not_to change { locale_dir.join("views.de.yml").read }
+  end
+
+  it "does nothing if no variant is configured" do
+    allow(Settings.application).to receive(:german_variant).and_return(nil)
+    write_variant("de_DE", "Hinzufuegen")
+
+    expect { task.invoke }.not_to change { locale_dir.join("views.de.yml").read }
+  end
+
+  it "patches wagon locale files as well" do
+    wagon_root = Pathname.new(Dir.mktmpdir)
+    wagon_root.join("config", "locales").mkpath
+    wagon_root.join("config", "locales", "wagon.de_DE.yml").write("de_DE:\n  foo: bar\n")
+    allow(Wagons).to receive(:all).and_return([double(root: wagon_root)])
+
+    task.invoke
+
+    expect(wagon_root.join("config", "locales", "wagon.de.yml").read).to eq("de:\n  foo: bar\n")
+  ensure
+    wagon_root&.rmtree
+  end
+end


### PR DESCRIPTION
Adds a place to put the general, non-organization-specific German adjustments like ss -> ß, DE sample IBAN or Anlass -> Veranstaltung.
Translations for these files can be extracted from hitobito/hitobito_pfadi_de#118 and hitobito/hitobito_bdp#42