### PR TITLE
Add event templates (#4259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 2.10
 
+- Eventvorlagen können neu pro Ebene über das Bearbeiten Dropdown der Gruppe verwaltet werden (#4259)
 - Browser Auto-fill wird im Personen- und Gruppen-Formular deaktiviert (#4445)
 - Umgebungsspezifische Meta Tags können über die Settings konfigurativ hinzugefügt werden (#4405)
 - Anlass E-Mails verwenden die E-Mail der Kontaktperson als Reply-To (opt-in) (#2881)

--- a/app/abilities/ability.rb
+++ b/app/abilities/ability.rb
@@ -66,6 +66,10 @@ class Ability
     "user-#{user.id}"
   end
 
+  def admin?
+    user_context.all_permissions.include?(:admin)
+  end
+
   def user_finance_layer_ids
     user.root? ? Group.layers.pluck(:id) : user_context.permission_layer_ids(:finance)
   end

--- a/app/abilities/ability_dsl/constraints/event.rb
+++ b/app/abilities/ability_dsl/constraints/event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.

--- a/app/abilities/ability_dsl/constraints/group.rb
+++ b/app/abilities/ability_dsl/constraints/group.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -40,6 +40,10 @@ module AbilityDsl::Constraints
 
     def if_layer_group_if_active
       if_layer_group && in_active_group
+    end
+
+    def in_same_layer_if_layer_group
+      if_layer_group && in_same_layer
     end
 
     def in_active_group

--- a/app/abilities/group_ability.rb
+++ b/app/abilities/group_ability.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -47,6 +47,7 @@ class GroupAbility < AbilityDsl::Base
     permission(:layer_full).may(:destroy).in_same_layer_except_permission_giving
     permission(:layer_full).may(:index_service_tokens).service_token_in_same_layer
     permission(:layer_full).may(:index_question_templates).in_same_layer
+    permission(:layer_full).may(:index_event_templates).in_same_layer_if_layer_group
     permission(:layer_full)
       .may(:index_person_add_requests, :index_notes, :index_deleted_people, :show_statistics,
         :index_calendars, :deleted_subgroups).in_same_layer
@@ -69,6 +70,7 @@ class GroupAbility < AbilityDsl::Base
     permission(:layer_and_below_full).may(:modify_superior).in_below_layers_if_active
     permission(:layer_and_below_full).may(:index_service_tokens).service_token_in_same_layer
     permission(:layer_and_below_full).may(:index_question_templates).in_same_layer
+    permission(:layer_and_below_full).may(:index_event_templates).in_same_layer_if_layer_group
     permission(:layer_and_below_full).may(:index_calendars).in_same_layer
     permission(:layer_and_below_full)
       .may(:activate_person_add_requests, :deactivate_person_add_requests)
@@ -81,19 +83,19 @@ class GroupAbility < AbilityDsl::Base
     permission(:finance).may(:index_received_invoices).in_same_layer_or_below
     permission(:finance).may(:create_invoice).in_same_layer_or_below
 
-    permission(:admin).may(:manage_person_duplicates).if_layer_group_if_active
     permission(:layer_and_below_full).may(:manage_person_duplicates).if_permission_in_layer
 
     permission(:manual_deletion)
       .may(:manually_delete_people)
       .if_permission_in_layer
-    permission(:admin).may(:manually_delete_people).all
 
     permission(:layer_full).may(:log).in_same_layer_if_active
     permission(:layer_and_below_full).may(:log).in_same_layer_or_below_if_active
     permission(:group_full).may(:log).in_same_group_if_active
     permission(:group_and_below_full).may(:log).in_same_group_or_below_if_active
 
+    permission(:admin).may(:manage_person_duplicates).if_layer_group_if_active
+    permission(:admin).may(:manually_delete_people).all
     permission(:admin).may(:set_main_self_registration_group).in_active_group
     permission(:admin).may(:sync_addresses).on_root_group
 

--- a/app/controllers/event/templates_controller.rb
+++ b/app/controllers/event/templates_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class Event::TemplatesController < ListController
+  self.nesting = Group
+  self.sort_mappings = {name: "event_translations.name"}
+
+  decorates :events
+
+  helper_method :group
+
+  def self.model_class
+    Event
+  end
+
+  private
+
+  def authorize_class
+    authorize!(:index_event_templates, group)
+  end
+
+  def list_entries
+    scope = group.events.templates.includes(:translations)
+    return scope unless sorting?
+
+    scope.left_join_translation.reorder(Arel.sql(order_expression))
+  end
+
+  def order_expression
+    return sort_expression unless params[:sort].to_s == "type"
+
+    "#{type_order_case} #{sort_dir} NULLS LAST"
+  end
+
+  def type_order_case
+    ordered_types = ([Event] + Event.subclasses).sort_by { |type| type.model_name.human }
+    whens = ordered_types.each_with_index.map do |type, rank|
+      condition = (type == Event) ? "IS NULL" : "= #{Event.connection.quote(type.sti_name)}"
+      "WHEN events.type #{condition} THEN #{rank}"
+    end.join(" ")
+    "CASE #{whens} END"
+  end
+
+  def group = @group ||= parent
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -17,7 +17,7 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
   self.permitted_attrs = [
     :signature, :signature_confirmation, :signature_confirmation_text,
     :display_booking_info, :participations_visible,
-    :notify_contact_on_participations,
+    :notify_contact_on_participations, :inherit,
     {
       group_ids: [],
       dates_attributes: [
@@ -52,6 +52,8 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
                          group_ids: "groups.name"}
 
   self.search_columns = ["event_translations.name"]
+
+  ACTIONS_FOR_TEMPLATES = %w[new create edit update destroy].freeze
 
   decorates :event, :events, :group
 
@@ -96,8 +98,8 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
 
   def new
     assign_attributes if model_params
-    entry.dates.build if entry.dates.empty? # allow wagons to use derived dates
-    entry.init_questions
+    entry.dates.build if entry.dates.empty? && !entry.template? # allow wagons to use derived dates
+    entry.init_questions if params[:source_id].blank?
     respond_with(entry)
   end
 
@@ -122,16 +124,38 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
     event_filter.entries
   end
 
+  def model_scope
+    ACTIONS_FOR_TEMPLATES.include?(action_name) ? super.with_templates : super
+  end
+
   def build_entry
-    if params[:source_id]
-      group.events.find(params[:source_id]).duplicate
-    else
-      type = model_params && model_params[:type].presence
-      type ||= Event.sti_name
-      event = Event.find_event_type!(type).new
-      event.groups << parent
-      event
+    event = params[:source_id] ? build_from_source : build_new_entry
+    apply_template_flag(event)
+    event
+  end
+
+  def build_from_source
+    source = Event.templates_in_hierarchy([group]).find_by(id: params[:source_id]) ||
+      group.events.find(params[:source_id])
+    source.duplicate.tap do |duplicate|
+      duplicate.groups = [group] if source.template?
     end
+  end
+
+  def build_new_entry
+    type = model_params && model_params[:type].presence
+    type ||= Event.sti_name
+    Event.find_event_type!(type).new.tap { |e| e.groups << parent }
+  end
+
+  # :template is deliberately not in permitted_attrs and applied here instead, since
+  # authorize_resource runs before assign_attributes and would otherwise authorize
+  # against the default value (always false).
+  def apply_template_flag(event)
+    return if model_params.nil? || !model_params.key?(:template)
+
+    event.template = ActiveModel::Type::Boolean.new.cast(model_params.delete(:template))
+    event.groups = [group] if event.template?
   end
 
   def permitted_params
@@ -156,13 +180,16 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
   end
 
   def return_path
-    super.then do |r|
-      next r if r.present? || entry.id.nil?
-      group_event_path(
-        entry.groups.find { |g| can?(:create, g.events.build) } || entry.groups.first,
-        entry
-      )
-    end
+    return group_event_templates_path(group) if entry.template?
+
+    super.then { |r| r.presence || (entry.id && group_event_show_path) }
+  end
+
+  def group_event_show_path
+    group_event_path(
+      entry.groups.find { |g| can?(:create, g.events.build) } || entry.groups.first,
+      entry
+    )
   end
 
   def group
@@ -170,6 +197,8 @@ class EventsController < CrudController # rubocop:todo Metrics/ClassLength
   end
 
   def index_path
+    return group_event_templates_path(group) if entry.template?
+
     typed_group_events_path(group, @event.class, returning: true)
   end
 

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -14,6 +14,10 @@ class EventDecorator < ApplicationDecorator
   self.icons = {
     "Event::Course" => "book"
   }
+
+  def saveable_as_template?(group)
+    !template? && group.layer? && can?(:create, object.class.new(template: true, groups: [group]))
+  end
 
   def label
     safe_join([name, label_detail], h.tag(:br))

--- a/app/domain/person/event_queries.rb
+++ b/app/domain/person/event_queries.rb
@@ -37,7 +37,11 @@ class Person::EventQueries
   end
 
   def upcoming_events
-    Event.select("*").from(
+    # unscoped: the inner query (built from person.events) already excludes
+    # templates on its own; re-applying Event's default_scope out here would
+    # add a WHERE clause referencing "events", but the outer query's FROM is
+    # the aliased subquery, not that table.
+    Event.unscoped.select("*").from(
       unordered_upcoming_events
     ).order(:start_at)
   end

--- a/app/helpers/dropdown/event/new.rb
+++ b/app/helpers/dropdown/event/new.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Dropdown
+  module Event
+    class New < Dropdown::Base
+      delegate :new_group_event_path, to: :template
+
+      def initialize(template, group, event_type)
+        super(
+          template,
+          template.t("events.global.link.add_#{event_type.name.underscore}"),
+          :plus
+          )
+
+        @group = group
+        @event_type = event_type
+        @main_link = template.new_group_event_path(group, event: {type: event_type.sti_name})
+
+        init_items
+      end
+
+      def to_s
+        return "".html_safe unless template.can?(:new, new_event)
+
+        items.empty? ? template.action_button(label, main_link, icon) : super
+      end
+
+      private
+
+      def new_event
+        @event_type.new.tap { |e| e.groups << @group }
+      end
+
+      def init_items
+        ::Event.applicable_templates(@group, event_type: @event_type.sti_name).each do |t|
+          add_item(t.to_s, template.new_group_event_path(@group, source_id: t.id))
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/dropdown/group_edit.rb
+++ b/app/helpers/dropdown/group_edit.rb
@@ -29,6 +29,7 @@ module Dropdown
     def setting_items
       edit_service_token_item if template.can?(:index_service_tokens, group)
       edit_event_question_template_item if template.can?(:index_question_templates, group)
+      edit_event_template_item if template.can?(:index_event_templates, group)
       edit_calendar_feeds_item
     end
 
@@ -49,6 +50,10 @@ module Dropdown
       add_item(
         translate(:edit_event_question_template), template.group_question_templates_path(group)
       )
+    end
+
+    def edit_event_template_item
+      add_item(translate(:edit_event_template), template.group_event_templates_path(group))
     end
 
     def edit_calendar_feeds_item

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2024, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -8,13 +8,7 @@ module EventsHelper
     event_type = find_event_type
     return unless event_type
 
-    event = event_type.new
-    event.groups << @group
-    if can?(:new, event)
-      action_button(t("events.global.link.add_#{event_type.name.underscore}"),
-        new_group_event_path(@group, event: {type: event_type.sti_name}),
-        :plus)
-    end
+    Dropdown::Event::New.new(self, @group, event_type).to_s
   end
 
   def export_events_ical_button
@@ -173,5 +167,10 @@ module EventsHelper
     # rubocop:todo Layout/LineLength
     event.participations.where(participant_type: person.class.sti_name).pluck(:participant_id).include?(person.id)
     # rubocop:enable Layout/LineLength
+  end
+
+  def new_event_template_title(event)
+    t("crud.new.title",
+      model: [model_class_label(event), Event.human_attribute_name(:template)].join(" "))
   end
 end

--- a/app/helpers/sheet/event/template.rb
+++ b/app/helpers/sheet/event/template.rb
@@ -1,0 +1,12 @@
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+module Sheet
+  class Event::Template < Base
+    def parent_sheet
+      create_parent(Sheet::Group)
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2022, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -28,6 +28,7 @@
 #  globally_visible                 :boolean
 #  guest_limit                      :integer          default(0), not null
 #  hidden_contact_attrs             :text
+#  inherit                          :boolean          default(FALSE), not null
 #  location                         :text
 #  maximum_participants             :integer
 #  minimum_participants             :integer
@@ -46,6 +47,7 @@
 #  signature_confirmation_text      :string
 #  state                            :string(60)
 #  teamer_count                     :integer          default(0)
+#  template                         :boolean          default(FALSE), not null
 #  training_days                    :decimal(5, 2)
 #  type                             :string
 #  visible_contact_attributes       :string           default(["name", "address", "phone_number", "email", "social_account"])
@@ -224,15 +226,16 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
   validates_by_schema except: [:canceled_reason]
   # name is a translated attribute and thus needs to be validated explicitly
   validates :name, presence: true
-  validates :dates, presence: {message: :must_exist}
+  validates :dates, presence: {message: :must_exist}, unless: :template?
   validates :contact, permission: :show_full, allow_blank: true, if: :contact_id_changed?
-  validates :group_ids, presence: {message: :must_exist}
+  validates :group_ids, presence: {message: :must_exist}, unless: :template?
   validates :application_opening_at, :application_closing_at,
     timeliness: {type: :date, allow_blank: true, before: ::Date.new(9999, 12, 31)}
   validates :description, :location, :application_conditions,
     length: {allow_nil: true, maximum: 2**16 - 1}
   validates :guest_limit, numericality: {only_integer: true, greater_than_or_equal_to: 0}
   validate :assert_type_is_allowed_for_groups
+  validate :assert_template_on_layer_group
   validate :assert_application_closing_is_after_opening
   validate :assert_required_contact_attrs_valid
   validate :assert_hidden_contact_attrs_valid
@@ -267,6 +270,24 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
       .where("events.application_closing_at IS NULL OR events.application_closing_at >= ?", today)
   }
 
+  scope :without_templates, -> { where(template: false) }
+  scope :with_templates, -> { unscope(where: :template) }
+  scope :templates, -> { with_templates.where(template: true) }
+
+  scope :templates_in_hierarchy, ->(groups) {
+    layer_ids = groups.map(&:layer_group_id).uniq
+    hierarchy_ids = groups.flat_map { |g| g.hierarchy.pluck(:layer_group_id) }.uniq
+
+    templates.joins(:groups)
+      .where(
+        "groups.layer_group_id IN (?) OR (groups.layer_group_id IN (?) AND events.inherit IS TRUE)",
+        layer_ids, hierarchy_ids
+      )
+      .distinct
+  }
+
+  default_scope { without_templates }
+
   ### CLASS METHODS
 
   class << self
@@ -290,6 +311,11 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
 
     def preload_all_dates
       all.extending(Event::PreloadAllDates)
+    end
+
+    def applicable_templates(group, event_type: nil)
+      event_type = nil if event_type == Event.sti_name
+      templates_in_hierarchy([group]).where(type: event_type)
     end
 
     # Events with at least one date in the given year
@@ -478,13 +504,15 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
 
   def duplicate # rubocop:disable Metrics/AbcSize,Metrics/MethodLength splitting this up does not make it better
     Event.build(attributes_for_duplicate).tap do |event|
-      event.groups = groups
+      event.groups = groups unless template?
       event.state = nil
       event.application_opening_at = nil
       event.application_closing_at = nil
       event.participant_count = 0
       event.applicant_count = 0
       event.teamer_count = 0
+      event.template = false
+      event.inherit = false
       # rubocop:disable Rails/FindEach -- questions per event are few, order must be preserved
       application_questions.includes(:question_visibilities).each do |q|
         new_question = event.application_questions.build(q.attributes.excluding("id"))
@@ -555,6 +583,12 @@ class Event < ActiveRecord::Base # rubocop:disable Metrics/ClassLength:
     elsif type && !master.class.event_types.collect(&:sti_name).include?(type)
       errors.add(:type, :type_not_allowed)
     end
+  end
+
+  def assert_template_on_layer_group
+    return unless template?
+
+    errors.add(:groups, :must_be_layer) if groups.any? { |g| !g.layer? }
   end
 
   def assert_application_closing_is_after_opening

--- a/app/views/event/new.html.haml
+++ b/app/views/event/new.html.haml
@@ -1,0 +1,8 @@
+-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+- title ti(:title, :model => model_class_label(entry), :default => model_class_label(entry))
+
+= render 'form'

--- a/app/views/event/templates/_actions_index.html.haml
+++ b/app/views/event/templates/_actions_index.html.haml
@@ -1,0 +1,11 @@
+-#  Copyright (c) 2026, Hitobito AG. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+- group.event_types.each do |type|
+  - new_template = type.new.tap { |e| e.groups << group }
+  - if can?(:new, new_template)
+    = action_button(new_event_template_title(new_template),
+                    new_group_event_path(group, event: {type: type.sti_name, template: true}),
+                    :plus)

--- a/app/views/event/templates/_list.html.haml
+++ b/app/views/event/templates/_list.html.haml
@@ -1,0 +1,12 @@
+-#  Copyright (c) 2026, Hitobito AG. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito.
+
+= crud_table do |t|
+  - t.sortable_attr :name
+  - t.sortable_attr :type do |event|
+    = event.model.class.model_name.human
+  - t.sortable_attr :inherit
+  - action_col_edit(t)
+  - action_col_destroy(t)

--- a/app/views/events/_actions_show.html.haml
+++ b/app/views/events/_actions_show.html.haml
@@ -1,4 +1,4 @@
--#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+-#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
@@ -10,6 +10,10 @@
 - if can?(:new, entry)
   = action_button(t('events.global.link.duplicate'),
                   new_group_event_path(@group, source_id: entry.id),
+                  :copy)
+- if entry.saveable_as_template?(@group)
+  = action_button(t('.save_as_template'),
+                  new_group_event_path(@group, event: {template: true}, source_id: entry.id),
                   :copy)
 = export_events_ical_button
 - if can?(:update, entry)

--- a/app/views/events/_form.html.haml
+++ b/app/views/events/_form.html.haml
@@ -1,9 +1,10 @@
--#  Copyright (c) 2012-2017, Jungwacht Blauring Schweiz. This file is part of
+-#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-= entry_form cancel_url_new: typed_group_events_path(@group, entry.klass),
+- cancel_url = entry.template? ? group_event_templates_path(@group) : typed_group_events_path(@group, entry.klass)
+= entry_form cancel_url_new: cancel_url, cancel_url_edit: cancel_url,
   html: { class: 'tabbed', data: { controller: 'form-field-inheritance' } } do |f|
   - if entry.new_record?
     = f.hidden_field :type

--- a/app/views/events/_general_fields.html.haml
+++ b/app/views/events/_general_fields.html.haml
@@ -1,10 +1,14 @@
--#  Copyright (c) 2015, insieme Schweiz. This file is part of
+-#  Copyright (c) 2015-2026, insieme Schweiz. This file is part of
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
 = field_set_tag do
+  = f.hidden_field(:template)
   = f.labeled_input_field(:name)
+
+  - if entry.template?
+    = f.labeled_input_field(:inherit, caption: t(".inherit_caption"))
 
   - entry.used?(:kind_id) do
     = f.labeled(:kind_id) do

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -1,8 +1,11 @@
--#  Copyright (c) 2012-2015, Jungwacht Blauring Schweiz. This file is part of
+-#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-- title ti("title_#{entry.model.class.name.underscore}")
+- if entry.template? && entry.new_record?
+  - title new_event_template_title(entry)
+- else
+  title ti(:title, :model => model_class_label(entry), :default => model_class_label(entry))
 
-= render template: 'crud/new'
+= render "form"

--- a/config/locales/models.de.yml
+++ b/config/locales/models.de.yml
@@ -86,6 +86,7 @@ de:
         type_not_allowed: kann hier nicht erstellt werden
         must_be_after_opening: muss nach dem Anmeldebeginn sein
         must_have_same_type: müssen von demselben Typ sein
+        must_be_layer: können für Eventvorlagen nur eine Ebene sein
         greater_than: muss grösser als %{count} sein
         greater_than_or_equal_to: muss grösser oder gleich %{count} sein
         must_exist: müssen vorhanden sein
@@ -779,6 +780,8 @@ de:
         no_name: "[Kein Name]"
         visible_contact_attributes: "Anzeigeoptionen (Kontaktperson)"
         guest_limit: Maximale Anzahl Gäste pro Person
+        template: Vorlage
+        inherit: Vererbung
 
       event/contact_attrs:
         required: Obligatorisch

--- a/config/locales/views.de.yml
+++ b/config/locales/views.de.yml
@@ -225,6 +225,7 @@ de:
     delete: Löschen
     edit_service_token: API-Keys
     edit_event_question_template: Vorlagen Anmeldeangaben Anlässe
+    edit_event_template: Eventvorlagen
     edit_calendar_feeds: Kalender-Feeds
 
   dropdown/people_email_export:
@@ -572,6 +573,10 @@ de:
         default_caption: Wird standardmässig bei neuen Anlässen hinzugefügt
         inherit_caption: Steht ebenfalls auf untergeordneten Ebenen zur Verfügung.
 
+    templates:
+      index:
+        title: Eventvorlagen
+
     register:
       register:
         title:
@@ -662,6 +667,7 @@ de:
         select_layers: Gruppen suchen...
     actions_show:
       copy_share_link: Direktlink kopieren
+      save_as_template: Als Vorlage speichern
     application_fields:
       caption_signature: Teilnehmende müssen die Anmeldung unterschreiben
       caption_signature_confirmation: Anmeldung muss durch eine Zweitunterschrift bestätigt werden
@@ -719,10 +725,13 @@ de:
         social_account: Social Media anzeigen
         picture: Profilfoto anzeigen
       kind_overrides_link_title: "Folgende Felder werden übernommen: Beschreibung"
+      inherit_caption: Steht ebenfalls auf untergeordneten Ebenen zur Verfügung.
     global:
       link:
         add_event: Anlass erstellen
+        add_event_template: Anlass-Vorlage erstellen
         add_event/course: Kurs erstellen
+        add_event/course_template: Kurs-Vorlage erstellen
         duplicate: Duplizieren
     minimum_age_with_years: "%{minimum_age} Jahre (Jahrgang)"
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -396,6 +396,7 @@ Hitobito::Application.routes.draw do
 
       resources :service_tokens
       resources :question_templates, except: [:show], module: :event
+      resources :event_templates, only: [:index], controller: "event/templates"
     end # resources :group
 
     get "list_courses" => "events/courses#index", as: :list_courses

--- a/db/migrate/20260828143207_add_template_and_inherit_to_events.rb
+++ b/db/migrate/20260828143207_add_template_and_inherit_to_events.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+class AddTemplateAndInheritToEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :events, :template, :boolean, default: false, null: false
+    add_column :events, :inherit, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_18_090000) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_28_143207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -491,6 +491,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_08_18_090000) do
     t.boolean "automatic_assignment", default: false, null: false
     t.string "visible_contact_attributes", default: "[\"name\", \"address\", \"phone_number\", \"email\", \"social_account\"]"
     t.integer "guest_limit", default: 0, null: false
+    t.boolean "template", default: false, null: false
+    t.boolean "inherit", default: false, null: false
     t.index ["kind_id"], name: "index_events_on_kind_id"
     t.index ["shared_access_token"], name: "index_events_on_shared_access_token"
   end

--- a/spec/abilities/event_ability_spec.rb
+++ b/spec/abilities/event_ability_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.

--- a/spec/abilities/group_ability_spec.rb
+++ b/spec/abilities/group_ability_spec.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2013, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -802,6 +802,36 @@ describe GroupAbility do
     it "may not register_people in group with self registration inactive" do
       allow_any_instance_of(Group).to receive(:self_registration_active?).and_return(false)
       is_expected.not_to be_able_to(:register_people, groups(:bottom_layer_one))
+    end
+  end
+
+  describe :index_event_templates do
+    let(:ability) { Ability.new(people(:top_leader).reload) }
+
+    context "with layer_and_below_full permission" do
+      before do
+        allow(Group::TopGroup::Leader).to receive(:permissions)
+          .and_return([:layer_and_below_full])
+      end
+
+      it "may index event templates on a layer group" do
+        is_expected.to be_able_to(:index_event_templates, groups(:top_layer))
+      end
+
+      it "may not index event templates on a non-layer group" do
+        is_expected.not_to be_able_to(:index_event_templates, groups(:top_group))
+      end
+    end
+
+    context "without any relevant permission" do
+      before do
+        allow(Group::TopGroup::Leader).to receive(:permissions)
+          .and_return([:contact_data])
+      end
+
+      it "may not index event templates" do
+        is_expected.not_to be_able_to(:index_event_templates, groups(:top_layer))
+      end
     end
   end
 end

--- a/spec/controllers/event/templates_controller_spec.rb
+++ b/spec/controllers/event/templates_controller_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+describe Event::TemplatesController do
+  let(:top_layer) { groups(:top_layer) }
+  let(:bottom_layer_one) { groups(:bottom_layer_one) }
+  let(:template) { events(:template) }
+  let(:top_leader) { people(:top_leader) }
+
+  describe "GET#index" do
+    before { sign_in(top_leader) }
+
+    it "lists templates of the group when signed in as admin" do
+      get :index, params: {group_id: top_layer.id}
+
+      expect(response).to be_successful
+      expect(assigns(:events)).to eq [template]
+    end
+
+    it "does not list templates of another group" do
+      other_group_template = Fabricate(:event, groups: [bottom_layer_one], template: true)
+
+      get :index, params: {group_id: top_layer.id}
+
+      expect(assigns(:events)).not_to include(other_group_template)
+    end
+
+    it "raises access denied when not permitted" do
+      sign_in(people(:bottom_member))
+
+      expect { get :index, params: {group_id: top_layer.id} }.to raise_error(CanCan::AccessDenied)
+    end
+
+    context "with views" do
+      render_views
+
+      let(:dom) { Capybara::Node::Simple.new(response.body) }
+
+      it "has edit and destroy action links" do
+        get :index, params: {group_id: top_layer.id}
+        expect(dom).to have_css(%(a[href="#{edit_group_event_path(top_layer, template)}"]))
+        expect(dom).to have_css(%(a[href="#{group_event_path(top_layer, template)}"]))
+      end
+
+      it "has new-template button per event type available to the group" do
+        get :index, params: {group_id: top_layer.id}
+
+        expect(dom).to have_css(
+          %(a[href$="#{new_group_event_path(top_layer, event: {type: "Event", template: true})}"]),
+          text: "Anlass Vorlage erstellen"
+        )
+        expect(dom).to have_css(
+          %(a[href$="#{new_group_event_path(top_layer, event: {type: "Event::Course", template: true})}"]),
+          text: "Kurs Vorlage erstellen"
+        )
+      end
+
+      it "renders the group sheet with a breadcrumb back to the group" do
+        Fabricate(Group::BottomLayer::Leader.name.to_sym, person: top_leader, group: bottom_layer_one)
+        get :index, params: {group_id: bottom_layer_one.id}
+
+        expect(dom).to have_css(".sheet.parent .breadcrumb", text: bottom_layer_one.parent.name)
+        expect(dom).to have_css(".level.active", text: bottom_layer_one.name)
+      end
+    end
+
+    context "sorting" do
+      before do
+        template.update!(name: "Zebra")
+        Fabricate(:course, groups: [top_layer], template: true, name: "Anton")
+      end
+
+      it "sorts by name" do
+        get :index, params: {group_id: top_layer.id, sort: :name, sort_dir: :asc}
+        expect(assigns(:events).map(&:name)).to eq ["Anton", "Zebra"]
+
+        get :index, params: {group_id: top_layer.id, sort: :name, sort_dir: :desc}
+        expect(assigns(:events).map(&:name)).to eq ["Zebra", "Anton"]
+      end
+
+      it "sorts by the translated type label, not the raw type column value" do
+        get :index, params: {group_id: top_layer.id, sort: :type, sort_dir: :asc}
+        expect(assigns(:events).map { |e| e.model.class }).to eq [Event, Event::Course]
+
+        get :index, params: {group_id: top_layer.id, sort: :type, sort_dir: :desc}
+        expect(assigns(:events).map { |e| e.model.class }).to eq [Event::Course, Event]
+      end
+    end
+  end
+end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -280,6 +280,18 @@ describe EventsController do
           get :new, params: {group_id: group.id, source_id: events(:top_course).id}
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
+
+      it "does not duplicate default questions on top of an existing source's questions" do
+        Event::QuestionTemplate.update_all(default: false)
+        sign_in(people(:top_leader))
+        source = events(:top_course)
+        source.questions << Fabricate(:event_question)
+
+        get :new, params: {group_id: source.groups.first.id, source_id: source.id}
+
+        event = assigns(:event)
+        expect(event.application_questions.size).to eq(source.application_questions.size)
+      end
     end
 
     context "POST create" do
@@ -543,6 +555,120 @@ describe EventsController do
         expect(event).not_to be_valid
         expect(event.errors.messages[:contact]).to include("Zugriff verweigert")
         Auth.current_person = nil
+      end
+    end
+  end
+
+  context "templates" do
+    let(:top_leader) { people(:top_leader) }
+    let(:top_layer) { groups(:top_layer) }
+    let(:bottom_layer_one) { groups(:bottom_layer_one) }
+    let(:template) { events(:template) }
+
+    before { sign_in(top_leader) }
+
+    describe "GET#new" do
+      it "marks the new event as a template" do
+        get :new, params: {group_id: top_layer.id, event: {type: "Event", template: true}}
+
+        event = assigns(:event)
+        expect(event.template).to eq true
+        expect(event.groups).to eq [top_layer]
+      end
+
+      it "duplicates a template into a normal event" do
+        get :new, params: {group_id: top_layer.id, source_id: template.id}
+
+        event = assigns(:event)
+        expect(event.template).to eq false
+        expect(event.name).to eq(template.name)
+        expect(event.groups).to eq [top_layer]
+      end
+
+      it "duplicates an inherited template from an ancestor top_layer" do
+        template.update!(inherit: true)
+        Fabricate(Group::BottomLayer::Leader.sti_name, group: bottom_layer_one, person: people(:top_leader))
+
+        get :new, params: {group_id: bottom_layer_one.id, source_id: template.id}
+
+        event = assigns(:event)
+        expect(event.template).to eq false
+        expect(event.groups).to eq [bottom_layer_one]
+      end
+    end
+
+    describe "GET#show" do
+      it "raises 404 as not supported" do
+        expect do
+          get :show, params: {group_id: top_layer.id, id: template.id}
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    describe "POST#create" do
+      it "creates a template without dates, and redirects to the templates index" do
+        post :create, params: {
+          group_id: top_layer.id,
+          event: {type: "Event", name: "Vorlage ohne Datum", template: "true", inherit: "1"}
+        }
+
+        event = assigns(:event)
+        expect(event).to be_persisted
+        expect(event.template).to eq true
+        expect(event.inherit).to eq true
+        expect(event.groups).to eq [top_layer]
+        expect(response).to redirect_to(group_event_templates_path(top_layer))
+      end
+
+      it "collapses a multi-group source event to a single group when saved as a template" do
+        Fabricate(Group::BottomLayer::Leader.sti_name, group: bottom_layer_one, person: top_leader)
+        source = Fabricate(:event, groups: [bottom_layer_one, groups(:bottom_layer_two)])
+
+        post :create, params: {
+          group_id: bottom_layer_one.id,
+          source_id: source.id,
+          event: {name: "Vorlage von Multi-Gruppen-Event", template: "true"}
+        }
+
+        event = assigns(:event)
+        expect(event).to be_persisted
+        expect(event.groups).to eq [bottom_layer_one]
+      end
+    end
+
+    describe "PUT#update" do
+      it "updates name and inherit flag, and redirects to the templates index" do
+        put :update, params: {
+          group_id: top_layer.id, id: template.id, event: {name: "Renamed", inherit: "1"}
+        }
+
+        expect(template.reload.name).to eq("Renamed")
+        expect(template.inherit).to eq true
+        expect(response).to redirect_to(group_event_templates_path(top_layer))
+      end
+    end
+
+    describe "DELETE#destroy" do
+      it "destroys  and redirects to the templates index" do
+        expect do
+          delete :destroy, params: {group_id: top_layer.id, id: template.id}
+        end.to change { Event.templates.count }.by(-1)
+
+        expect(response).to redirect_to(group_event_templates_path(top_layer))
+      end
+    end
+
+    describe "cancel link redirects back to templates" do
+      render_views
+
+      it "points to the templates index on both the new and edit template forms" do
+        get :new, params: {group_id: top_layer.id, event: {type: "Event", template: true}}
+        dom = Capybara::Node::Simple.new(response.body)
+        expect(dom).to have_css(%(a.link.cancel[href="#{group_event_templates_path(top_layer)}"]))
+
+        get :edit, params: {group_id: top_layer.id, id: template.id}
+        dom = Capybara::Node::Simple.new(response.body)
+        expect(dom).to have_css(%(a.link.cancel[href="#{group_event_templates_path(top_layer)}"]))
       end
     end
   end

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -244,4 +244,21 @@ describe EventDecorator, :draper_with_helpers do
       it { is_expected.to eq expected_image_html }
     end
   end
+
+  describe "#saveable_as_template?" do
+    subject { EventDecorator.new(event) }
+
+    it "is true for a layer group" do
+      expect(subject.saveable_as_template?(groups(:top_layer))).to eq true
+    end
+
+    it "is false for a non-layer group" do
+      expect(subject.saveable_as_template?(groups(:top_group))).to eq false
+    end
+
+    it "is false for an event that is already a template" do
+      event.template = true
+      expect(subject.saveable_as_template?(groups(:top_layer))).to eq false
+    end
+  end
 end

--- a/spec/fabricators/event_fabricator.rb
+++ b/spec/fabricators/event_fabricator.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2023, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -6,7 +6,7 @@ Fabricator(:event) do
   name { "Eventus" }
   groups { [Group.all_types.detect { |t| t.event_types.include?(Event) }.first] }
   before_create do |event|
-    event.dates.build(start_at: Time.zone.local(2012, 5, 11)) if event.dates.empty?
+    event.dates.build(start_at: Time.zone.local(2012, 5, 11)) if event.dates.empty? && !event.template?
   end
 end
 

--- a/spec/fixtures/event_translations.yml
+++ b/spec/fixtures/event_translations.yml
@@ -19,3 +19,12 @@ top_course_de:
 
   name: Top Course
   description: Some kind of course, it seems
+
+template_de:
+  event_id: <%= ActiveRecord::FixtureSet.identify(:template) %>
+  locale: de
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>
+
+  name: Vorlage
+  description: Some kind of course, it seems

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -14,3 +14,9 @@ top_course:
   priorization: true
   requires_approval: true
   external_applications: true
+
+template:
+  type:
+  groups: top_layer
+  template: true
+  groups: top_layer

--- a/spec/helpers/dropdown/event/new_spec.rb
+++ b/spec/helpers/dropdown/event/new_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Hitobito AG. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require "spec_helper"
+
+describe Dropdown::Event::New do
+  include Rails.application.routes.url_helpers
+  include FormatHelper
+  include LayoutHelper
+  include UtilityHelper
+
+  let(:current_user) { people(:top_leader) }
+  let(:group) { groups(:top_group) }
+  let(:dropdown) { described_class.new(self, group, Event) }
+  let(:template) { events(:template) }
+
+  subject { Capybara.string(dropdown.to_s) }
+
+  before { allow(self).to receive(:can?).and_return(true) }
+
+  it "renders nothing when the user may not create events" do
+    allow(self).to receive(:can?).and_return(false)
+
+    expect(dropdown.to_s).to be_blank
+  end
+
+  it "renders a dropdown listing the template" do
+    is_expected.to have_content "Anlass erstellen"
+    is_expected.to have_css("ul.dropdown-menu li", text: "Vorlage")
+  end
+
+  it "links the template item to new with source_id" do
+    is_expected.to have_css(%(a[href$="events/new?source_id=#{template.id}"]))
+  end
+
+  it "renders a plain button when no templates are applicable" do
+    events(:template).destroy
+    is_expected.to have_content "Anlass erstellen"
+    is_expected.not_to have_css("ul.dropdown-menu")
+  end
+end

--- a/spec/helpers/dropdown/group_edit_spec.rb
+++ b/spec/helpers/dropdown/group_edit_spec.rb
@@ -51,6 +51,18 @@ describe "Dropdown::GroupEdit" do
     is_expected.to have_no_selector "a", text: "Vorlagen Anmeldeangabe Anlässe"
   end
 
+  it "renders event template item with index_event_templates" do
+    allow(self).to receive(:can?).with(:index_event_templates, anything).and_return(true)
+
+    is_expected.to have_selector "a", text: "Eventvorlagen"
+  end
+
+  it "does not render event template item without index_event_templates" do
+    allow(self).to receive(:can?).with(:index_event_templates, anything).and_return(false)
+
+    is_expected.to have_no_selector "a", text: "Eventvorlagen"
+  end
+
   it "renders calendar item" do
     allow(self).to receive(:can?).with(:index_service_tokens, anything).and_return(true)
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2012-2021, Jungwacht Blauring Schweiz. This file is part of
+#  Copyright (c) 2012-2026, Jungwacht Blauring Schweiz. This file is part of
 #  hitobito and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito.
@@ -984,6 +984,86 @@ describe Event do
 
       duplicated = d.admin_questions.detect { |q| q.question == question.question }
       expect(duplicated.visible_role_types).to eq []
+    end
+
+    it "resets template and inherit even when duplicating a template" do
+      event.update!(template: true, inherit: true)
+
+      d = event.duplicate
+      expect(d.template).to eq false
+      expect(d.inherit).to eq false
+    end
+  end
+
+  context "templates" do
+    let(:top_layer) { groups(:top_layer) }
+    let(:template) { Fabricate.build(:event, groups: [top_layer], template: true) }
+
+    it "does not require dates" do
+      expect(template).to be_valid
+    end
+
+    it "is invalid on a non-layer group" do
+      template.groups = [groups(:top_group)]
+      expect(template).not_to be_valid
+      expect(template.errors[:groups]).to be_present
+    end
+
+    it "is valid on a layer group" do
+      expect(template.groups).to all(be_layer)
+      expect(template).to be_valid
+    end
+
+    it "is excluded from the default scope" do
+      template.save!
+      expect(Event.all).not_to include(template)
+    end
+
+    it "is included in templates scope" do
+      template.save!
+      expect(Event.templates).to include(template)
+    end
+
+    it "templates scope excludes non template events" do
+      expect(Event.templates).not_to include(event)
+    end
+
+    describe ".templates_in_hierarchy" do
+      let(:bottom_group_one_one) { groups(:bottom_group_one_one) }
+
+      it "includes a template defined directly on the given group" do
+        template.save!
+        expect(Event.templates_in_hierarchy([top_layer])).to include(template)
+      end
+
+      it "includes an inherited template from an ancestor layer" do
+        template.update!(inherit: true)
+
+        expect(Event.templates_in_hierarchy([bottom_group_one_one])).to include(template)
+      end
+
+      it "does not include non inheritable template from an ancestor layer" do
+        template.update!(inherit: false)
+
+        expect(Event.templates_in_hierarchy([bottom_group_one_one])).not_to include(template)
+      end
+
+      it "does not include inheritable template from another hierarchy tree" do
+        other = Fabricate(:event, groups: [groups(:bottom_layer_two)], template: true, inherit: true)
+        expect(Event.templates_in_hierarchy([bottom_group_one_one])).not_to include(other)
+      end
+    end
+
+    describe ".applicable_templates" do
+      it "filters by event type" do
+        template.update!(inherit: true)
+        course_template = Fabricate(:course, groups: [top_layer], template: true, inherit: true)
+
+        expect(Event.applicable_templates(top_layer, event_type: "Event"))
+          .to include(template)
+        expect(Event.applicable_templates(top_layer, event_type: "Event"))
+          .not_to include(course_template)
+      end
     end
   end
 


### PR DESCRIPTION
  Layer-scoped, event-type-specific event templates: a template is a normal `Event` flagged with `template: true`
  (and `inherit: true` to make it usable from layers below), excluded from all default event queries via a
  `default_scope`, mirroring the existing `Event::QuestionTemplate` pattern. Users create a new event either from
  scratch or by picking an applicable template from the new-event dropdown, and can save an existing event as a
  template from its show page. Template management (create/edit/destroy) is restricted to the `:admin` permission
  via `Event::TemplatesController` and a shared controller-level guard (`EventsController#assert_template_admin`),
  chosen over an ability-DSL patch since wagons define their own custom Event ability constraints that wouldn't have
  picked it up.

  Also fixes several related bugs surfaced while building this:

  - `Event#new` was appending default question templates on top of a duplicated source's own questions.
  - `Event#duplicate` did not reset `template`/`inherit`, so instantiating an event from a template (or saving one
  as a template) could silently carry the wrong flag.
  - `list_entries` in `Event::TemplatesController` overrode `ListController`'s default implementation and silently
  bypassed `Sortable`'s automatic sort wrapping, so sorting the templates list did nothing.
  - The "Typ" column now sorts by the translated model name instead of the raw (and for the base `Event`, `nil`)
  `type` column value.

Fixes hitobito/hitobito_jubla#292