### PR TITLE
Fix tooltip not show in multi-entry edit forms

### DIFF
--- a/app/javascript/javascripts/modules/tooltips.js
+++ b/app/javascript/javascripts/modules/tooltips.js
@@ -8,7 +8,7 @@ function registerTooltips() {
     document.querySelectorAll('[data-bs-toggle="tooltip"]')
   );
   tooltipTriggerList.forEach((el) => {
-    new Tooltip(el, {
+    Tooltip.getOrCreateInstance(el, {
       placement: el.dataset.bsPlacement || "right",
     });
   });


### PR DESCRIPTION
Beim Bearbeiten von Feldern wie Weitere Adresse, Telefonnummern etc. sind die Info-Tooltips nur beim untersten Eintrag funktionsfähig. Durch diesen PR funktionieren die Tooltips bei jeder Zeile.

Technische Details:
- registerTooltips() re-scans every [data-bs-toggle="tooltip"] element each time a nested-form row is added (via the rails-nested-form:add event), which is necessary to pick up the new row's tooltip
- However, it called new Tooltip(el, …) unconditionally, so already-initialized rows got a second (and third, fourth, …) Tooltip instance stacked on top with each subsequent "add" — each with its own mouseenter/mouseleave listeners that were never disposed
- This left older rows (e.g. previously-added email/phone-number entries) with broken/conflicting tooltip behavior, while only the most recently added row — which only ever went through one init cycle — worked correctly
- Swapped new Tooltip(el, …) for Tooltip.getOrCreateInstance(el, …), which reuses an existing instance instead of creating a duplicate (available since Bootstrap 5.2, already the pinned version)