### PR TITLE
Fix form styling

### DIFF
--- a/app/javascript/stylesheets/hitobito/_form.scss
+++ b/app/javascript/stylesheets/hitobito/_form.scss
@@ -10,6 +10,16 @@
   margin-bottom: $v-space;
 }
 
+// Bootstrap's grid gives every direct .row child `width: 100%; flex-shrink: 0`.
+// Combined with the offset-* margin-left used to indent the bottom/top button
+// toolbar, that adds up to more than 100% of the row and overflows horizontally.
+// Allow the toolbar to shrink so its margin is accounted for.
+.row > .bottom,
+.row > .top {
+  flex-shrink: 1;
+  min-width: 0;
+}
+
 .btn {
   color: $blue-dark;
 

--- a/app/views/mailing_lists/_form.html.haml
+++ b/app/views/mailing_lists/_form.html.haml
@@ -21,7 +21,7 @@
               = f.inline_radio_button(:subscribable_mode, key, entry.subscribable_mode_label(key))
     = tab_content(:email) do
       %fieldset
-        = f.labeled(:mail_name, class: 'd-flex') do
+        = f.labeled(:mail_name) do
           .col
             .input-group.input-group-sm
               = f.input_field(:mail_name)


### PR DESCRIPTION
Fixes #3842 

Fixes Problem wo der Hilfetext beim ausklappen das TExtfeld zum EIntragen der Mailadresse vom Abo verkleinert.

<img width="755" height="90" alt="grafik" src="https://github.com/user-attachments/assets/1a871a66-cbf2-40cb-8979-70277642769f" />
