### PR TITLE
Devise-Mailer Grussname statt vollständigem Namen in der Anrede verwenden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Die Länge von Mahnungstexten ist nicht mehr begrenzt (sww#414)
 - Für die Schwyzer Kantonalbank SZKB wurde eine Ebics Zahlungsschnittstelle hinzugefügt (#4400)
 - Zusätzliche Adressen erhalten dieselben Namensfelder (Vorname, Nachname, Firma/Firmenname) wie die Hauptadresse und sind neu auch im JSON:API verfügbar (#4411)
+- In den E-Mails zur Kontobestätigung, zum Zurücksetzen des Passworts und zum Entsperren des Kontos wird neu der Grussname statt des vollständigen Namens verwendet (#4459)
 
 ## Version 2.10
 

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -1,4 +1,4 @@
-%p= t('.body.greeting', name: @resource.full_name)
+%p= t('.body.greeting', name: @resource.greeting_name)
 
 %p= t('.body.information_html')
 

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito.
 
-%p= t('.body.greeting', name: @resource.full_name)
+%p= t('.body.greeting', name: @resource.greeting_name)
 
 - if @resource.encrypted_password.present?
   %p= t('.body.reset_instructions.with_password', application_name: Settings.application.name)

--- a/app/views/devise/mailer/unlock_instructions.html.haml
+++ b/app/views/devise/mailer/unlock_instructions.html.haml
@@ -1,4 +1,4 @@
-%p= t('.body.greeting', name: @resource.full_name)
+%p= t('.body.greeting', name: @resource.greeting_name)
 
 %p= t('.body.information_html')
 


### PR DESCRIPTION
Closes #4459