### PR TITLE
Fix execution order bug for people.search_by_id

### DIFF
--- a/app/domain/search_strategies/person_search.rb
+++ b/app/domain/search_strategies/person_search.rb
@@ -10,7 +10,6 @@ module SearchStrategies
 
     self.model_class = Person
     self.readables_ability = PersonReadables
-    self.searchable_identifiers = {id: /\A\d+\z/} if FeatureGate.enabled?("people.search_by_id")
 
     def initialize(user, term, page, limit: nil)
       super
@@ -19,6 +18,12 @@ module SearchStrategies
     end
 
     private
+
+    def searchable_identifiers
+      return {} unless FeatureGate.enabled?("people.search_by_id")
+
+      {id: /\A\d+\z/}
+    end
 
     def accessible_scope
       scopes = [super, people_without_role, deleted_people].compact

--- a/spec/domain/search_strategies/person_search_spec.rb
+++ b/spec/domain/search_strategies/person_search_spec.rb
@@ -154,8 +154,8 @@ describe SearchStrategies::PersonSearch do
 
   describe "feature toggle people.search_by_id" do
     before do
+      allow(FeatureGate).to receive(:enabled?).and_call_original
       allow(FeatureGate).to receive(:enabled?).with("people.search_by_id").and_return(false)
-      expect(described_class).to receive(:searchable_identifiers).and_return({})
     end
 
     context "as leader" do


### PR DESCRIPTION
In SearchStrategies::PersonSearch wurde searchable_identifiers bisher direkt im Klassenkörper gesetzt:

`self.searchable_identifiers = {id: /\A\d+\z/} if FeatureGate.enabled?("people.search_by_id")`

Da dies eine Zuweisung im Klassenkörper ist, wird der `FeatureGate.enabled?`-Check nur ein einziges Mal ausgeführt – nämlich genau dann, wenn die Datei lädt (beim Autoload bzw. beim Eager Loading in Produktion/Test). Das Ergebnis wird als `class_attribute` für die gesamte Lebensdauer des Prozesses eingefroren.

Das ist inkonsistent mit jedem anderen FeatureGate-Aufruf in der Codebase (>20 Stellen in Controllern, Models, Jobs, Helpers, Resources), die alle innerhalb einer Methode ausgewertet werden und damit bei jedem Aufruf den aktuellen Settings-Stand prüfen. Nur `person_search.rb` war die einzige Stelle, die den Wert einmalig zur Ladezeit festgeschrieben hat.

Konkrete Auswirkungen:

1. Ladezeit-Abhängigkeit statt Laufzeit-Auswertung: Ob Suche-nach-ID aktiv ist, hängt davon ab, zu welchem Zeitpunkt im Boot-/Autoload-Prozess diese Datei geladen wird – nicht vom tatsächlich aktuellen Settings-Wert.
2. Test konnte den deaktivierten Pfad nicht echt abdecken: Der bestehende Spec konnte FeatureGate.enabled? nicht sinnvoll stubben, weil die Klasse zum Zeitpunkt des Stubs bereits geladen und das Attribut bereits fixiert war. Der Test musste stattdessen expect(described_class).to receive(:searchable_identifiers).and_return({}) verwenden – er mockte also genau die Methode, die er eigentlich verifizieren sollte.

Lösung:

`searchable_identifiers` wird als Instanzmethode implementiert, die `FeatureGate.enabled?` bei jedem Aufruf neu auswertet – analog zu allen anderen Feature-Gate-Stellen im Code.