### PR TITLE
Improve readability of grouped qualifications by using line breaks

### DIFF
--- a/app/helpers/event_kinds_helper.rb
+++ b/app/helpers/event_kinds_helper.rb
@@ -29,7 +29,7 @@ module EventKindsHelper
     kinds = kind.qualification_kinds(category, role).group_by(&:id)
     grouped_ids = kind.grouped_qualification_kind_ids(category, role)
     or_separator = [
-      " ",
+      tag(:br),
       content_tag(:span, t("event.kinds.qualifications.or"), class: "muted"),
       " "
     ]

--- a/app/helpers/event_kinds_helper.rb
+++ b/app/helpers/event_kinds_helper.rb
@@ -29,7 +29,7 @@ module EventKindsHelper
     kinds = kind.qualification_kinds(category, role).group_by(&:id)
     grouped_ids = kind.grouped_qualification_kind_ids(category, role)
     or_separator = [
-      tag(:br),
+      tag.br,
       content_tag(:span, t("event.kinds.qualifications.or"), class: "muted"),
       " "
     ]


### PR DESCRIPTION
Especially in longer lists, reading all the different qualifications is nearly impossible. This is an attempt to visually structure the text.

Before:
<img width="666" height="200" alt="image" src="https://github.com/user-attachments/assets/915f042e-5ba1-4fca-a87a-472ac5378b97" />

After:
<img width="661" height="261" alt="image" src="https://github.com/user-attachments/assets/8d3a0295-11e3-4418-99db-2e0bb472afb5" />
