### PR TITLE
Add asset directory to webpack watch folders

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -6,10 +6,10 @@ const config = environment.toWebpackConfig()
 // The wagon require.context in controllers/index.js watches a broad parent directory
 // (../../../../) to discover wagon controllers. This causes webpack to watch the entire
 // app/ tree including public/packs/, tmp/, log/, etc. — triggering spurious recompiles.
-// Whitelist only app/javascript and app/components (webpack's actual source directories)
-// so the watcher ignores everything outside those paths.
+// Whitelist only app/javascript, app/components and app/assets (webpack's actual source 
+// directories) so the watcher ignores everything outside those paths.
 const onlyWatchSourceDirs = (absolutePath) => {
-  return !["/app/javascript/", "/app/components/"].some((dir) =>
+  return !["/app/javascript/", "/app/components/", "/app/assets/"].some((dir) =>
     absolutePath.includes(dir)
   )
 }


### PR DESCRIPTION
https://github.com/hitobito/hitobito/pull/4366 optimised webpack to only watch javascript sources, however it also processes the stylesheets with are now excluded from reloading. To improve developer experience during design activities, this PR proposes to include the /app/assets directory too.